### PR TITLE
Bot实现调整：移除 `friends` 相关api；追加 `contacts` 相关api

### DIFF
--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/Bot.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/Bot.kt
@@ -39,9 +39,16 @@ import kotlin.coroutines.CoroutineContext
  * [Bot] 是一个活动个体，通过 [BotManager] 构建而来。
  * 其作为一个 [CoroutineScope] 来持有自己的协程上下文。
  *
+ * ## 社交关系容器
+ * [Bot] 会默认实现部分 [社交关系容器][SocialRelationsContainer]：[ContactsContainer]、[GroupsContainer]、[GuildsContainer]。
+ * 有关它们的信息请参考对应的注释说明。
+ *
+ * 值得一提的是，[Bot] 不会默认实现 [FriendsContainer], 因为并非所有组件中的 bot 都存在“好友”的概念，取而代之的则是 [ContactsContainer]。
+ *
+ *
  * @see LoggerContainer
  * @see ComponentContainer
- * @see FriendsContainer
+ * @see ContactsContainer
  * @see GroupsContainer
  * @see GuildsContainer
  *
@@ -49,7 +56,7 @@ import kotlin.coroutines.CoroutineContext
  */
 public interface Bot : User, CoroutineScope, Survivable,
     LoggerContainer, ComponentContainer,
