### PR TITLE
为 `Image` 增加默认实现、调整相关API

### DIFF
--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/Bot.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/Bot.kt
@@ -26,6 +26,7 @@ import love.forte.simbot.definition.UserInfo
 import love.forte.simbot.definition.UserStatus
 import love.forte.simbot.event.EventProcessor
 import love.forte.simbot.message.Image
+import love.forte.simbot.message.Image.Key.asImage
 import love.forte.simbot.resources.Resource
 import love.forte.simbot.utils.runInBlocking
 import org.slf4j.Logger
@@ -112,15 +113,23 @@ public interface Bot : User, CoroutineScope, Survivable,
      * 上传一个资源作为资源，并在预期内得到一个 [Image] 结果。
      * 这个 [Image] 不一定是真正已经上传后的结果，它有可能只是一个预处理类型。
      * 在执行 [uploadImage] 的过程中也不一定出现真正的挂起行为，具体细节请参考具体实现。
+     *
+     * _Deprecated: 直接通过 [Resource.asImage][Image.asImage] 构建 [Image] 实例即可。_
      */
     @JvmSynthetic
-    public suspend fun uploadImage(resource: Resource): Image<*>
+    @Deprecated("Just use Resource.asImage",
+        ReplaceWith("resource.asImage()", "love.forte.simbot.message.Image.Key.asImage")
+    )
+    public suspend fun uploadImage(resource: Resource): Image<*> = resource.asImage()
     
     /**
+     *
+     * Deprecated: 直接通过 [Resource.asImage][Image.asImage] 构建 [Image] 实例即可。
      * @see uploadImage
      */
     @Api4J
-    public fun uploadImageBlocking(resource: Resource): Image<*> = runInBlocking { uploadImage(resource) }
+    @Deprecated("Just use Image.of", ReplaceWith("resource.asImage()", "love.forte.simbot.message.Image.Key.asImage"))
+    public fun uploadImageBlocking(resource: Resource): Image<*> = resource.asImage()
     
     
     /**
@@ -130,9 +139,12 @@ public interface Bot : User, CoroutineScope, Survivable,
      */
     public suspend fun resolveImage(id: ID): Image<*>
     
-    
     /**
-     * @see resolveImage
+     *  尝试通过解析一个 [ID] 并得到对应的可用于发送的图片实例。
+     *  这个 [Image] 不一定是真正远端图片结果，它有可能只是一个预处理类型。
+     *  在执行 [resolveImage] 的过程中也不一定出现真正的挂起行为，具体细节请参考具体实现。
+     *
+     *  @see resolveImage
      */
     @Api4J
     public fun resolveImageBlocking(id: ID): Image<*> = runInBlocking { resolveImage(id) }

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/Bot.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/Bot.kt
@@ -26,7 +26,7 @@ import love.forte.simbot.definition.UserInfo
 import love.forte.simbot.definition.UserStatus
 import love.forte.simbot.event.EventProcessor
 import love.forte.simbot.message.Image
-import love.forte.simbot.message.Image.Key.asImage
+import love.forte.simbot.message.Image.Key.toImage
 import love.forte.simbot.resources.Resource
 import love.forte.simbot.utils.runInBlocking
 import org.slf4j.Logger
@@ -114,22 +114,22 @@ public interface Bot : User, CoroutineScope, Survivable,
      * 这个 [Image] 不一定是真正已经上传后的结果，它有可能只是一个预处理类型。
      * 在执行 [uploadImage] 的过程中也不一定出现真正的挂起行为，具体细节请参考具体实现。
      *
-     * _Deprecated: 直接通过 [Resource.asImage][Image.asImage] 构建 [Image] 实例即可。_
+     * _Deprecated: 直接通过 [Resource.asImage][Image.toImage] 构建 [Image] 实例即可。_
      */
     @JvmSynthetic
     @Deprecated("Just use Resource.asImage",
         ReplaceWith("resource.asImage()", "love.forte.simbot.message.Image.Key.asImage")
     )
