### PR TITLE
调整 `BotManager` 和 `OriginBotManager` 相关内容。

### DIFF
--- a/.changelog/v3.0.0.preview.8.0.md
+++ b/.changelog/v3.0.0.preview.8.0.md
@@ -1,19 +1,22 @@
 ⚠️ **不兼容**更新。
 
 ## 事件相关变更
-变更部分事件的定义，去除大部分事件API的默认实现、去除部分事件的部分泛型定义。
-
+- 变更部分事件的定义，去除大部分事件API的默认实现、去除部分事件的部分泛型定义。
 去除泛型的变更所涉及的事件：
 `ChangeEvent`、`ChangedEvent`、`StartPointEvent`、
 `EndPointEvent`、`IncreaseEvent`、`DecreaseEvent`、
 `FriendChangedEvent`、`FriendIncreaseEvent`、`FriendDecreaseEvent`、
 `MemberChangedEvent`、`MemberIncreaseEvent`、`MemberDecreaseEvent`
 
-新增标准事件类型： `FriendChangedEvent` 来作为好友的对应增加/减少事件的父类事件。
+- 新增标准事件类型： `FriendChangedEvent` 来作为好友的对应增加/减少事件的父类事件。
 
 ## OriginBotManager & BotManager
-调整了 `OriginBotManager` 中 `getManagers` 的返回值，现在它将直接返回 `List` 类型。
-
+- 调整了 `OriginBotManager` 中 `getManagers` 的返回值，现在它将直接返回 `List` 类型。
+- `OriginBotManager` 的 `getManagers` 取消 `@JvmSynthetic` 注解。
+- `OriginBotManager` 中增加额外的 `getBot` 重载。 
+- `OriginBotManager` 中增加 `getAny` 。 
+- `BotManager` 的 `get` 方法增加 `operator` 修饰符。
+- 
 
 ## 组件更新
 相关组件会在后续跟进更新

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ dokka/**
 
 *.gpg
 
+.git
+
 # Ignore Gradle GUI config
 gradle-app.setting
 

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/BotManager.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/BotManager.kt
@@ -148,7 +148,7 @@ public abstract class BotManager<B : Bot> : BotRegistrar, ComponentContainer, Su
      * 当 [Bot] 关闭后，[BotManager] 中不应能够再获取到此Bot。
      *
      */
-    public abstract fun get(id: ID): B?
+    public abstract operator fun get(id: ID): B?
 
     /**
      * 获取当前管理器下的所有BOT列表。

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/BotManager.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/BotManager.kt
@@ -12,14 +12,11 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
- *
  */
 
 package love.forte.simbot
 
 import java.io.InputStream
-import java.util.stream.Stream
-import kotlin.streams.asStream
 
 
 /**
@@ -154,17 +151,9 @@ public abstract class BotManager<B : Bot> : BotRegistrar, ComponentContainer, Su
     public abstract fun get(id: ID): B?
 
     /**
-     * 获取当前管理器下的所有BOT。
+     * 获取当前管理器下的所有BOT列表。
      */
-    @JvmSynthetic
-    public abstract fun all(): Sequence<B>
-
-    /**
-     * 获取 [Stream] 形式的bot流。
-     */
-    @Api4J
-    @JvmName("all")
-    public fun all4J(): Stream<B> = all().asStream()
+    public abstract fun all(): List<B>
 
 }
 

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/OriginBotManager.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/OriginBotManager.kt
@@ -12,7 +12,6 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
- *
  */
 
 package love.forte.simbot
@@ -35,12 +34,20 @@ import kotlin.concurrent.write
  *
  * 如果你想要某个 [BotManager] 脱离 [OriginBotManager] 的管理，使用 [BotManager.breakAway]
  *
- * ## 谨慎使用
+ * **遍历所有**:
+ * ```kotlin
+ * OriginBotManager.forEach { manager ->
+ *  // do...
+ *  }
+ * ```
+ *
+ * ## ⚠ 谨慎使用
  * [OriginBotManager] 是脱离环境的 **全局性** 功能，当你的整个应用中存在多个环境时，使用它则很可能造成各种混乱。
- * [BotManager] 作为属性存在于很多对象中，你应当优先考虑使用那些明确的api，而对于全局性的 [OriginBotManager],
- * 则是最后的选择。
+ * [BotManager] 作为属性存在于很多对象中，你应当优先考虑使用那些明确的api（例如 [Bot.manager]、[love.forte.simbot.event.Event.bot] 等），
+ * 而对于全局性的 [OriginBotManager], 是最后的选择。
  *
  */
