### PR TITLE
重写 BotVerifyInfo

### DIFF
--- a/.changelog/v3.0.0.preview.8.0.md
+++ b/.changelog/v3.0.0.preview.8.0.md
@@ -1,12 +1,13 @@
-⚠️ **不兼容**更新。
+## ⚠️ **不兼容**更新。
 
 ## 事件相关变更
 - 变更部分事件的定义，去除大部分事件API的默认实现、去除部分事件的部分泛型定义。
-去除泛型的变更所涉及的事件：
-`ChangeEvent`、`ChangedEvent`、`StartPointEvent`、
-`EndPointEvent`、`IncreaseEvent`、`DecreaseEvent`、
-`FriendChangedEvent`、`FriendIncreaseEvent`、`FriendDecreaseEvent`、
-`MemberChangedEvent`、`MemberIncreaseEvent`、`MemberDecreaseEvent`
+
+    去除泛型的变更所涉及的事件：
+    `ChangeEvent`、`ChangedEvent`、`StartPointEvent`、
+    `EndPointEvent`、`IncreaseEvent`、`DecreaseEvent`、
+    `FriendChangedEvent`、`FriendIncreaseEvent`、`FriendDecreaseEvent`、
+    `MemberChangedEvent`、`MemberIncreaseEvent`、`MemberDecreaseEvent`
 
 - 新增标准事件类型： `FriendChangedEvent` 来作为好友的对应增加/减少事件的父类事件。
 
@@ -16,7 +17,36 @@
 - `OriginBotManager` 中增加额外的 `getBot` 重载。 
 - `OriginBotManager` 中增加 `getAny` 。 
 - `BotManager` 的 `get` 方法增加 `operator` 修饰符。
-- 
+
+## BotVerifyInfo
+重写 `BotVerifyInfo`, 为其在 `preview.10.x` 重构时能够支持多格式做准备。
+
+### 对比
+
+**旧** 
+```kotlin
+val path = Path("my-bot.bot")
+val info = path.asBotVerifyInfo()
+
+// 获取源输入流并操作
+val inputStream = info.inputStream()
+// do by inputStream...
+```
+
+**新**
+```kotlin
+val path = Path("my-bot.bot")
+val info = path.toBotVerifyInfo(StandardBotVerifyInfoDecoderFactory.Json)
+
+// 可以直接进行反序列化
+val config = info.decode(MyConfig.serializer())
+// do...
+
+// 保留获取源输入流的能力
+val inputStream = info.inputStream()
+```
+
+
 
 ## 组件更新
 相关组件会在后续跟进更新

--- a/.changelog/v3.0.0.preview.8.0.md
+++ b/.changelog/v3.0.0.preview.8.0.md
@@ -1,19 +1,22 @@
 ⚠️ **不兼容**更新。
 
 ## 事件相关变更
-变更部分事件的定义，去除大部分事件API的默认实现、去除部分事件的部分泛型定义。
-
+- 变更部分事件的定义，去除大部分事件API的默认实现、去除部分事件的部分泛型定义。
 去除泛型的变更所涉及的事件：
 `ChangeEvent`、`ChangedEvent`、`StartPointEvent`、
 `EndPointEvent`、`IncreaseEvent`、`DecreaseEvent`、
 `FriendChangedEvent`、`FriendIncreaseEvent`、`FriendDecreaseEvent`、
 `MemberChangedEvent`、`MemberIncreaseEvent`、`MemberDecreaseEvent`
 
-新增标准事件类型： `FriendChangedEvent` 来作为好友的对应增加/减少事件的父类事件。
+- 新增标准事件类型： `FriendChangedEvent` 来作为好友的对应增加/减少事件的父类事件。
 
 ## OriginBotManager & BotManager