-    public suspend fun uploadImage(resource: Resource): Image<*> = resource.asImage()
+    public suspend fun uploadImage(resource: Resource): Image<*> = resource.toImage()
     
     /**
      *
-     * Deprecated: 直接通过 [Resource.asImage][Image.asImage] 构建 [Image] 实例即可。
+     * Deprecated: 直接通过 [Resource.asImage][Image.toImage] 构建 [Image] 实例即可。
      * @see uploadImage
      */
     @Api4J
     @Deprecated("Just use Image.of", ReplaceWith("resource.asImage()", "love.forte.simbot.message.Image.Key.asImage"))
-    public fun uploadImageBlocking(resource: Resource): Image<*> = resource.asImage()
+    public fun uploadImageBlocking(resource: Resource): Image<*> = resource.toImage()
     
     
     /**

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/ID.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/ID.kt
@@ -322,25 +322,25 @@ public sealed class NumericalID<N : Number> : ID() {
         if (other === this) return 0
         if (other is NumericalID<*>) {
             return when (other) {
-                is IntID -> toInt().compareTo(other.value)
-                is LongID -> toLong().compareTo(other.value)
-                is DoubleID -> toDouble().compareTo(other.value)
-                is FloatID -> toFloat().compareTo(other.value)
+                is IntID -> toInt().compareTo(other.number)
+                is LongID -> toLong().compareTo(other.number)
+                is DoubleID -> toDouble().compareTo(other.number)
+                is FloatID -> toFloat().compareTo(other.number)
                 is BigIntegerID -> when (this) {
                     is BigIntegerID -> this.value.compareTo(other.value)
                     is BigDecimalID -> this.value.compareTo(other.value.toBigDecimal())
-                    is IntID -> toInt().compareTo(other.value.toInt())
-                    is LongID -> toLong().compareTo(other.value.toLong())
-                    is DoubleID -> toDouble().compareTo(other.value.toDouble())
-                    is FloatID -> toFloat().compareTo(other.value.toFloat())
+                    is IntID -> number.compareTo(other.value.toInt())
+                    is LongID -> number.compareTo(other.value.toLong())
+                    is DoubleID -> number.compareTo(other.value.toDouble())
+                    is FloatID -> number.compareTo(other.value.toFloat())
                 }
                 is BigDecimalID -> when (this) {
-                    is BigDecimalID -> this.value.compareTo(other.value)
-                    is BigIntegerID -> this.value.compareTo(other.value.toBigInteger())
-                    is IntID -> toInt().compareTo(other.value.toInt())
-                    is LongID -> toLong().compareTo(other.value.toLong())
-                    is DoubleID -> toDouble().compareTo(other.value.toDouble())
-                    is FloatID -> toFloat().compareTo(other.value.toFloat())
+                    is BigDecimalID -> value.compareTo(other.value)
+                    is BigIntegerID -> value.compareTo(other.value.toBigInteger())
+                    is IntID -> number.compareTo(other.value.toInt())
+                    is LongID -> number.compareTo(other.value.toLong())
+                    is DoubleID -> number.compareTo(other.value.toDouble())
+                    is FloatID -> number.compareTo(other.value.toFloat())
                 }
             }
         }
@@ -394,10 +394,10 @@ public sealed class NumericalID<N : Number> : ID() {
     override fun doEquals(other: ID): Boolean {
         if (other is NumericalID<*>) {
             return when (other) {
-                is IntID -> toInt() == other.value
-                is LongID -> toLong() == other.value
-                is DoubleID -> toDouble() == other.value
-                is FloatID -> toFloat() == other.value
+                is IntID -> toInt() == other.number
+                is LongID -> toLong() == other.number
+                is DoubleID -> toDouble() == other.number
+                is FloatID -> toFloat() == other.number
                 is BigIntegerID -> this is BigIntegerID && (value == other.value)
                 is BigDecimalID -> this is BigDecimalID && (value == other.value)
             }

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/message/BaseStandardMessage.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/message/BaseStandardMessage.kt
@@ -12,7 +12,6 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
- *
  */
 
 package love.forte.simbot.message