+@Suppress("MemberVisibilityCanBePrivate")
 public object OriginBotManager : Set<BotManager<*>> {
     private val logger = LoggerFactory.getLogger(OriginBotManager::class)
     private val lock = ReentrantReadWriteLock()
@@ -125,15 +132,15 @@ public object OriginBotManager : Set<BotManager<*>> {
      * 例如, 获取某组件下所有bot的所有好友：
      * ```kotlin
      * OriginBotManager
-     * .getManagers(XxxComponent)
+     * .getManagers("component.id".ID)
      * .flatMap { manager -> manager.all() }
      * .asFlow() // Bot.friends() 是Flow类型
      * .flatMapConcat { bot -> bot.friends() }
      * ```
      *
-     * ### getManagers()?
+     * ## getManagers()?
      *
-     * 如果你在寻找不需要 [Component] 参数的 `getManagers()` 函数，请停下。[OriginBotManager] 其本身作为一个 [Set] 的实现即可以代表所有的BotManager。
+     * 如果你在寻找不需要参数的 `getManagers()` 函数，请停下。[OriginBotManager] 其本身作为一个 [Set] 的实现即可以直接代表所有的 [BotManager]。
      *
      * 假如你需要遍历所有，那么：
      * ```kotlin
@@ -143,7 +150,6 @@ public object OriginBotManager : Set<BotManager<*>> {
      * ```
      *
      */
-    @JvmSynthetic
     public fun getManagers(component: Component): List<BotManager<*>> {
         lock.read {
             checkShutdown()
@@ -154,7 +160,6 @@ public object OriginBotManager : Set<BotManager<*>> {
     /**
      * 根据指定ID查询组件ID与其相等的 [BotManager].
      */
-    @JvmSynthetic
     public fun getManagers(componentId: ID): List<BotManager<*>> {
         lock.read {
             checkShutdown()
@@ -197,6 +202,42 @@ public object OriginBotManager : Set<BotManager<*>> {
         }?.get(id)
     }
 
+    /**
+     * 根据一个Bot的id以及对应的组件ID来得到一个此组件下指定ID的bot。如果manager不存在或者没有这个id的bot，则会得到null。
+     *
+     * 如果提供的 [组件ID][componentId] 为null，则会尝试寻找第一个id匹配的bot。
+     *
+     * @param id Bot的id
+     * @param componentId [Component.id]
+     */
+    @JvmOverloads
+    public fun getBot(id: ID, componentId: ID? = null): Bot? {
+        if (componentId == null) {
+            val managers = managers.keys
+            for (manager in managers) {
+                val bot = manager.get(id)
+                if (bot != null) return bot
+            }
+            return null
+        }
+
+        return managers.keys.firstOrNull {
+            it.component.id == componentId
+        }?.get(id)
+    }
+
+
+    /**
+     * 尝试获取任意一个 [BotManager] 下的任意一个 [Bot]。如果当前元素为空则会得到null。
+     *
+     * @param component 可以提供一个组件信息。默认为null
+     */
+    @JvmOverloads
+    public fun getAnyBot(component: Component? = null): Bot? {
+        fun Iterable<BotManager<*>>.firstBotOrNull() = firstOrNull()?.all()?.firstOrNull()
+
+        return (component?.let { getManagers(component) } ?: this).firstBotOrNull()
+    }
 
     /**
      * 尝试获取任意一个manager。如果当前元素为空则会得到null。

--- a/apis/simbot-api/src/test/kotlin/BotManagerTest.kt
+++ b/apis/simbot-api/src/test/kotlin/BotManagerTest.kt
@@ -12,11 +12,8 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
- *
  */
 
-import love.forte.simbot.Bot
-import love.forte.simbot.BotManager
 import love.forte.simbot.ID
 import love.forte.simbot.OriginBotManager
 
@@ -34,18 +31,10 @@ import love.forte.simbot.OriginBotManager
 
 
 fun main() {
-    OriginBotManager.forEach {
-        println("BotManager: $it")
-    }
+    val manager = OriginBotManager.getFirstManager(123.ID)!!
 
-    OriginBotManager.cancel()
+    val bot = manager[123.ID]
+
 
 }
 
-fun bm(manager: BotManager<*>) {
-    // 获取所有Bot，以序列Sequence的形式返回
-    val all: Sequence<Bot> = manager.all()
-
-    // 获取指定的Bot
-    val bot: Bot? = manager.get(123.ID)
-}


### PR DESCRIPTION
- 调整了 `OriginBotManager` 中 `getManagers` 的返回值，现在它将直接返回 `List` 类型。
- `OriginBotManager` 的 `getManagers` 取消 `@JvmSynthetic` 注解。
- `OriginBotManager` 中增加额外的 `getBot` 重载。 
- `OriginBotManager` 中增加 `getAny` 。 
- `BotManager` 的 `get` 方法增加 `operator` 修饰符。