-调整了 `OriginBotManager` 中 `getManagers` 的返回值，现在它将直接返回 `List` 类型。
-
+- 调整了 `OriginBotManager` 中 `getManagers` 的返回值，现在它将直接返回 `List` 类型。
+- `OriginBotManager` 的 `getManagers` 取消 `@JvmSynthetic` 注解。
+- `OriginBotManager` 中增加额外的 `getBot` 重载。 
+- `OriginBotManager` 中增加 `getAny` 。 
+- `BotManager` 的 `get` 方法增加 `operator` 修饰符。
+- 
 
 ## 组件更新
 相关组件会在后续跟进更新

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ dokka/**
 
 *.gpg
 
+.git
+
 # Ignore Gradle GUI config
 gradle-app.setting
 

--- a/apis/simbot-api/build.gradle.kts
+++ b/apis/simbot-api/build.gradle.kts
@@ -12,7 +12,6 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
- *
  */
 
 plugins {
@@ -40,6 +39,7 @@ dependencies {
     testImplementation(V.Kotlin.Reflect.notation)
     testImplementation(V.Kotlin.Test.Junit5.notation)
     testImplementation(V.Kotlinx.Serialization.Json.notation)
+    testImplementation(V.Kotlinx.Serialization.Yaml.notation)
     testImplementation(V.Kotlinx.Serialization.Properties.notation)
     testImplementation(V.Kotlinx.Serialization.Protobuf.notation)
 }

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/BotManager.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/BotManager.kt
@@ -148,7 +148,7 @@ public abstract class BotManager<B : Bot> : BotRegistrar, ComponentContainer, Su
      * 当 [Bot] 关闭后，[BotManager] 中不应能够再获取到此Bot。
      *
      */
-    public abstract fun get(id: ID): B?
+    public abstract operator fun get(id: ID): B?
 
     /**
      * 获取当前管理器下的所有BOT列表。

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/BotManager.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/BotManager.kt
@@ -16,8 +16,6 @@
 
 package love.forte.simbot
 
-import java.io.InputStream
-
 
 /**
  * Bot注册器。
@@ -42,7 +40,9 @@ public interface BotRegistrar : ComponentContainer {
     public fun register(verifyInfo: BotVerifyInfo): Bot
 }
 
-
+/**
+ * 当组件与预期组件不匹配的时候出现的异常。
+ */
 public open class ComponentMismatchException : SimbotIllegalArgumentException {
     public constructor() : super()
     public constructor(message: String?) : super(message)
@@ -50,72 +50,14 @@ public open class ComponentMismatchException : SimbotIllegalArgumentException {
     public constructor(cause: Throwable?) : super(cause)
 }
 
+/**
+ * 当验证失败的时候出现的异常。
+ */
 public open class VerifyFailureException : SimbotIllegalStateException {
     public constructor() : super()
     public constructor(message: String?) : super(message)
     public constructor(message: String?, cause: Throwable?) : super(message, cause)
     public constructor(cause: Throwable?) : super(cause)
-}
-
-
-/**
- * 目前支持的bot配置文件格式。
- */
-public enum class SupportedBotVerificationType(
-    /**
-     * 用于验证一个文件名是否为匹配的文件名。
-     */
-    private val fileNameMatcher: (name: String) -> Boolean,
-) {
-    /**
-     * Json格式的bot配置文件。格式允许 `*.bot` 或 `*.bot.json`。
-     */
-    JSON(regexMatcher(Regex(".+\\.bot(\\.json)?"))),
-
-    /**
-     * Yaml格式的bot配置文件。格式允许 `*.bot.yaml` 或 `*.bot.yml`。
-     */
-    YAML(regexMatcher(Regex(".+\\.bot\\.ya?ml"))),
-
-    /**
-     * Properties格式的bot配置文件。格式允许 `*.bot.properties`。
-     */
-    PROPERTIES(regexMatcher(Regex(".+\\.bot\\.properties"))),
-    ;
-
-    /**
-     * 判断文件名是否匹配。
-     */
-    public fun match(fileName: String): Boolean = fileNameMatcher(fileName)
-
-}
-
-
-private fun regexMatcher(regex: Regex): (String) -> Boolean = regex::matches
-
-
-/**
- * BOT用于验证身份的信息，通过读取 `.bot` 文件解析而来.
- *
- * [BotVerifyInfo] 为 Json 格式的内容。
- *
- * 此处仅提供获取其输入流的方法.
- *
- */
-public interface BotVerifyInfo {
-
-    // TODO
-    // public val componentId: String
-
-    /**
-     * 获取此资源的名称，一般代表其文件名。
-     */
-    public val infoName: String
-
-    /**
-     * 读取其输入流.
-     */
-    public fun inputStream(): InputStream
 }
 
 

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/BotManager.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/BotManager.kt
@@ -12,7 +12,6 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
- *
  */
 
 package love.forte.simbot
@@ -62,6 +61,42 @@ public open class VerifyFailureException : SimbotIllegalStateException {
 
 
 /**
+ * 目前支持的bot配置文件格式。
+ */
+public enum class SupportedBotVerificationType(
+    /**
+     * 用于验证一个文件名是否为匹配的文件名。
+     */
+    private val fileNameMatcher: (name: String) -> Boolean,
+) {
+    /**
+     * Json格式的bot配置文件。格式允许 `*.bot` 或 `*.bot.json`。
+     */
+    JSON(regexMatcher(Regex(".+\\.bot(\\.json)?"))),
+
+    /**
+     * Yaml格式的bot配置文件。格式允许 `*.bot.yaml` 或 `*.bot.yml`。
+     */
+    YAML(regexMatcher(Regex(".+\\.bot\\.ya?ml"))),
+
+    /**
+     * Properties格式的bot配置文件。格式允许 `*.bot.properties`。
+     */
+    PROPERTIES(regexMatcher(Regex(".+\\.bot\\.properties"))),
+    ;
+
+    /**
+     * 判断文件名是否匹配。
+     */
+    public fun match(fileName: String): Boolean = fileNameMatcher(fileName)
+
+}
+
+
+private fun regexMatcher(regex: Regex): (String) -> Boolean = regex::matches
+
+
+/**
  * BOT用于验证身份的信息，通过读取 `.bot` 文件解析而来.
  *
  * [BotVerifyInfo] 为 Json 格式的内容。
@@ -70,6 +105,9 @@ public open class VerifyFailureException : SimbotIllegalStateException {
  *
  */
 public interface BotVerifyInfo {
+
+    // TODO
+    // public val componentId: String
 
     /**
      * 获取此资源的名称，一般代表其文件名。

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/BotManager.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/BotManager.kt
@@ -12,14 +12,11 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
- *
  */
 
 package love.forte.simbot
 
 import java.io.InputStream
-import java.util.stream.Stream
-import kotlin.streams.asStream
 
 
 /**
@@ -154,17 +151,9 @@ public abstract class BotManager<B : Bot> : BotRegistrar, ComponentContainer, Su
     public abstract fun get(id: ID): B?
 
     /**
-     * 获取当前管理器下的所有BOT。
+     * 获取当前管理器下的所有BOT列表。
      */
-    @JvmSynthetic
-    public abstract fun all(): Sequence<B>
-
-    /**
-     * 获取 [Stream] 形式的bot流。
-     */
-    @Api4J
-    @JvmName("all")
-    public fun all4J(): Stream<B> = all().asStream()
+    public abstract fun all(): List<B>
 
 }
 

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/BotVerifyInfo.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/BotVerifyInfo.kt
@@ -1,0 +1,517 @@
+/*
+ *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ *
+ *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
+ *
+ *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ *
+ *  发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
+ *
+ *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ *  https://www.gnu.org/licenses
+ *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ *
+ */
+
+package love.forte.simbot
+
+import com.charleskorn.kaml.Yaml
+import com.charleskorn.kaml.YamlConfiguration
+import kotlinx.serialization.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonBuilder
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.properties.Properties
+import org.slf4j.Logger
+import java.io.InputStream
+import java.util.Properties as JavaProperties
+
+/**
+ * 用于快速从配置信息中解析出来 `component` 信息的模型。
+ *
+ * 使用的时候需要注意确保所使用的解析器能够忽略未知或冗余属性。
+ */
+@Serializable
+public data class ComponentModel(val component: String? = null)
+
+
+/**
+ * BOT用于验证身份的信息，通过读取 `*.bot` 文件解析而来.
+ *
+ * 目前实际支持的解析格式可参考 [StandardBotVerifyInfoDecoderFactory] 下的所有实现。
+ *
+ * ## 构建
+ * 来构建一个 [BotVerifyInfo] 可以通过:
+ * - [java.net.URL.toBotVerifyInfo]
+ * - [java.nio.file.Path.toBotVerifyInfo]
+ * - [InputStream.toBotVerifyInfo]
+ * - [ByteArrayBotVerifyInfo]
+ * - 自行实现 [BotVerifyInfo]
+ *
+ * ```kotlin
+ * val path: Path("my-bot.bot.json")
+ * val info = path.toBotVerifyInfo(StandardBotVerifyInfoDecoderFactory.Json)
+ * ```
+ *
+ * 在 Java 中，上述的 `toBotVerifyInfo` 方法存在于 `BotVerifyInfos` 类中。
+ *
+ * ```java
+ * final Path path = Paths.get("my-bot.bot.json");
+ * final BotVerifyInfo info = BotVerifyInfos.toBotVerifyInfo(path, StandardBotVerifyInfoDecoderFactory.json());
+ * ```
+ *
+ *
+ *
+ */
+public interface BotVerifyInfo {
+
+    public companion object {
+
+        /**
+         * 在所有的配置文件中, 'component' 所应当代表的属性名。
+         *
+         * @see ComponentModel
+         */
+        public const val COMPONENT_PROPERTIES_KEY: String = "component"
+
+    }
+
+    /**
+     * 此验证信息中的组件信息。
+     */
+    public val componentId: String
+
+
+    /**
+     * 获取此资源的名称，一般代表其文件名。
+     */
+    public val infoName: String
+
+    /**
+     * 读取其输入流.
+     */
+    public fun inputStream(): InputStream
+
+
+    /**
+     * 提供一个 [DeserializationStrategy], 将当前验证信息解码为目标类型。
+     */
+    public fun <T> decode(deserializer: DeserializationStrategy<T>): T
+
+
+}
+
+
+/**
+ * [BotVerifyInfoDecoder] 的构建工厂。
+ *
+ * 对此类的实现尽可能以伴生或单例的形式实现，在使用的时候会直接以此类实例作为唯一标识使用。
+ *
+ */
+public interface BotVerifyInfoDecoderFactory<C : Any, D : BotVerifyInfoDecoder> {
+
+    /**
+     * 根据提供的名称验证是否符合此工厂目标decoder的要求。
+     */
+    public fun match(verificationInfoName: String): Boolean
+
+    /**
+     * 提供配置，并构建一个目标解码器。
+     */
+    public fun create(configurator: C.() -> Unit = {}): D
+
+}
+
+/**
+ * bot验证信息的解码器。
+ *
+ * 默认提供的实现可以参考 [StandardBotVerifyInfoDecoderFactory] 的实现工厂。
+ *
+ * @see StandardBotVerifyInfoDecoderFactory
+ */
+public interface BotVerifyInfoDecoder {
+
+    /**
+     * 尝试从提供的数据信息中解析得到当前配置中的组件信息。
+     *
+     * @param inputStream 提供的数据输入流。应当由调用者关闭。
+     */
+    public fun decodeComponentId(inputStream: InputStream): String?
+
+    /**
+     * 提供数据输入流和[deserializer], 解析为目标类型。
+     *
+     * @param inputStream 提供的数据输入流。应当由调用者关闭。
+     */
+    public fun <T> decode(inputStream: InputStream, deserializer: DeserializationStrategy<T>): T
+
+}
+
+
+/**
+ * 基于 [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization) 库中的部分模块的 [BotVerifyInfoDecoderFactory] 标准实现。
+ *
+ * @see JsonBotVerifyInfoDecoder
+ *
+ */
+public sealed class StandardBotVerifyInfoDecoderFactory<C : Any, D : BotVerifyInfoDecoder> :
+    BotVerifyInfoDecoderFactory<C, D> {
+
+    public companion object {
+        private val logger: Logger = LoggerFactory.getLogger("love.forte.simbot.StandardBotVerifyInfoDecoderFactory")
+
+        /**
+         * 支持`Json`格式的bot配置文件。
+         *
+         * @see JsonBotVerifyInfoDecoder
+         */
+        @JvmStatic
+        @get:JvmName("json")
+        public val Json: JsonBotVerifyInfoDecoder.Factory get() = JsonBotVerifyInfoDecoder
+
+        /**
+         * 支持`Yaml`格式的bot配置文件。
+         *
+         * @see YamlBotVerifyInfoDecoder
+         */
+        @JvmStatic
+        @get:JvmName("yaml")
+        public val Yaml: YamlBotVerifyInfoDecoder.Factory get() = YamlBotVerifyInfoDecoder
+
+        /**
+         * 支持`Properties`格式的bot配置文件。
+         *
+         * @see PropertiesBotVerifyInfoDecoder
+         */
+        @ExperimentalSerializationApi
+        @JvmStatic
+        @get:JvmName("properties")
+        public val Properties: PropertiesBotVerifyInfoDecoder.Factory get() = PropertiesBotVerifyInfoDecoder
+
+        /**
+         * 尝试获取当前环境下所支持的所有解析工厂。
+         *
+         * @param classLoader 用于检测环境的 ClassLoader.
+         * @param warnLogger 当存在不支持的解析器的时候, 会使用提供的 logger 输出警告日志。
+         */
+        @JvmStatic
+        @JvmOverloads
+        @ExperimentalSimbotApi
+        @ExperimentalSerializationApi
+        public fun supportDecoderFactories(
+            warnLogger: Logger? = logger,
+            classLoader: ClassLoader = Companion::class.java.classLoader,
+        ): List<StandardBotVerifyInfoDecoderFactory<*, *>> {
+            return buildList {
+                if (checkJson(warnLogger, classLoader)) {
+                    add(Json)
+                }
+
+                if (checkYaml(warnLogger, classLoader)) {
+                    add(Yaml)
+                }
+
+                if (checkProperties(warnLogger, classLoader)) {
+                    add(Properties)
+                }
+            }
+        }
+
+
+        private fun checkJson(warnLogger: Logger?, classLoader: ClassLoader): Boolean {
+            return kotlin.runCatching {
+                classLoader.loadClass("kotlinx.serialization.json.Json")
+                true
+            }.getOrElse {
+                warnLogger?.warn("Unable to find the kotlinx-serialization-json in current classpath, the bot configuration parser in *.bot(.json) format will not be available.")
+                false
+            }
+        }
+
+        private fun checkYaml(warnLogger: Logger?, classLoader: ClassLoader): Boolean {
+            return kotlin.runCatching {
+                classLoader.loadClass("com.charleskorn.kaml.Yaml")
+                true
+            }.getOrElse {
+                warnLogger?.warn("Unable to find the com.charleskorn.kaml:kaml in current classpath, the bot configuration parser in *.bot.yaml format will not be available.")
+                false
+            }
+        }
+
+        private fun checkProperties(warnLogger: Logger?, classLoader: ClassLoader): Boolean {
+            return kotlin.runCatching {
+                classLoader.loadClass("kotlinx.serialization.properties.Properties")
+                true
+            }.getOrElse {
+                warnLogger?.warn("Unable to find the kotlinx-serialization-properties in current classpath, the bot configuration parser in *.bot.properties format will not be available.")
+                false
+            }
+        }
+
+
+    }
+
+}
+
+private fun regexMatcher(regex: Regex): (String) -> Boolean = regex::matches
+
+
+/**
+ * 基于 [SerialFormat] 的标准解码器抽象。
+ */
+public abstract class StandardSerialFormatBotVerifyInfoDecoder<F : SerialFormat, V : Any> internal constructor() :
+    BotVerifyInfoDecoder {
+
+    /**
+     * 用于进行常规解码的解码器。
+     */
+    protected abstract val decoder: F
+
+
+    /**
+     * 解码。
+     */
+    public abstract fun <T> decode(decoder: F, value: V, deserializer: DeserializationStrategy<T>): T
+
+
+    /**
+     * 解码。
+     */
+    public fun <T> decode(value: V, deserializer: DeserializationStrategy<T>): T = decode(decoder, value, deserializer)
+
+    /**
+     * 将 [inputStream] 准备为目标结果类型。
+     */
+    protected abstract fun InputStream.prepareToValue(): V
+
+
+    /**
+     * 解码目标类型。
+     */
+    override fun <T> decode(inputStream: InputStream, deserializer: DeserializationStrategy<T>): T {
+        val value = inputStream.prepareToValue()
+        return decode(decoder, value, deserializer)
+    }
+}
+
+/**
+ * 基于 [StringFormat] 的标准解码器抽象。
+ */
+public abstract class StandardStringFormatBotVerifyInfoDecoder internal constructor() :
+    StandardSerialFormatBotVerifyInfoDecoder<StringFormat, String>() {
+
+    /**
+     * 用于解析 [ComponentModel] 的解码器。通常应该提供一个具有较为宽松的规则的解码器。
+     */
+    protected abstract val modelDecoder: StringFormat
+
+
+    override fun InputStream.prepareToValue(): String {
+        return trimText()
+    }
+
+    override fun <T> decode(decoder: StringFormat, value: String, deserializer: DeserializationStrategy<T>): T {
+        return decoder.decodeFromString(deserializer, value)
+    }
+
+    override fun decodeComponentId(inputStream: InputStream): String? {
+        val value = inputStream.prepareToValue().takeIf { it.isNotEmpty() } ?: return null
+        val model = decode(modelDecoder, value, ComponentModel.serializer())
+        return model.component
+    }
+}
+
+/**
+ * 基于 [BinaryFormat] 的标准解码器抽象。
+ */
+public abstract class StandardBinaryFormatBotVerifyInfoDecoder internal constructor() :
+    StandardSerialFormatBotVerifyInfoDecoder<BinaryFormat, ByteArray>() {
+
+    /**
+     * 用于解析 [ComponentModel] 的解码器。通常应该提供一个具有较为宽松的规则的解码器。
+     */
+    protected abstract val modelDecoder: BinaryFormat
+
+
+    override fun InputStream.prepareToValue(): ByteArray {
+        return this.readBytes()
+    }
+
+    override fun <T> decode(decoder: BinaryFormat, value: ByteArray, deserializer: DeserializationStrategy<T>): T {
+        return decoder.decodeFromByteArray(deserializer, value)
+    }
+
+    override fun decodeComponentId(inputStream: InputStream): String? {
+        val value = inputStream.prepareToValue().takeIf { it.isNotEmpty() } ?: return null
+        val model = decode(modelDecoder, value, ComponentModel.serializer())
+        return model.component
+    }
+}
+
+
+private fun InputStream.trimText(): String = reader().readText().trim()
+
+
+/**
+ * 使用 [Json] decode 验证信息。
+ *
+ * 支持解析Json格式的bot配置文件。格式允许 `*.bot` 或 `*.bot.json`。
+ *
+ * Note: 需要保证环境中存在 `org.jetbrains.kotlinx:kotlinx-serialization-json`，参考 [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)。
+ *
+ */
+public class JsonBotVerifyInfoDecoder internal constructor(override val decoder: Json) :
+    StandardStringFormatBotVerifyInfoDecoder() {
+    override val modelDecoder: StringFormat = Json(from = decoder) {
+        isLenient = true
+        ignoreUnknownKeys = true
+    }
+
+
+    /**
+     * [JsonBotVerifyInfoDecoder] 的工厂.
+     */
+    public companion object Factory : StandardBotVerifyInfoDecoderFactory<JsonBuilder, JsonBotVerifyInfoDecoder>() {
+        private val matcher = regexMatcher(Regex(".+\\.bot(\\.json)?"))
+        override fun match(verificationInfoName: String): Boolean {
+            return matcher(verificationInfoName)
+        }
+
+        override fun create(configurator: JsonBuilder.() -> Unit): JsonBotVerifyInfoDecoder {
+            return JsonBotVerifyInfoDecoder(Json {
+                isLenient = true
+                ignoreUnknownKeys = true
+                configurator()
+            })
+        }
+
+        public fun create(decoder: Json): JsonBotVerifyInfoDecoder {
+            return JsonBotVerifyInfoDecoder(decoder)
+        }
+    }
+}
+
+/**
+ * 使用 [Yaml] decode 验证信息。
+ *
+ * 支持解析 [Yaml](https://yaml.org) 格式的bot配置文件。格式允许 `*.bot.yaml` 或 `*.bot.yml`。
+ *
+ * Note: 需要保证环境中存在 `com.charleskorn.kaml:kaml`, 参考 [charleskorn/kaml](https://github.com/charleskorn/kaml)
+ *
+ */
+public class YamlBotVerifyInfoDecoder internal constructor(override val decoder: Yaml) :
+    StandardStringFormatBotVerifyInfoDecoder() {
+    override val modelDecoder: StringFormat =
+        Yaml(decoder.serializersModule, decoder.configuration.copy(strictMode = false))
+
+    public companion object Factory :
+        StandardBotVerifyInfoDecoderFactory<YamlBotVerifyInfoDecoderConfiguration, YamlBotVerifyInfoDecoder>() {
+        private val matcher = regexMatcher(Regex(".+\\.bot\\.ya?ml"))
+        override fun match(verificationInfoName: String): Boolean {
+            return matcher(verificationInfoName)
+        }
+
+        override fun create(configurator: YamlBotVerifyInfoDecoderConfiguration.() -> Unit): YamlBotVerifyInfoDecoder {
+            val configuration = YamlBotVerifyInfoDecoderConfiguration().also(configurator)
+            return YamlBotVerifyInfoDecoder(Yaml(configuration.serializersModule,
+                configuration.createYamlConfiguration()))
+        }
+
+        public fun create(decoder: Yaml): YamlBotVerifyInfoDecoder {
+            return YamlBotVerifyInfoDecoder(decoder)
+        }
+    }
+
+    /**
+     * 用于 [YamlBotVerifyInfoDecoder.Factory] 的配置类。
+     */
+    public open class YamlBotVerifyInfoDecoderConfiguration {
+        /**
+         * 配置 [SerializersModule].
+         */
+        public var serializersModule: SerializersModule = SerializersModule {}
+
+        private var configuration: YamlConfiguration? = null
+
+        public fun config(newConfiguration: YamlConfiguration) {
+            configuration = newConfiguration
+        }
+
+        internal fun createYamlConfiguration(): YamlConfiguration {
+            return configuration ?: YamlConfiguration(strictMode = false)
+        }
+
+    }
+}
+
+
+/**
+ * 使用 [kotlinx.serialization.properties.Properties] decode 验证信息。
+ *
+ * 支持解析 kotlinx.properties 格式的bot配置文件。格式允许 `*.bot.properties`。
+ *
+ * Note: 需要保证环境中存在 `org.jetbrains.kotlinx:kotlinx-serialization-properties`，参考 [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)。
+ *
+ */
+@ExperimentalSerializationApi
+public class PropertiesBotVerifyInfoDecoder internal constructor(override val decoder: Properties) :
+    StandardSerialFormatBotVerifyInfoDecoder<Properties, Map<String, String>>() {
+
+    override fun decodeComponentId(inputStream: InputStream): String? {
+        val javaProperties = inputStream.prepareToJavaProperties()
+        return javaProperties.getProperty(BotVerifyInfo.COMPONENT_PROPERTIES_KEY)
+    }
+
+    override fun <T> decode(
+        decoder: Properties,
+        value: Map<String, String>,
+        deserializer: DeserializationStrategy<T>,
+    ): T {
+        return decoder.decodeFromStringMap(deserializer, value)
+    }
+
+    private fun InputStream.prepareToJavaProperties(): JavaProperties {
+        return JavaProperties().also {
+            it.load(reader())
+        }
+    }
+
+    override fun InputStream.prepareToValue(): Map<String, String> {
+        return prepareToJavaProperties().toStringMap()
+    }
+
+
+    /**
+     * [PropertiesBotVerifyInfoDecoder] 的工厂。
+     */
+    public companion object Factory :
+        StandardBotVerifyInfoDecoderFactory<PropertiesConfiguration, PropertiesBotVerifyInfoDecoder>() {
+        private val matcher = regexMatcher(Regex(".+\\.bot\\.properties"))
+        private fun JavaProperties.toStringMap(): Map<String, String> {
+            val stringMap = mutableMapOf<String, String>()
+            stringPropertyNames().forEach { name ->
+                stringMap[name] = getProperty(name)
+            }
+            return stringMap
+        }
+
+
+        override fun match(verificationInfoName: String): Boolean {
+            return matcher(verificationInfoName)
+        }
+
+        override fun create(configurator: PropertiesConfiguration.() -> Unit): PropertiesBotVerifyInfoDecoder {
+            return PropertiesBotVerifyInfoDecoder(Properties(PropertiesConfiguration().also(configurator).serializersModule))
+        }
+    }
+
+    /**
+     * 服务于 [PropertiesBotVerifyInfoDecoder.Factory] 的配置类。
+     */
+    public open class PropertiesConfiguration {
+        public var serializersModule: SerializersModule = SerializersModule {}
+    }
+}
+
+

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/BotVerifyInfos.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/BotVerifyInfos.kt
@@ -12,63 +12,191 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
- *
  */
 
-@file:JvmName("BotVerifyInfoUtil")
+@file:JvmName("BotVerifyInfos")
 
 package love.forte.simbot
 
+import kotlinx.serialization.DeserializationStrategy
 import java.io.InputStream
 import java.net.URL
 import java.nio.file.Path
 import kotlin.io.path.inputStream
 
 
-public fun URL.asBotVerifyInfo(): BotVerifyInfo {
-    return URLBotVerifyInfo(this)
+/**
+ *
+ * [BotVerifyInfo] 的基础抽象类, 使用 [BotVerifyInfoDecoder] 作为内置解码器。
+ *
+ */
+public abstract class DecoderBotVerifyInfo : BotVerifyInfo {
+    protected abstract val decoder: BotVerifyInfoDecoder
+
+    /**
+     * 已经初始化了的组件id信息。
+     *
+     * 此属性只会被使用一次。
+     */
+    protected open val initializedComponentId: String? get() = null
+
+    /**
+     * 获取此验证信息的组件id。默认情况下优先尝试通过 [initializedComponentId] 初始化信息，
+     * 如果 [initializedComponentId] 值为null, 则尝试通过 [decoder.decodeComponentId(...)][BotVerifyInfoDecoder.decodeComponentId]
+     * 来初始化组件id信息。
+     */
+    override val componentId: String by lazy {
+        initializedComponentId
+            ?: inputStream().use { inp -> decoder.decodeComponentId(inp) }
+            ?: throw NoSuchComponentException("required property 'component' cannot be found in current verify info $infoName")
+    }
+
+    override fun <T> decode(deserializer: DeserializationStrategy<T>): T {
+        return inputStream().use { inp -> decoder.decode(inp, deserializer) }
+    }
+
 }
 
 
 private class URLBotVerifyInfo(
+    override val decoder: BotVerifyInfoDecoder,
     private val url: URL,
-) : BotVerifyInfo {
+) : DecoderBotVerifyInfo() {
     override val infoName: String get() = url.toString()
 
     override fun inputStream(): InputStream = url.openStream()
 }
 
 
-public fun Path.asBotVerifyInfo(): BotVerifyInfo {
-    return PathBotVerifyInfo(this)
-}
-
-private class PathBotVerifyInfo(private val path: Path) : BotVerifyInfo {
+private class PathBotVerifyInfo(
+    override val decoder: BotVerifyInfoDecoder,
+    private val path: Path,
+) : DecoderBotVerifyInfo() {
     override val infoName: String get() = path.toString()
+
     override fun inputStream(): InputStream = path.inputStream()
 }
 
+/**
+ * 将 [ByteArray] 内容作为 [BotVerifyInfo] 实现。
+ *
+ */
+public class ByteArrayBotVerifyInfo(
+    override val decoder: BotVerifyInfoDecoder,
+    override val infoName: String,
+    private val value: ByteArray,
+) : DecoderBotVerifyInfo() {
 
-public inline fun <T> BotVerifyInfo.tryResolveVerifyInfo(
-    initErr: () -> Throwable,
-    vararg decoders: (InputStream) -> T
-): Result<T> {
-    lateinit var err: Throwable
-
-    decoders.forEachIndexed { index, decoder ->
-        val inp = inputStream()
-        try {
-            val result = decoder(inp)
-            return Result.success(result)
-        } catch (e: Throwable) {
-            if (index == 0) {
-                err = initErr()
-            }
-            err.addSuppressed(e)
-        } finally {
-            inp.close()
-        }
+    override fun inputStream(): InputStream {
+        return value.inputStream()
     }
 
-    return Result.failure(err)
+    override fun <T> decode(deserializer: DeserializationStrategy<T>): T {
+        if (decoder is StandardBinaryFormatBotVerifyInfoDecoder) {
+            return decoder.decode(value, deserializer)
+        }
+
+        if (decoder is StandardStringFormatBotVerifyInfoDecoder) {
+            return decoder.decode(value.toString(Charsets.UTF_8), deserializer)
+        }
+
+        return super.decode(deserializer)
+    }
 }
+
+
+/**
+ * 将一个 [URL] 转为 [BotVerifyInfo].
+ *
+ */
+public fun URL.toBotVerifyInfo(decoder: BotVerifyInfoDecoder): BotVerifyInfo {
+    return URLBotVerifyInfo(decoder, this)
+}
+
+/**
+ * 将一个 [Path] 转为 [BotVerifyInfo].
+ */
+public fun Path.toBotVerifyInfo(decoder: BotVerifyInfoDecoder): BotVerifyInfo {
+    return PathBotVerifyInfo(decoder, this)
+}
+
+/**
+ * 将一个 [InputStream] 转为 [BotVerifyInfo].
+ *
+ * @param infoName 给 bot verify info 提供一个名称。
+ */
+public fun InputStream.toBotVerifyInfo(decoder: BotVerifyInfoDecoder, infoName: String): ByteArrayBotVerifyInfo {
+    val bytes = readBytes()
+    return ByteArrayBotVerifyInfo(decoder, infoName, bytes)
+}
+
+/**
+ * 将一个 [URL] 转为 [BotVerifyInfo].
+ *
+ * e.g.
+ * ```kotlin
+ * // 解析json配置
+ *
+ * url: URL = ...
+ *
+ * url.toBotVerifyInfo(StandardBotVerifyInfoDecoderFactory.Json) {
+ *   isLenient = true
+ *   ignoreUnknownKeys = true
+ * }
+ * ```
+ */
+@JvmOverloads
+public fun <C : Any> URL.toBotVerifyInfo(
+    factory: BotVerifyInfoDecoderFactory<C, *>,
+    configurator: C.() -> Unit = {},
+): BotVerifyInfo {
+    return toBotVerifyInfo(factory.create(configurator))
+}
+
+
+/**
+ * 将一个 [Path] 转为 [BotVerifyInfo].
+ * e.g.
+ * ```kotlin
+ * // 解析json配置
+ * path: Path = ...
+ * path.toBotVerifyInfo(StandardBotVerifyInfoDecoderFactory.Json) {
+ *   isLenient = true
+ *   ignoreUnknownKeys = true
+ * }
+ * ```
+ */
+@JvmOverloads
+public fun <C : Any> Path.toBotVerifyInfo(
+    factory: BotVerifyInfoDecoderFactory<C, *>,
+    configurator: C.() -> Unit = {},
+): BotVerifyInfo {
+    return toBotVerifyInfo(factory.create(configurator))
+}
+
+
+/**
+ * 将一个 [InputStream] 转为 [BotVerifyInfo].
+ * e.g.
+ * ```kotlin
+ * // 解析json配置
+ * input: InputStream = ...
+ * val infoName: String = "myBot.json"
+ * input.toBotVerifyInfo(StandardBotVerifyInfoDecoderFactory.Json, infoName) {
+ *   isLenient = true
+ *   ignoreUnknownKeys = true
+ * }
+ * ```
+ */
+@JvmOverloads
+public fun <C : Any> InputStream.toBotVerifyInfo(
+    factory: BotVerifyInfoDecoderFactory<C, *>,
+    infoName: String,
+    configurator: C.() -> Unit = {},
+): BotVerifyInfo {
+    return toBotVerifyInfo(factory.create(configurator), infoName)
+}
+
+
+
+

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/OriginBotManager.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/OriginBotManager.kt
@@ -12,7 +12,6 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
- *
  */
 
 package love.forte.simbot
@@ -35,12 +34,20 @@ import kotlin.concurrent.write
  *
  * 如果你想要某个 [BotManager] 脱离 [OriginBotManager] 的管理，使用 [BotManager.breakAway]
  *
- * ## 谨慎使用
+ * **遍历所有**:
+ * ```kotlin
+ * OriginBotManager.forEach { manager ->
+ *  // do...
+ *  }
+ * ```
+ *
+ * ## ⚠ 谨慎使用
  * [OriginBotManager] 是脱离环境的 **全局性** 功能，当你的整个应用中存在多个环境时，使用它则很可能造成各种混乱。
- * [BotManager] 作为属性存在于很多对象中，你应当优先考虑使用那些明确的api，而对于全局性的 [OriginBotManager],
- * 则是最后的选择。
+ * [BotManager] 作为属性存在于很多对象中，你应当优先考虑使用那些明确的api（例如 [Bot.manager]、[love.forte.simbot.event.Event.bot] 等），
+ * 而对于全局性的 [OriginBotManager], 是最后的选择。
  *
  */
+@Suppress("MemberVisibilityCanBePrivate")
 public object OriginBotManager : Set<BotManager<*>> {
     private val logger = LoggerFactory.getLogger(OriginBotManager::class)
     private val lock = ReentrantReadWriteLock()
@@ -125,15 +132,15 @@ public object OriginBotManager : Set<BotManager<*>> {
      * 例如, 获取某组件下所有bot的所有好友：
      * ```kotlin
      * OriginBotManager
-     * .getManagers(XxxComponent)
+     * .getManagers("component.id".ID)
      * .flatMap { manager -> manager.all() }
      * .asFlow() // Bot.friends() 是Flow类型
      * .flatMapConcat { bot -> bot.friends() }
      * ```
      *
-     * ### getManagers()?
+     * ## getManagers()?
      *
-     * 如果你在寻找不需要 [Component] 参数的 `getManagers()` 函数，请停下。[OriginBotManager] 其本身作为一个 [Set] 的实现即可以代表所有的BotManager。
+     * 如果你在寻找不需要参数的 `getManagers()` 函数，请停下。[OriginBotManager] 其本身作为一个 [Set] 的实现即可以直接代表所有的 [BotManager]。
      *
      * 假如你需要遍历所有，那么：
      * ```kotlin
@@ -143,7 +150,6 @@ public object OriginBotManager : Set<BotManager<*>> {
      * ```
      *
      */
-    @JvmSynthetic
     public fun getManagers(component: Component): List<BotManager<*>> {
         lock.read {
             checkShutdown()
@@ -154,7 +160,6 @@ public object OriginBotManager : Set<BotManager<*>> {
     /**
      * 根据指定ID查询组件ID与其相等的 [BotManager].
      */
-    @JvmSynthetic
     public fun getManagers(componentId: ID): List<BotManager<*>> {
         lock.read {
             checkShutdown()
@@ -197,6 +202,42 @@ public object OriginBotManager : Set<BotManager<*>> {
         }?.get(id)
     }
 
+    /**
+     * 根据一个Bot的id以及对应的组件ID来得到一个此组件下指定ID的bot。如果manager不存在或者没有这个id的bot，则会得到null。
+     *
+     * 如果提供的 [组件ID][componentId] 为null，则会尝试寻找第一个id匹配的bot。
+     *
+     * @param id Bot的id
+     * @param componentId [Component.id]
+     */
+    @JvmOverloads
+    public fun getBot(id: ID, componentId: ID? = null): Bot? {
+        if (componentId == null) {
+            val managers = managers.keys
+            for (manager in managers) {
+                val bot = manager.get(id)
+                if (bot != null) return bot
+            }
+            return null
+        }
+
+        return managers.keys.firstOrNull {
+            it.component.id == componentId
+        }?.get(id)
+    }
+
+
+    /**
+     * 尝试获取任意一个 [BotManager] 下的任意一个 [Bot]。如果当前元素为空则会得到null。
+     *
+     * @param component 可以提供一个组件信息。默认为null
+     */
+    @JvmOverloads
+    public fun getAnyBot(component: Component? = null): Bot? {
+        fun Iterable<BotManager<*>>.firstBotOrNull() = firstOrNull()?.all()?.firstOrNull()
+
+        return (component?.let { getManagers(component) } ?: this).firstBotOrNull()
+    }
 
     /**
      * 尝试获取任意一个manager。如果当前元素为空则会得到null。

--- a/apis/simbot-api/src/test/java/JavaMessageSerializerTest.java
+++ b/apis/simbot-api/src/test/java/JavaMessageSerializerTest.java
@@ -1,9 +1,31 @@
+/*
+ *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ *
+ *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
+ *
+ *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ *
+ *  发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
+ *
+ *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ *  https://www.gnu.org/licenses
+ *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ *
+ */
+
+import love.forte.simbot.BotVerifyInfo;
+import love.forte.simbot.BotVerifyInfos;
 import love.forte.simbot.Identifies;
+import love.forte.simbot.StandardBotVerifyInfoDecoderFactory;
 import love.forte.simbot.message.At;
 import love.forte.simbot.message.Messages;
 import love.forte.simbot.message.Text;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * @author ForteScarlet
@@ -25,6 +47,9 @@ public class JavaMessageSerializerTest {
 
         assert messages.equals(messages2);
         assert messages2.equals(messages);
+
+        final Path path = Paths.get("my-bot.bot.json");
+        final BotVerifyInfo info = BotVerifyInfos.toBotVerifyInfo(path, StandardBotVerifyInfoDecoderFactory.json());
 
 
     }

--- a/apis/simbot-api/src/test/kotlin/BotManagerTest.kt
+++ b/apis/simbot-api/src/test/kotlin/BotManagerTest.kt
@@ -12,11 +12,8 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
- *
  */
 
-import love.forte.simbot.Bot
-import love.forte.simbot.BotManager
 import love.forte.simbot.ID
 import love.forte.simbot.OriginBotManager
 
@@ -34,18 +31,10 @@ import love.forte.simbot.OriginBotManager
 
 
 fun main() {
-    OriginBotManager.forEach {
-        println("BotManager: $it")
-    }
+    val manager = OriginBotManager.getFirstManager(123.ID)!!
 
-    OriginBotManager.cancel()
+    val bot = manager[123.ID]
+
 
 }
 
-fun bm(manager: BotManager<*>) {
-    // 获取所有Bot，以序列Sequence的形式返回
-    val all: Sequence<Bot> = manager.all()
-
-    // 获取指定的Bot
-    val bot: Bot? = manager.get(123.ID)
-}

--- a/apis/simbot-api/src/test/kotlin/BotVerifyInfoPropertySerializerTest.kt
+++ b/apis/simbot-api/src/test/kotlin/BotVerifyInfoPropertySerializerTest.kt
@@ -1,4 +1,24 @@
 /*
+ *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ *
+ *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
+ *
+ *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ *
+ *  发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
+ *
+ *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ *  https://www.gnu.org/licenses
+ *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ *
+ */
+
+import love.forte.simbot.StandardBotVerifyInfoDecoderFactory
+import love.forte.simbot.toBotVerifyInfo
+import kotlin.test.Test
+
+/*
  *  Copyright (c) 2021-2022 ForteScarlet <ForteScarlet@163.com>
  *
  *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
@@ -15,21 +35,32 @@
  *
  */
 
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.Serializable
 
 
-@Serializable
-data class Hi(val name: String, val age: Int)
+class BotVerifyInfoPropertySerializerTest {
+
+    @Test
+    fun test() {
+        val info = configValue.byteInputStream().toBotVerifyInfo(StandardBotVerifyInfoDecoderFactory.Json, "my-test-bot.bot.json")
+        assert(info.componentId == COMPONENT)
+        val config = info.decode(Config.serializer())
+
+        println(config)
+        assert(config.name == NAME)
+        assert(config.age == AGE)
 
 
-@OptIn(ExperimentalSerializationApi::class)
-fun main() {
-    // val info = mapOf("name" to "forte", "age" to "123").asBotVerifyInfo("abc")
-    //
-    // val p = Properties(EmptySerializersModule)
-    //
-    // val hi = p.decodeFromStringMap(Hi.serializer(), info)
-    //
-    // println(hi)
+    }
+
+
 }
+private const val COMPONENT = "simbot.test"
+private const val NAME = "forte"
+private const val AGE = 16
+
+@kotlinx.serialization.Serializable
+private data class Config(val name: String, val age: Int)
+
+private val configValue = """
+    {"component": "$COMPONENT", "name": "$NAME", "age": $AGE}
+""".trimIndent()

--- a/boots/simboot-core/src/main/kotlin/love/forte/simboot/core/internal/CoreBootEntranceContextImpl.kt
+++ b/boots/simboot-core/src/main/kotlin/love/forte/simboot/core/internal/CoreBootEntranceContextImpl.kt
@@ -1,7 +1,7 @@
 /*
- *  Copyright (c) 2021-2022 ForteScarlet <https://github.com/ForteScarlet>
+ *  Copyright (c) 2021-2022 ForteScarlet <ForteScarlet@163.com>
  *
- *  本文件是 simply-robot (或称 simple-robot 3.x、simbot 3.x、simbot3) 的一部分。
+ *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
  *
  *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
  *
@@ -40,11 +40,6 @@ import love.forte.simbot.event.EventListenerManager
 import love.forte.simbot.event.EventProcessingInterceptor
 import love.forte.simbot.utils.systemProperties
 import org.slf4j.Logger
-import java.net.URL
-import java.nio.file.Path
-import java.util.*
-import kotlin.collections.set
-import kotlin.io.path.bufferedReader
 import kotlin.reflect.KAnnotatedElement
 import kotlin.reflect.KClass
 import kotlin.reflect.KVisibility
@@ -199,13 +194,14 @@ internal class CoreBootEntranceContextImpl(
                 .glob(glob)
                 .visitJarEntry { entry, _ ->
                     if (!entry.isDirectory) {
-                        it.classLoader.getResource(entry.toString())?.asBotVerifyInfo()?.let { url -> sequenceOf(url) }
+                        // TODO
+                        it.classLoader.getResource(entry.toString())?.toBotVerifyInfo(StandardBotVerifyInfoDecoderFactory.Json)?.let { url -> sequenceOf(url) }
                             ?: emptySequence()
                     } else emptySequence()
                 }
                 .visitPath { (path, _) ->
                     sequenceOf(
-                        path.asBotVerifyInfo()
+                        path.toBotVerifyInfo(StandardBotVerifyInfoDecoderFactory.Json)
                     )
                 }
                 .toList(false)
@@ -299,26 +295,6 @@ private class AnnotationToolGetter(private val tool: KAnnotationTool) : Annotati
         }
     }
 }
-
-
-private fun Path.readProperties(): Properties {
-    return Properties().also { p ->
-        bufferedReader().use(p::load)
-    }
-}
-
-private fun URL.readProperties(): Properties {
-    return Properties().also { p ->
-        openStream().bufferedReader().use(p::load)
-    }
-}
-
-private val Properties.stringMap: Map<String, String>
-    get() {
-        return mutableMapOf<String, String>().also { map ->
-            stringPropertyNames().forEach { name -> map[name] = getProperty(name) }
-        }
-    }
 
 
 private object EmptyConfiguration : Configuration {


### PR DESCRIPTION
重写 `BotVerifyInfo`, 为其在 `preview.10.x` 重构时能够支持多格式做准备。

对比: 

**旧** 
```kotlin
val path = Path("my-bot.bot")
val info = path.asBotVerifyInfo()

// 获取源输入流并操作
val inputStream = info.inputStream()
// do by inputStream...
```

**新**
```kotlin
val path = Path("my-bot.bot")
val info = path.toBotVerifyInfo(StandardBotVerifyInfoDecoderFactory.Json)

// 可以直接进行反序列化
val config = info.decode(MyConfig.serializer())
// do...

// 保留获取源输入流的能力
val inputStream = info.inputStream()
```

