### PR TITLE
调整 DeleteSupport 实现

### DIFF
--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/action/DeleteSupport.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/action/DeleteSupport.kt
@@ -12,7 +12,6 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
- *
  */
 
 package love.forte.simbot.action
@@ -23,7 +22,12 @@ import love.forte.simbot.utils.runInBlocking
 
 /**
  * 允许一种删除行为。
- * 标记一个消息为可删除的，通常可理解为是可撤回的。
+ * 标记一个消息为可删除的。
+ *
+ * 对于一种**删除行为**来讲，它最常见的含义就是**撤回**（针对于消息, 参考 [RemoteMessageContent][love.forte.simbot.message.RemoteMessageContent]）
+ * 和 **踢出/移除**（针对于好友、群成员等, 但是没有提供默认实现）。
+ *
+ * @see love.forte.simbot.message.RemoteMessageContent
  *
  * @author ForteScarlet
  */
@@ -37,20 +41,20 @@ public interface DeleteSupport {
      *
      * 如果是因为诸如权限、超时等限制条件导致的无法删除，则可能会抛出相应的异常。
      *
-     * @return 是否删除成功，不代表会捕获异常。
+     * @return 在支持的情况下代表是否删除成功，不支持的情况下可能恒返回 `false`。
      */
     @JvmSynthetic
     public suspend fun delete(): Boolean
-
+    
     /**
-     * 删除当前目标。
+     * 阻塞的删除当前目标。
      *
      * 如果因为组件自身特性而导致任何条件都无法满足任何对象的 `delete` 操作，
      * 则可能固定返回 `false`, 否则大多数情况下会返回 `true`.
      *
      * 如果是因为诸如权限、超时等限制条件导致的无法删除，则可能会抛出相应的异常。
      *
-     * @return 是否删除成功，不代表会捕获异常。
+     * @return 在支持的情况下代表是否删除成功，不支持的情况下可能恒返回 `false`。
      */
     @Api4J
     public fun deleteBlocking(): Boolean = runInBlocking { delete() }

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/action/DeleteSupport.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/action/DeleteSupport.kt
@@ -24,7 +24,7 @@ import love.forte.simbot.utils.runInBlocking
  * 允许一种删除行为。
  * 标记一个消息为可删除的。
  *
- * 对于一种**删除行为**来讲，它最常见的含义就是**撤回**（针对于消息, 参考 [RemoteMessageContent][love.forte.simbot.message.RemoteMessageContent]）
+ * 对于一种**删除行为**来讲，它最常见的含义就是**撤回**（针对于消息, 参考 [RemoteMessageContent][love.forte.simbot.message.RemoteMessageContent]、[MessageReceipt][love.forte.simbot.message.MessageReceipt]）
  * 和 **踢出/移除**（针对于好友、群成员等, 但是没有提供默认实现）。
  *
  * @see love.forte.simbot.message.RemoteMessageContent

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/event/MessageEvents.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/event/MessageEvents.kt
@@ -19,7 +19,6 @@ package love.forte.simbot.event
 import love.forte.simbot.Api4J
 import love.forte.simbot.Bot
 import love.forte.simbot.ID
-import love.forte.simbot.action.DeleteSupport
 import love.forte.simbot.action.ReplySupport
 import love.forte.simbot.action.SendSupport
 import love.forte.simbot.definition.*
@@ -184,7 +183,7 @@ public interface FriendMessageEvent : ContactMessageEvent, FriendEvent {
  * @see ChannelMessageEvent
  *
  */
-public interface ChatRoomMessageEvent : MessageEvent, OrganizationEvent, DeleteSupport, RemoteMessageContainer {
+public interface ChatRoomMessageEvent : MessageEvent, OrganizationEvent, RemoteMessageContainer {
     override val id: ID
 
     /**
@@ -215,11 +214,26 @@ public interface ChatRoomMessageEvent : MessageEvent, OrganizationEvent, DeleteS
     /**
      * 预期内，假若当前bot拥有足够的权限则可以对消息进行删除（撤回）操作。
      *
-     * @see DeleteSupport
+     * Deprecated: 使用 [messageContent.delete][RemoteMessageContent.delete]。
+     *
+     * @see messageContent
      */
     @JvmSynthetic
-    override suspend fun delete(): Boolean
+    @Deprecated("Use messageContent.delete()", ReplaceWith("messageContent.delete()"))
+    public suspend fun delete(): Boolean = messageContent.delete()
 
+    /**
+     * 预期内，假若当前bot拥有足够的权限则可以对消息进行删除（撤回）操作。
+     *
+     * Deprecated: 使用 [messageContent.deleteBlocking][RemoteMessageContent.deleteBlocking]。
+     *
+     * @see messageContent
+     */
+    @Api4J
+    @Deprecated("Use getMessageContent().deleteBlocking()", ReplaceWith("messageContent.deleteBlocking()"))
+    public fun deleteBlocking(): Boolean = messageContent.deleteBlocking()
+
+    
 
     public companion object Key : BaseEventKey<ChatRoomMessageEvent>(
         "api.chat_room_message", MessageEvent.Key

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/message/MessageContent.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/message/MessageContent.kt
@@ -12,12 +12,12 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
- *
  */
 
 package love.forte.simbot.message
 
 import love.forte.simbot.ID
+import love.forte.simbot.action.DeleteSupport
 
 /**
  * 一个消息内容，其中存在一个[消息链][Messages]。
@@ -49,13 +49,28 @@ public abstract class MessageContent {
 
 /**
  * 一个远端消息主体，一般代表通过事件或者查询而得的事件主体。
+ *
+ * [RemoteMessageContent] 实现 [DeleteSupport], 代表 [RemoteMessageContent] **可能允许** 被删除。
+ *
+ * @see DeleteSupport
  */
-public sealed class RemoteMessageContent : MessageContent() {
+public sealed class RemoteMessageContent : MessageContent(), DeleteSupport {
 
     /**
      * 此消息的唯一标识。
      */
     abstract override val messageId: ID
+    
+    /**
+     * 尝试删除当前消息。
+     *
+     * 如果此消息的实现不支持这种删除行为，则可能直接返回固定值 `false`；
+     * 如果此消息由于诸如**权限**等原因而导致无法删除，则可能会导致对应的异常。
+     *
+     */
+    @JvmSynthetic
+    abstract override suspend fun delete(): Boolean
+ 
 }
 
 

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/message/MessageReceipt.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/message/MessageReceipt.kt
@@ -20,14 +20,13 @@ import love.forte.simbot.Api4J
 import love.forte.simbot.ID
 import love.forte.simbot.action.DeleteSupport
 import love.forte.simbot.definition.IDContainer
-import love.forte.simbot.utils.runInBlocking
 
 
 /**
  * 消息回执，当消息发出去后所得到的回执信息。
  * @author ForteScarlet
  */
-public interface MessageReceipt : IDContainer {
+public interface MessageReceipt : IDContainer, DeleteSupport {
 
     /**
      * 一个消息回执中存在一个ID.
@@ -46,19 +45,23 @@ public interface MessageReceipt : IDContainer {
     /**
      * 如果此回执单是可删除的, 执行删除。
      *
-     * 不会也不应捕获异常。
+     * Deprecated: [MessageReceipt] 已实现 [DeleteSupport], 可以直接使用 [MessageReceipt.delete].
      *
      * @return 删除成功为true，失败或不可删除均为null。
      */
     @Api4J
-    public fun deleteIfSupportBlocking(): Boolean = if (this is DeleteSupport) runInBlocking { delete() } else false
+    @Deprecated("Just use deleteBlocking()", ReplaceWith("deleteBlocking()"))
+    public fun deleteIfSupportBlocking(): Boolean = deleteBlocking() // if (this is DeleteSupport) runInBlocking { delete() } else false
 }
 
 
 /**
  * 如果此回执单是可删除的, 执行删除。
  *
+ * Deprecated: [MessageReceipt] 已实现 [DeleteSupport], 可以直接使用 [MessageReceipt.delete].
+ *
  * @return 删除成功为true，失败或不可删除均为null。
  */
 @JvmSynthetic
-public suspend fun MessageReceipt.deleteIfSupport(): Boolean = if (this is DeleteSupport) delete() else false
+@Deprecated("Just use delete()", ReplaceWith("delete()"))
+public suspend fun MessageReceipt.deleteIfSupport(): Boolean = delete()


### PR DESCRIPTION
默认情况下，`DeleteSupport` 由 `MessageReceipt`（消息发送回执）和 `RemoteMessageContent` 默认实现，并移除 `ChatRoomMessageEvent` 对 `DeleteSupport` 的实现。（暂时保留 `delete` api）