### PR TITLE
bot内容器拆分

### DIFF
--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/Bot.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/Bot.kt
@@ -20,15 +20,15 @@ import kotlinx.coroutines.CompletionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.Flow
 import love.forte.simbot.ability.Survivable
-import love.forte.simbot.definition.*
+import love.forte.simbot.definition.User
+import love.forte.simbot.definition.UserInfo
+import love.forte.simbot.definition.UserStatus
 import love.forte.simbot.event.EventProcessor
 import love.forte.simbot.message.Image
 import love.forte.simbot.resources.Resource
 import love.forte.simbot.utils.runInBlocking
 import org.slf4j.Logger
-import java.util.stream.Stream
 import kotlin.coroutines.CoroutineContext
 
 
@@ -36,14 +36,22 @@ import kotlin.coroutines.CoroutineContext
  *
  * 一个 [Bot]. 同时, [Bot] 也属于一个用户 [User]。
  *
- * Bot是一个活动个体，通过 [BotManager] 构建而来。
+ * [Bot] 是一个活动个体，通过 [BotManager] 构建而来。
  * 其作为一个 [CoroutineScope] 来持有自己的协程上下文。
+ *
+ * @see LoggerContainer
+ * @see ComponentContainer
+ * @see FriendsContainer
+ * @see GroupsContainer
+ * @see GuildsContainer
  *
  * @author ForteScarlet
  */
