### PR TITLE
只在 `simbot-core`、`simboot-core` 中传递使用 `simbot-logger` 作为默认SLF4J日志实现

### DIFF
--- a/apis/simbot-api/build.gradle.kts
+++ b/apis/simbot-api/build.gradle.kts
@@ -29,7 +29,6 @@ dependencies {
     api(V.Kotlinx.Coroutines.J8.notation)
     api(V.Kotlinx.Serialization.Core.notation)
     api(V.Slf4j.Api.notation)
-    api(project(":apis:simbot-logger"))
     compileOnly(V.Jetbrains.Annotations.notation)
 
     compileOnly(V.Kotlinx.Serialization.Json.notation)

--- a/boots/simboot-core-spring-boot-starter/build.gradle.kts
+++ b/boots/simboot-core-spring-boot-starter/build.gradle.kts
@@ -12,7 +12,6 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
- *
  */
 
 plugins {
@@ -40,9 +39,13 @@ repositories {
 }
 
 dependencies {
-    api(project(":boots:simboot-core"))
+    api(project(":boots:simboot-core")) {
+        exclude("love.forte.simbot", "simbot-logger")
+    }
+
     api(V.Javax.Inject.notation)
     api(P.ForteDI.Spring.notation)
+    api(V.Spring.Boot.Logging.notation)
 
     implementation(V.Spring.Boot.Autoconfigure.notation)
     implementation(V.Spring.Boot.ConfigurationProcessor.notation)

--- a/boots/simboot-core/build.gradle.kts
+++ b/boots/simboot-core/build.gradle.kts
@@ -12,7 +12,6 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
- *
  */
 
 plugins {
@@ -37,6 +36,8 @@ repositories {
 
 
 dependencies {
+    // boot-core 使用 simbot-logger
+    api(project(":apis:simbot-logger"))
     api(project(":boots:simboot-api"))
     api(project(":boots:simboot-core-annotation"))
 
@@ -54,7 +55,7 @@ dependencies {
 }
 
 kotlin {
-    // 严格模式
+    // 严格模式warn
     explicitApiWarning()
 
 

--- a/cores/simbot-core/build.gradle.kts
+++ b/cores/simbot-core/build.gradle.kts
@@ -29,6 +29,8 @@ tasks.getByName<Test>("test") {
 
 
 dependencies {
+    // simbot-core 使用 logger
+    api(project(":apis:simbot-logger"))
     api(project(":apis:simbot-api"))
     api(V.Slf4j.Api.notation)
     api(V.Kotlinx.Coroutines.Core.Jvm.notation)


### PR DESCRIPTION
只在 `simbot-core`、`simboot-core` 中传递使用 `simbot-logger` 作为默认SLF4J日志实现，
在 `simboot-core-spring-boot-starter` 中默认使用 `spring-boot-starter-logging` ，
其他模块不提供默认实现。