-    FriendsContainer, GroupsContainer, GuildsContainer {
+    ContactsContainer, GroupsContainer, GuildsContainer {
     override val coroutineContext: CoroutineContext
     
     /**

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/BotContainers.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/BotContainers.kt
@@ -91,16 +91,18 @@ public interface FriendsContainer : SocialRelationsContainer {
  * 通常应用于 [Bot] 中为其提供获取 [Contact] 相关的属性api。
  *
  * [联系人][Contact] 通常代表为与当前容器存在"会话"的联系人，
- * 它们之间必须存在一种常驻关系（例如它们之间是 [好友][Friend] 关系）
+ * 它们之间必须存在一种硬性关系（例如它们之间是 [好友][Friend] 关系）
  * 或者存在一个被创建过的"会话"（例如某联系人主动与bot进行过交流或者
  * 与当前容器创建过与某个目标的会话）。
  *
- * 因上述约束，[ContactsContainer.contacts] 通常不具备检索诸如 [组织成员][Member]
- * 之类的间接联系人的能力 ———— 除非它们与当前容器存在可查会话。
+ * 因上述约束，[ContactsContainer.contacts] 通常不具备检索 组织成员 [Member]
+ * 这类间接联系人的能力, 尽管 [Member] 也属于 [Contact] 类型 ———— 除非它们与当前容器存在可查会话。
+ *
+ * 当一个bot中，所有可能的联系人都是与bot存在硬性关系（例如它们之间是 [好友][Friend] 关系）的时候，
+ * [ContactsContainer] 的表现将会与 [FriendsContainer] 类似。
  *
  */
 public interface ContactsContainer : SocialRelationsContainer {
-    // TODO impl for Bot
     
     /**
      * 得到当前容器中能够获取到的联系人序列。

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/ChatRoom.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/ChatRoom.kt
@@ -12,7 +12,6 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
- *
  */
 
 package love.forte.simbot.definition
@@ -23,9 +22,9 @@ import love.forte.simbot.utils.item.Items.Companion.emptyItems
 
 
 /**
- * 一个 **聊天室**。 聊天室是组织的一个子集，代表其是一个存在多人且允许相互交流“发送消息”的组织。
+ * 一个 **聊天室**。 聊天室是 [组织][Organization] 的子类型，代表其是一个存在多人且允许相互交流“发送消息”的组织。
  *
- * 聊天室允许发送消息.
+ * 聊天室实现 [SendSupport] ，允许发送消息。
  *
  * @author ForteScarlet
  */

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Contact.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Contact.kt
@@ -27,7 +27,7 @@ import love.forte.simbot.message.MessageReceipt
  *
  * 一个联系目标。联系人是除 [Bot] 以外的可以进行信息交流的 [User], 例如 [好友][Friend], 或者一个[群成员][Member]。
  *
- * 虽然 [Contact] 实现了 [SendSupport], 但是并不是 [Bot] 以外的所有人都可以进行信息交流，比如对于一个群成员，可能会受限于权限，或者受限于组织类型（例如一个订阅型组织，参考tg的频道）.
+ * 虽然 [Contact] 实现了 [SendSupport], 但是并不是 [Bot] 以外的所有人都一定可以进行信息交流，比如对于一个群成员，可能会受限于权限，或者受限于组织类型（例如一个订阅型组织，参考tg的"频道"）.
  *
  *
  * @author ForteScarlet
@@ -48,7 +48,9 @@ public interface Contact : User, SendSupport, BotContainer {
     @JvmSynthetic
     override suspend fun send(message: Message): MessageReceipt
     
-    
+    /**
+     * 直接使用 [sendBlocking].
+     */
     @Api4J
     @Deprecated("Just use sendBlocking.", ReplaceWith("sendBlocking(message)"))
     override fun sendIfSupportBlocking(message: Message): MessageReceipt = sendBlocking(message)

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Objectives.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Objectives.kt
@@ -12,7 +12,6 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
- *
  */
 
 package love.forte.simbot.definition
@@ -21,9 +20,11 @@ import love.forte.simbot.Api4J
 import love.forte.simbot.Bot
 import love.forte.simbot.ID
 import love.forte.simbot.action.SendSupport
+import love.forte.simbot.action.sendIfSupport
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.MessageReceipt
 import love.forte.simbot.utils.runInBlocking
+
 
 /**
  * [Objectives] 是对与 [Bot] 相关联的对象 （一个[组织][Organization]或一个具体的[用户][User]） 的统称。
@@ -37,29 +38,51 @@ import love.forte.simbot.utils.runInBlocking
  * @author ForteScarlet
  */
 public sealed interface Objectives : BotContainer, IDContainer {
-
+    
     /**
      * 当前对象对应的唯一ID。
      *
      * @see ID
      */
     override val id: ID
-
+    
     /**
      * 当前 [Objectives] 来自的bot。
      */
     override val bot: Bot
-
-
+    
+    
     /**
      * 如果当前支持发送消息，则发送.
      * 否则得到null。
      *
-     * kotlin see `Objectives.trySend`
+     * kotlin see [Objectives.sendIfSupport].
+     *
+     * Deprecated: 此API在 [Contact] 实现了 [SendSupport] 之后，存在的意义便不太大了，拟定在后续删除。
+     * 大部分场景下都不需要通过 `sendIfSupport` 这种语义的API来进行消息发送。如果在真的有需要的情况下，
+     * 自行判断类型即可。
+     * ```java
+     * if (objective instanceof SendSupport) {
+     *     // ...
+     * }
+     * ```
+     * 或者
+     * ```java
+     * if (objective instanceof Contact) {
+     *    // ...
+     * }
+     * ```
      */
     @Api4J
+    @Deprecated(
+        "Insignificant API, planned to be removed", ReplaceWith(
+            "if (this is SendSupport) runInBlocking { send(message) } else null",
+            "love.forte.simbot.action.SendSupport",
+            "love.forte.simbot.utils.runInBlocking"
+        )
+    )
     public fun sendIfSupportBlocking(message: Message): MessageReceipt? =
         if (this is SendSupport) runInBlocking { send(message) } else null
-
-
+    
+    
 }


### PR DESCRIPTION
调整Bot社交关系容器的实现：
- `Bot` 不再默认实现 `FriendsContainer` 
- `Bot` 默认实现 `ContactsContainer`

弃用 `Objectives.sendIfSupportBlocking` 函数并拟定后续删除。