@@ -32,11 +31,11 @@ import love.forte.simbot.resources.Resource
 /**
  * 一些由核心提供的标准 [Message] 实例或标准.
  * 标准消息中，仅提供如下实现：
- * - [纯文本消息][Text]
+ * - [纯文本消息][PlainText]
  * - [AT消息][At]
  * - [图片消息][Image]
- * - [表情消息][]
- * - [emoji][]
+ * - [表情消息][Face]
+ * - [emoji][Emoji]
  *
  */
 public sealed interface StandardMessage<out E : Message.Element<E>> : Message.Element<E>
@@ -50,23 +49,26 @@ public sealed class BaseStandardMessage<out E : Message.Element<E>> : StandardMe
 public inline val Message.Element<*>.isStandard: Boolean get() = this is StandardMessage
 
 
-//region Text
+// region Text
 
 /**
  * 纯文本消息。代表一段只存在[文本][text]的消息。
+ *
+ * 实际上绝大多数情况下，都不需要独立实现 [PlainText] 类型，
+ * [PlainText] 提供了最基础的实现类型 [Text]。
  *
  * @see Text
  */
 public interface PlainText<out A : PlainText<A>> : StandardMessage<A> {
     public val text: String
-
+    
     public companion object Key : Message.Key<PlainText<*>> {
         override fun safeCast(value: Any): PlainText<*>? = safeCast(value)
     }
 }
 
 /**
- * 一个文本消息 [Text].
+ * 一个文本消息 [Text]。[Text] 是 [PlainText] 基础实现类型。
  *
  * 文本消息可以存在多个，但是对于不同平台来讲，有可能存在差异。
  * 部分平台会按照正常的方式顺序排列消息，而有的则会组合消息列表中的所有文本消息为一个整体。
@@ -81,15 +83,15 @@ public interface PlainText<out A : PlainText<A>> : StandardMessage<A> {
 @SerialName("m.std.text")
 public open class Text protected constructor(override val text: String) : PlainText<Text>, BaseStandardMessage<Text>() {
     override val key: Message.Key<Text> get() = Key
-
+    
     public fun trim(): Text = of(text.trim())
-
+    
     public operator fun plus(other: Text): Text = when {
         text.isEmpty() -> other
         other.text.isEmpty() -> this
         else -> of(text + other.text)
     }
-
+    
     public operator fun plus(other: String): Text = if (text.isEmpty()) Text(other) else Text(text + other)
     override fun toString(): String = "Text($text)"
     override fun equals(other: Any?): Boolean {
@@ -97,36 +99,56 @@ public open class Text protected constructor(override val text: String) : PlainT
         if (other !is Text) return false
         return text == other.text
     }
-
+    
     override fun hashCode(): Int = text.hashCode()
-
+    
     public companion object Key : Message.Key<Text> {
         private val empty = Text("")
         override fun safeCast(value: Any): Text? = doSafeCast(value)
-
+        
         @JvmStatic
         public fun of(text: String): Text {
             return if (text.isEmpty()) empty
             else Text(text)
         }
-
+        
         @JvmStatic
         public fun getEmptyText(): Text = empty
     }
-
+    
 }
 
-
+/**
+ * 将一个字符串转化为 [Text].
+ * ```kotlin
+ * val text: Text = "mua".toText()
+ * ```
+ */
 @Suppress("RemoveRedundantQualifierName")
 public fun String.toText(): Text = Text.of(this)
 
+/**
+ * 得到一个空的 [Text].
+ *
+ * @see Text.getEmptyText
+ *
+ */
 @Suppress("RemoveRedundantQualifierName")
 public fun Text(): Text = Text.getEmptyText()
+
+/**
+ * 构建一个 [Text].
+ *
+ * ```kotlin
+ * val text: Text = Text { "Hello" }
+ * ```
+ *
+ */
 public inline fun Text(block: () -> String): Text = block().toText()