-public interface Bot : User, CoroutineScope, Survivable, LoggerContainer, ComponentContainer {
+public interface Bot : User, CoroutineScope, Survivable,
+    LoggerContainer, ComponentContainer,
+    FriendsContainer, GroupsContainer, GuildsContainer {
     override val coroutineContext: CoroutineContext
-
+    
     /**
      * Bot的唯一标识。此处的唯一标识通常指的是在其所属的 [BotManager] 中的唯一标识，
      * 而不代表其在对应平台系统内的唯一标识。
@@ -58,177 +66,37 @@ public interface Bot : User, CoroutineScope, Survivable, LoggerContainer, Compon
     override val username: String
     override val avatar: String
     override val logger: Logger
-
+    
     /**
      * 每个bot都肯定会由一个 [BotManager] 进行管理。
      *
      */
     public val manager: BotManager<out Bot>
-
+    
     /**
      * 对于一个Bot，其应当存在一个事件处理器。
      */
     public val eventProcessor: EventProcessor
-
+    
     /**
      * 每个Bot都有一个所属组件。
      *
      */
     override val component: Component
-
+    
     /**
      * 当前Bot的用户状态。
      */
     override val status: UserStatus
-
+    
     /**
      * 用于检测一个 [ID] 是否属于当前BOT。一个bot可能会存在多个领域的ID，例如作为bot的client ID和作为user的普通ID。
      */
     public fun isMe(id: ID): Boolean
-
-
-    //region 批量获取相关api
-    // TODO contacts?
-
-
-    // friends
-    /**
-     * 根据分组和限流信息得到此bot下的好友列表。
-     *
-     *
-     * *分组不一定存在，限流器也不一定生效，这两个参数的有效情况取决于当前 [Bot] 的实现情况。*
-     *
-     */
-    @JvmSynthetic
-    public suspend fun friends(grouping: Grouping = Grouping.EMPTY, limiter: Limiter = Limiter): Flow<Friend>
-
-    /**
-     * @see friends
-     */
-    @Api4J
-    public fun getFriends(grouping: Grouping, limiter: Limiter): Stream<out Friend>
-
-    /**
-     * @see friends
-     */
-    @Api4J
-    public fun getFriends(): Stream<out Friend> = getFriends(Grouping.EMPTY, Limiter)
-
-    /**
-     * @see friends
-     */
-    @Api4J
-    public fun getFriends(limiter: Limiter): Stream<out Friend> = getFriends(Grouping.EMPTY, limiter)
-
-
-    // organizations
-    /**
-     * 获取群列表。
-     *
-     * *分组不一定存在，限流器也不一定生效，这两个参数的有效情况取决于当前 [Bot] 的实现情况。*
-     */
-    @JvmSynthetic
-    public suspend fun groups(grouping: Grouping = Grouping.EMPTY, limiter: Limiter = Limiter): Flow<Group>
-
-    /**
-     * @see groups
-     */
-    @Api4J
-    public fun getGroups(grouping: Grouping, limiter: Limiter): Stream<out Group>
-
-    /**
-     * @see groups
-     */
-    @Api4J
-    public fun getGroups(): Stream<out Group> = getGroups(Grouping.EMPTY, Limiter)
-
-    /**
-     * @see groups
-     */
-    @Api4J
-    public fun getGroups(limiter: Limiter): Stream<out Group> = getGroups(Grouping.EMPTY, limiter)
-
-    /**
-     * 获取当前的所有频道服务器列表
-     *
-     * *分组不一定存在，限流器也不一定生效，这两个参数的有效情况取决于当前 [Bot] 的实现情况。*
-     */
-    @JvmSynthetic
-    public suspend fun guilds(grouping: Grouping = Grouping.EMPTY, limiter: Limiter = Limiter): Flow<Guild>
-
-    /**
-     * @see guilds
-     */
-    @Api4J
-    public fun getGuilds(grouping: Grouping, limiter: Limiter): Stream<out Guild>
-
-    /**
-     * @see guilds
-     */
-    @Api4J
-    public fun getGuilds(): Stream<out Guild> = getGuilds(Grouping.EMPTY, Limiter)
-
-    /**
-     * @see guilds
-     */
-    @Api4J
-    public fun getGuilds(limiter: Limiter): Stream<out Guild> = getGuilds(Grouping.EMPTY, limiter)
-    //endregion
-
-
-    //// 单独获取
-
-    //region 独立获取
-
-    //region 好友
-
-    /**
-     * 通过唯一标识获取这个bot对应的某个好友，获取不到则为null。
-     */
-    @JvmSynthetic
-    public suspend fun friend(id: ID): Friend?
-
-    /**
-     * 通过唯一标识获取这个bot对应的某个好友，获取不到则为null。
-     */
-    @Api4J
-    public fun getFriend(id: ID): Friend? = runInBlocking { friend(id) }
-
-    //endregion
-
-    //region 群
-    /**
-     * 通过唯一标识获取这个bot对应的某个群，获取不到则为null。
-     */
-    @JvmSynthetic
-    public suspend fun group(id: ID): Group?
-
-    /**
-     * 通过唯一标识获取这个bot对应的某个群，获取不到则为null。
-     */
-    @Api4J
-    public fun getGroup(id: ID): Group? = runInBlocking { group(id) }
-    //endregion
-
-    //region 频道
-    /**
-     * 通过唯一标识获取这个bot对应的某个频道，获取不到则为null。
-     */
-    @JvmSynthetic
-    public suspend fun guild(id: ID): Guild?
-
-    /**
-     * 通过唯一标识获取这个bot对应的某个频道，获取不到则为null。
-     */
-    @Api4J
-    public fun getGuild(id: ID): Guild? = runInBlocking { guild(id) }
-    //endregion
-
-    //endregion
-
-
+    
+    
     //// image api
-
+    
     /**
      * 上传一个资源作为资源，并在预期内得到一个 [Image] 结果。
      * 这个 [Image] 不一定是真正已经上传后的结果，它有可能只是一个预处理类型。
@@ -236,29 +104,29 @@ public interface Bot : User, CoroutineScope, Survivable, LoggerContainer, Compon
      */
     @JvmSynthetic
     public suspend fun uploadImage(resource: Resource): Image<*>
-
+    
     /**
      * @see uploadImage
      */
     @Api4J
     public fun uploadImageBlocking(resource: Resource): Image<*> = runInBlocking { uploadImage(resource) }
-
-
+    
+    
     /**
      *  尝试通过解析一个 [ID] 并得到对应的可用于发送的图片实例。
      *  这个 [Image] 不一定是真正远端图片结果，它有可能只是一个预处理类型。
      *  在执行 [resolveImage] 的过程中也不一定出现真正的挂起行为，具体细节请参考具体实现。
      */
     public suspend fun resolveImage(id: ID): Image<*>
-
-
+    
+    
     /**
      * @see resolveImage
      */
     @Api4J
     public fun resolveImageBlocking(id: ID): Image<*> = runInBlocking { resolveImage(id) }
     
-
+    
     // self
     /**
      * 真正的启动这个BOT。
@@ -268,13 +136,13 @@ public interface Bot : User, CoroutineScope, Survivable, LoggerContainer, Compon
      */
     @JvmSynthetic
     override suspend fun start(): Boolean
-
+    
     /**
      * 让当前bot挂起当前协程直至其被 [cancel]
      */
     @JvmSynthetic
     override suspend fun join()
-
+    
     /**
      * 关闭此Bot。
      *
@@ -286,26 +154,26 @@ public interface Bot : User, CoroutineScope, Survivable, LoggerContainer, Compon
      */
     @JvmSynthetic
     override suspend fun cancel(reason: Throwable?): Boolean
-
+    
     override fun invokeOnCompletion(handler: CompletionHandler) {
         coroutineContext[Job]?.invokeOnCompletion(handler) ?: throw IllegalStateException("No Job in here.")
     }
-
+    
     /**
      * 是否已经启动过了。
      */
     override val isStarted: Boolean
-
+    
     /**
      * 是否正在运行，即启动后尚未关闭。
      */
     override val isActive: Boolean
-
+    
     /**
      * 是否已经被取消。
      */
     override val isCancelled: Boolean
-
+    
 }
 
 

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/BotContainers.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/BotContainers.kt
@@ -1,0 +1,261 @@
+/*
+ *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ *
+ *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
+ *
+ *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ *
+ *  发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
+ *
+ *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ *  https://www.gnu.org/licenses
+ *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ *
+ */
+
+package love.forte.simbot
+
+import kotlinx.coroutines.flow.Flow
+import love.forte.simbot.definition.Friend
+import love.forte.simbot.definition.Group
+import love.forte.simbot.definition.Guild
+import love.forte.simbot.definition.SuspendablePropertyContainer
+import java.util.stream.Stream
+
+
+/**
+ * 与 [Bot] 的社交关系相关的容器。
+ *
+ */
+public sealed interface BotSocialRelationsContainer : SuspendablePropertyContainer
+
+
+/**
+ * 应用于 [Bot] 中为其提供获取 [Friend] 相关的属性api。
+ *
+ * [Bot] 或许会存在一些 "好友" 对象。
+ *
+ * "好友"并_**不一定**_代表那些需要 "添加申请"、"同意" 后出现在好友列表中的好友 ——
+ * 并非所有的组件都支持这种“好友”的概念。
+ *
+ * 对于一个以"频道"概念为主的组件就是最常见的例子 —— 它们通常没有真正的"好友"概念，
+ * 至少对于bot来讲没有。取而代之的则通常是"频道成员"或者一个"会话"。
+ *
+ * 实际上，对于一个bot来讲"好友"的概念确实可有可无，它更需要"联系人"。目前阶段将会暂时保留
+ * "[好友][Friend]" 容器，但是在未来可能会被标记过时并由其他概念代替。
+ *
+ *
+ */
+public interface FriendsContainer : BotSocialRelationsContainer {
+    
+    /**
+     * 根据分组和限流信息得到此bot下的好友列表。
+     *
+     * *分组不一定存在，限流器也不一定生效，这两个参数的有效情况取决于当前 [Bot] 的实现情况。*
+     *
+     * @param grouping 好友分组信息（如果支持的话。）
+     * @param limiter 数据限流
+     *
+     */
+    @JvmSynthetic
+    public suspend fun friends(grouping: Grouping = Grouping.EMPTY, limiter: Limiter = Limiter): Flow<Friend>
+    
+    /**
+     * 根据分组和限流信息得到此bot下的好友列表。
+     *
+     * *分组不一定存在，限流器也不一定生效，这两个参数的有效情况取决于当前 [Bot] 的实现情况。*
+     *
+     * @param grouping 好友分组信息（如果支持的话。）
+     * @param limiter 数据限流
+     *
+     * @see friends
+     */
+    @Api4J
+    public fun getFriends(grouping: Grouping, limiter: Limiter): Stream<out Friend>
+    
+    /**
+     * 根据分组和限流信息得到此bot下的好友列表。
+     *
+     * *分组不一定存在，限流器也不一定生效，这两个参数的有效情况取决于当前 [Bot] 的实现情况。*
+     *
+     * @see friends
+     */
+    @Api4J
+    public fun getFriends(limiter: Limiter): Stream<out Friend>
+    
+    /**
+     * 根据分组和限流信息得到此bot下的好友列表。
+     *
+     * *分组不一定存在，限流器也不一定生效，这两个参数的有效情况取决于当前 [Bot] 的实现情况。*
+     *
+     * @see friends
+     */
+    @Api4J
+    public fun getFriends(): Stream<out Friend>
+    
+    
+    /**
+     * 通过唯一标识获取这个bot对应的某个好友，获取不到则为null。
+     *
+     * @param id 好友的唯一标识
+     */
+    @JvmSynthetic
+    public suspend fun friend(id: ID): Friend?
+    
+    
+    /**
+     * 通过唯一标识获取这个bot对应的某个好友，获取不到则为null。
+     *
+     * @param id 好友的唯一标识
+     *
+     * @see friend
+     */
+    @Api4J
+    public fun getFriend(id: ID): Friend?
+    
+    
+}
+
+
+/**
+ * 应用于 [Bot] 中为其提供获取 [Group] 相关的属性api。
+ *
+ */
+public interface GroupsContainer : BotSocialRelationsContainer {
+    
+    /**
+     * 获取群列表。
+     *
+     * *分组不一定存在，限流器也不一定生效，这两个参数的有效情况取决于当前 [Bot] 的实现情况。*
+     *
+     * @param grouping 根据分组（如果支持的话）
+     * @param limiter 数据限流
+     *
+     */
+    @JvmSynthetic
+    public suspend fun groups(grouping: Grouping = Grouping.EMPTY, limiter: Limiter = Limiter): Flow<Group>
+    
+    /**
+     * 获取群列表。
+     *
+     * @param grouping 根据分组（如果支持的话）
+     * @param limiter 数据限流
+     *
+     * @see groups
+     */
+    @Api4J
+    public fun getGroups(grouping: Grouping, limiter: Limiter): Stream<out Group>
+    
+    /**
+     * 获取群列表。
+     *
+     * @param limiter 数据限流
+     *
+     * @see groups
+     */
+    @Api4J
+    public fun getGroups(limiter: Limiter): Stream<out Group>
+    
+    /**
+     * 获取群列表。
+     *
+     * @see groups
+     */
+    @Api4J
+    public fun getGroups(): Stream<out Group>
+    
+    /**
+     * 通过唯一标识获取这个bot对应的某个群，获取不到则为null。
+     *
+     * @param id 目标群唯一标识
+     */
+    @JvmSynthetic
+    public suspend fun group(id: ID): Group?
+    
+    /**
+     * 通过唯一标识获取这个bot对应的某个群，获取不到则为null。
+     *
+     * @param id 目标群唯一标识
+     *
+     * @see group
+     */
+    @Api4J
+    public fun getGroup(id: ID): Group?
+    
+}
+
+
+/**
+ * 应用于 [Bot] 中为其提供获取 [Guild] 相关属性的api。
+ *
+ */
+public interface GuildsContainer : BotSocialRelationsContainer {
+    
+    /**
+     * 获取当前的所有频道服务器列表
+     *
+     * *分组不一定存在，限流器也不一定生效，这两个参数的有效情况取决于当前 [Bot] 的实现情况。*
+     *
+     * @param grouping 频道服务器分组信息（如果支持的话）
+     * @param limiter 数据限流
+     */
+    @JvmSynthetic
+    public suspend fun guilds(grouping: Grouping = Grouping.EMPTY, limiter: Limiter = Limiter): Flow<Guild>
+    
+    /**
+     * 获取当前的所有频道服务器列表
+     *
+     * *分组不一定存在，限流器也不一定生效，这两个参数的有效情况取决于当前 [Bot] 的实现情况。*
+     *
+     * @param grouping 频道服务器分组信息（如果支持的话）
+     * @param limiter 数据限流
+     *
+     * @see guilds
+     */
+    @Api4J
+    public fun getGuilds(grouping: Grouping, limiter: Limiter): Stream<out Guild>
+    
+    /**
+     * 获取当前的所有频道服务器列表
+     *
+     * *分组不一定存在，限流器也不一定生效，这两个参数的有效情况取决于当前 [Bot] 的实现情况。*
+     *
+     * @param limiter 数据限流
+     *
+     * @see guilds
+     */
+    @Api4J
+    public fun getGuilds(limiter: Limiter): Stream<out Guild>
+    
+    /**
+     * 获取当前的所有频道服务器列表
+     *
+     * *分组不一定存在，限流器也不一定生效，这两个参数的有效情况取决于当前 [Bot] 的实现情况。*
+     *
+     * @see guilds
+     */
+    @Api4J
+    public fun getGuilds(): Stream<out Guild>
+    
+    /**
+     * 通过唯一标识获取这个bot对应的某个频道，获取不到则为null。
+     *
+     * @param id 频道服务器唯一标识
+     */
+    @JvmSynthetic
+    public suspend fun guild(id: ID): Guild?
+    
+    /**
+     * 通过唯一标识获取这个bot对应的某个频道，获取不到则为null。
+     *
+     * @param id 频道服务器唯一标识
+     *
+     * @see guild
+     */
+    @Api4J
+    public fun getGuild(id: ID): Guild?
+    
+}
+
+

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/Limiter.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/Limiter.kt
@@ -12,7 +12,6 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
- *
  */
 
 package love.forte.simbot
@@ -81,7 +80,7 @@ public interface Limiter {
      * 限流数量，即本次所得数据量最大不应超过此限制。
      * 例如 `limit = 10`, 那么返回值结果中的最终元素数量应当 `<= 10`.
      *
-     * 当 `limit <= 0` 的时候，可认为返回值不受限制，或者使用实现方的默认值。
+     * 当 `limit <= 0` 的时候，可认为返回值不受限制。
      *
      * 对于极少的情况，limit = 0 是存在特殊含义的时候，实现方应当有所说明。
      *


### PR DESCRIPTION
将 `friend`、`group`、`guild` 相关api拆分到各自的容器类型中