-//endregion
+// endregion
 
 
-//region At
+// region At
 /**
  * 一个 `at` 的标准。
  * at、或者说一个通知信息，用于通知一个用户目标。
@@ -139,36 +161,40 @@ public inline fun Text(block: () -> String): Text = block().toText()
 public data class At @JvmOverloads constructor(
     @Serializable(with = ID.AsCharSequenceIDSerializer::class)
     public val target: ID,
+
     /**
      * at的类型，默认情况下是针对一个 "用户"(`user`) 的 at。
      *
      * 其他情况，则可能有例如以一个 "角色"(`role`) 等。
      */
-    @SerialName("at_type")
-    public val atType: String = "user",
-
+    @SerialName("atType")
+    public val type: String = "user",
+    
     /**
      * 这个at在原始数据中或者原始事件中的样子。默认情况下，是字符串 '@[target]'。
      * 此值将不会参与 [equals] 于 [hashCode] 的计算。
      */
-    @SerialName("origin_content")
-    public val originContent: String = "@$target"
-
-) : BaseStandardMessage<At>() {
+    public val originContent: String = "@$target",
+    
+    ) : BaseStandardMessage<At>() {
     override val key: Message.Key<At> get() = Key
-
+    
+    
+    @Deprecated("Please use type", ReplaceWith("type"))
+    public val atType: String get() = type
+    
     override fun equals(other: Any?): Boolean {
         if (other === this) return true
         if (other !is At) return false
-        return other.target == target && other.atType == atType
+        return other.target == target && other.type == type
     }
-
-
+    
+    
     override fun hashCode(): Int {
-        return 31 * (target.hashCode() + atType.hashCode())
+        return 31 * (target.hashCode() + type.hashCode())
     }
-
-
+    
+    
     public companion object Key : Message.Key<At> {
         override fun safeCast(value: Any): At? = doSafeCast(value)
     }
@@ -182,25 +208,29 @@ public data class At @JvmOverloads constructor(
 public object AtAll : BaseStandardMessage<AtAll>(), Message.Key<AtAll> {
     override val key: Message.Key<AtAll>
         get() = this
-
+    
     override fun toString(): String = "AtAll"
     override fun equals(other: Any?): Boolean = other is AtAll
     override fun safeCast(value: Any): AtAll? = doSafeCast(value)
 }
 
-//endregion
+// endregion
 
 
-//region 图片
+// region 图片
 
 
 /**
  * 一个图片消息。
  *
- * 大多数情况下，图片都是需要上传到平台服务器后再使用的。
+ * [Image] 比较常见的有如下几种形式：
+ * 1. 由客户端本地上传。此类 [Image] 多为使用 [资源信息][Resource] 上传。
+ * 2. 客户端接收到的消息。此类 [Image] 大多数持有一个由服务端所提供的 [唯一标识][ID]。
  *
- * 因此 [Image] 需要通过 [love.forte.simbot.Bot] 进行上传获取。
+ * 标准消息类型中提供了一个 [ResourceImage] 来实现上述两种情况中的第 **`1`** 种情况：
+ * 由客户端提供 [Resource] 的图片类型。
  *
+ * @see ResourceImage
  */
 public interface Image<E : Image<E>> : StandardMessage<E>, IDContainer, ResourceContainer {
     /**
@@ -210,33 +240,73 @@ public interface Image<E : Image<E>> : StandardMessage<E>, IDContainer, Resource
      *
      */
     override val id: ID
-
-
+    
+    
     /**
      * 得到这个图片的数据资源。
      */
     @JvmSynthetic
     override suspend fun resource(): Resource
-
-
+    
+    
     /**
      * 得到这个图片的数据资源。
      */
     @Api4J
     override val resource: Resource
-
-
+    
+    
     public companion object Key : Message.Key<Image<*>> {
         override fun safeCast(value: Any): Image<*>? = doSafeCast(value)
+        
+        
+        /**
+         * 通过一个 [Resource] 构建一个 [Image] 实例。
+         *
+         * @param id 此图片的唯一标识。对于用于上传的客户端来说意义不大，
+         * 除非组件明确表示上传图片时需要指定格式的ID，否则对于大多数组件此参数可省略。
+         * 如果省略则使用 [Resource.name] 代替。
+         *
+         */
+        @JvmOverloads
+        @JvmName("of")
+        public fun Resource.asImage(id: ID = name.ID): ResourceImage {
+            return ResourceImage(id, this)
+        }
+        
     }
-
+    
 }
 
 
-//endregion
+/**
+ * 通过直接提供 [resource] 的标准 [Image] 实现类型。常用于发送。
+ *
+ * 通常情况下，当使用 [ResourceImage] 发送图片消息的时候，只有到真正执行
+ * [发送][love.forte.simbot.action.SendSupport.send] 的时候 [ResourceImage]
+ * 中的资源才会被进行验证，而在那之前 [ResourceImage] 仅为一种资源携带体，无法验证资源的有效性。
+ *
+ */
+@SerialName("m.std.img.resource")
+public data class ResourceImage @OptIn(Api4J::class) constructor(override val id: ID, override val resource: Resource) :
+    Image<ResourceImage> {
+    
+    @JvmSynthetic
+    override suspend fun resource(): Resource = resource
+    
+    override val key: Message.Key<ResourceImage>
+        get() = Key
+    
+    public companion object Key : Message.Key<ResourceImage> {
+        override fun safeCast(value: Any): ResourceImage? = doSafeCast(value)
+    }
+}
 
 
-//region Emoji
+// endregion
+
+
+// region Emoji
 /**
  * 一个 Emoji。
  * 目前绝大多数平台已经不会再用一个独特的 "Emoji" 类型来专门标识Emoji了，
@@ -249,20 +319,20 @@ public interface Image<E : Image<E>> : StandardMessage<E>, IDContainer, Resource
 @Serializable
 public data class Emoji(
     @Serializable(ID.AsCharSequenceIDSerializer::class)
-    val id: ID
+    val id: ID,
 ) : StandardMessage<Emoji> {
     override val key: Message.Key<Emoji>
         get() = Key
-
-
+    
+    
     public companion object Key : Message.Key<Emoji> {
         override fun safeCast(value: Any): Emoji? = doSafeCast(value)
     }
 }
-//endregion
+// endregion
 
 
-//region face
+// region face
 /**
  * 一个表情。一般代表平台提供的自带表情。
  */
@@ -270,56 +340,47 @@ public data class Emoji(
 @Serializable
 public data class Face(
     @Serializable(ID.AsCharSequenceIDSerializer::class)
-    val id: ID
+    val id: ID,
 ) : StandardMessage<Face> {
     override val key: Message.Key<Face>
         get() = Key
-
+    
     public companion object Key : Message.Key<Face> {
         override fun safeCast(value: Any): Face? = doSafeCast(value)
     }
 }
-//endregion
+// endregion
 
 
-//region 远程资源
+// region 远程资源
 /**
  * [RemoteResource] 代表一个携带 [url] 信息的远程资源。常见为文件或图片等形式。
  *
- * *此类型可能会被删除*
- *
  */
+@Suppress("DEPRECATION")
+@Deprecated("Unused type")
 public interface RemoteResource<E : RemoteResource<E>> : StandardMessage<E>, IDContainer {
-
+    
     /**
      * 对于一个资源，应当又一个对应的唯一ID。
      *
      * 在一些没有的场景下，id可能是 [url] 本身，或是一个固定值。
      */
     override val id: ID
-
+    
     /**
      * 此资源的URL地址。
      */
     public val url: String
-
+    
     public companion object Key : Message.Key<RemoteResource<*>> {
         override fun safeCast(value: Any): RemoteResource<*>? = doSafeCast(value)
     }
 }
-//endregion
+// endregion
 
 
-//region 多媒体
-// /**
-//  * 一个多媒体消息。多媒体消息常见为图片、
-//  *
-//  * 常见的多媒体消息有
-//  */
-// public interface Multimedia<A : Message.Element<A>> : StandardMessage<A> {
-//     public val name: String
-// }
-//endregion
+
 
 
 

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/message/BaseStandardMessage.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/message/BaseStandardMessage.kt
@@ -270,7 +270,7 @@ public interface Image<E : Image<E>> : StandardMessage<E>, IDContainer, Resource
          */
         @JvmOverloads
         @JvmName("of")
-        public fun Resource.asImage(id: ID = name.ID): ResourceImage {
+        public fun Resource.toImage(id: ID = name.ID): ResourceImage {
             return ResourceImage(id, this)
         }
         

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/message/MessagesBuilder.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/message/MessagesBuilder.kt
@@ -19,7 +19,7 @@ package love.forte.simbot.message
 import love.forte.simbot.Api4J
 import love.forte.simbot.Bot
 import love.forte.simbot.ID
-import love.forte.simbot.message.Image.Key.asImage
+import love.forte.simbot.message.Image.Key.toImage
 import love.forte.simbot.resources.Resource
 
 /**
@@ -116,11 +116,11 @@ public class MessagesBuilder
     /**
      * 通过 [ResourceImage] 拼接一个 [Image] 消息到当前消息中。
      *
-     * @see Image.asImage
+     * @see Image.toImage
      */
     @JvmOverloads
     public fun image(resource: Resource, id: ID = resource.name.ID): MessagesBuilder =
-        appendElement(resource.asImage(id))
+        appendElement(resource.toImage(id))
     
     /**
      * 通过 [Bot.resolveImage] 获取并拼接一个 [Image] 消息到当前消息中。

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/message/MessagesBuilder.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/message/MessagesBuilder.kt
@@ -1,8 +1,25 @@
+/*
+ *  Copyright (c) 2022 ForteScarlet <ForteScarlet@163.com>
+ *
+ *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
+ *
+ *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ *
+ *  发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
+ *
+ *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ *  https://www.gnu.org/licenses
+ *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ *
+ */
+
 package love.forte.simbot.message
 
 import love.forte.simbot.Api4J
 import love.forte.simbot.Bot
 import love.forte.simbot.ID
+import love.forte.simbot.message.Image.Key.asImage
 import love.forte.simbot.resources.Resource
 
 /**
@@ -41,23 +58,23 @@ import love.forte.simbot.resources.Resource
  */
 public class MessagesBuilder
 @JvmOverloads constructor(private var messages: Messages = EmptyMessages) {
-
+    
     private fun appendElement(messageElement: Message.Element<*>): MessagesBuilder = also {
         messages += messageElement
     }
-
+    
     private fun appendElements(messageElements: Collection<Message.Element<*>>): MessagesBuilder = also {
         messages += messageElements
     }
-
-
-    //region 整合方法
+    
+    
+    // region 整合方法
     /**
      * 拼接一个字符串文本。
      * @see Text
      */
     public fun text(text: String): MessagesBuilder = appendElement(text.toText())
-
+    
     /**
      * 拼接一个 [at][At]。
      *
@@ -66,34 +83,45 @@ public class MessagesBuilder
     @JvmOverloads
     public fun at(target: ID, atType: String = "user", originContent: String = "@$target"): MessagesBuilder =
         appendElement(At(target, atType, originContent))
-
+    
     /**
      * 拼接一个 [atAll][AtAll]。
      */
     public fun atAll(): MessagesBuilder = appendElement(AtAll)
-
+    
     /**
      * 拼接一个[表情][Face]。
      *
      * @see Face
      */
     public fun face(id: ID): MessagesBuilder = appendElement(Face(id))
-
+    
     /**
      * 拼接一个[emoji][Emoji]。
      *
      * @see Emoji
      */
     public fun emoji(id: ID): MessagesBuilder = appendElement(Emoji(id))
-
+    
     /**
      * 通过 [Bot.uploadImage] 上传并拼接一个 [Image] 消息到当前消息中。
      *
      * @see Bot.uploadImage
      */
+    @Suppress("UNUSED_PARAMETER", "RedundantSuspendModifier")
     @JvmSynthetic
-    public suspend fun image(bot: Bot, resource: Resource): MessagesBuilder = appendElement(bot.uploadImage(resource))
-
+    @Deprecated("Just use image(resource, id)", ReplaceWith("image(resource)"))
+    public suspend fun image(bot: Bot, resource: Resource): MessagesBuilder = image(resource)
+    
+    /**
+     * 通过 [ResourceImage] 拼接一个 [Image] 消息到当前消息中。
+     *
+     * @see Image.asImage
+     */
+    @JvmOverloads
+    public fun image(resource: Resource, id: ID = resource.name.ID): MessagesBuilder =
+        appendElement(resource.asImage(id))
+    
     /**
      * 通过 [Bot.resolveImage] 获取并拼接一个 [Image] 消息到当前消息中。
      *
@@ -101,7 +129,7 @@ public class MessagesBuilder
      */
     @JvmSynthetic
     public suspend fun image(bot: Bot, id: ID): MessagesBuilder = appendElement(bot.resolveImage(id))
-
+    
     /**
      * 通过 [Bot.uploadImageBlocking] 上传并拼接一个 [Image] 消息到当前消息中。
      *
@@ -109,8 +137,10 @@ public class MessagesBuilder
      */
     @Api4J
     @JvmName("image")
-    public fun image4J(bot: Bot, resource: Resource): MessagesBuilder = appendElement(bot.uploadImageBlocking(resource))
-
+    @Deprecated("Just use image(resource, id)", ReplaceWith("image(resource)"))
+    public fun image4J(bot: Bot, resource: Resource): MessagesBuilder = image(resource)
+    
+    
     /**
      * 通过 [Bot.resolveImageBlocking] 获取并拼接一个 [Image] 消息到当前消息中。
      *
@@ -119,20 +149,20 @@ public class MessagesBuilder
     @Api4J
     @JvmName("image")
     public fun image4J(bot: Bot, id: ID): MessagesBuilder = appendElement(bot.resolveImageBlocking(id))
-    //endregion
-
-
+    // endregion
+    
+    
     /**
      * 拼接一个字符串文本。
      */
     public fun append(text: String): MessagesBuilder = text(text)
-
+    
     /**
      * 拼接一个任意消息。
      */
     public fun append(element: Message.Element<*>): MessagesBuilder = appendElement(element)
-
-
+    
+    
     /**
      * 拼接多个任意消息。
      */
@@ -142,30 +172,33 @@ public class MessagesBuilder
         }
         return this
     }
-
+    
     /**
      * 拼接多个任意消息。
      */
     public fun append(elements: Collection<Message.Element<*>>): MessagesBuilder = appendElements(elements)
-
-
+    
+    
     /**
      * 拼接一个字符串文本。
      */
+    @JvmSynthetic
     public operator fun String.unaryPlus(): MessagesBuilder = append(this)
-
+    
     /**
      * 拼接一个任意消息。
      */
+    @JvmSynthetic
     public operator fun Message.Element<*>.unaryPlus(): MessagesBuilder = appendElement(this)
-
-
+    
+    
     /**
      * 拼接多个任意消息。
      */
+    @JvmSynthetic
     public operator fun Collection<Message.Element<*>>.unaryPlus(): MessagesBuilder = appendElements(this)
-
-
+    
+    
     /**
      * 获取当前构建器中的 [Messages] 实例。
      */

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/message/MessagesBuilder.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/message/MessagesBuilder.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 ForteScarlet <ForteScarlet@163.com>
+ *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
  *
  *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
  *
@@ -137,6 +137,7 @@ public class MessagesBuilder
      */
     @Api4J
     @JvmName("image")
+    @Suppress("UNUSED_PARAMETER")
     @Deprecated("Just use image(resource, id)", ReplaceWith("image(resource)"))
     public fun image4J(bot: Bot, resource: Resource): MessagesBuilder = image(resource)
     


### PR DESCRIPTION
为 `Image` 提供了一个默认的实现类型 `ResourceImage`。当需要通过 `Resource` 构建 `Image` 实例时不再需要通过 `Bot.uploadImage` 完成了：

```kotlin
// Kotlin
val resource: Resource = File("foo/bar.jpg").toResource()
val image: ResourceImage = resource.toImage()
```

```java
// Java
Image image = Image.of(Resource.of(new File("foo/bar.jpg")))
```

同时将 `Bot.uploadImage(Resource)` 标记为过时，并会在后续版本中移除。

同时调整相关涉及到的内容，例如 `MessagesBuilder`。