### PR TITLE
删除 `@Filter` 的 `and`、`or` 参数

### DIFF
--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/event/EventFilter.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/event/EventFilter.kt
@@ -21,6 +21,7 @@ import love.forte.simbot.Api4J
 import love.forte.simbot.BlockingFilter
 import love.forte.simbot.Filter
 import love.forte.simbot.PriorityConstant
+import love.forte.simbot.utils.runWithInterruptible
 
 /**
  * 事件过滤器。
@@ -33,6 +34,8 @@ import love.forte.simbot.PriorityConstant
  * 对于此接口的直接运用，常见的为在匹配失败的时候直接返回一个 [无效响应][EventResult.Invalid]。
  *
  * 过滤器存在 [优先级][priority], 默认情况下的优先级为 [PriorityConstant.NORMAL].
+ *
+ * 对于不支持挂起函数的实现者，可参考 [BlockingEventFilter]。
  *
  * @author ForteScarlet
  */
@@ -73,6 +76,6 @@ public interface BlockingEventFilter : EventFilter, BlockingFilter<EventListener
      */
     @JvmSynthetic
     @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
-    override suspend fun test(context: EventListenerProcessingContext): Boolean = testBlocking()
+    override suspend fun test(context: EventListenerProcessingContext): Boolean = runWithInterruptible { testBlocking() }
     
 }

--- a/boots/simboot-api/src/test/kotlin/MatcherTest.kt
+++ b/boots/simboot-api/src/test/kotlin/MatcherTest.kt
@@ -16,7 +16,7 @@
  */
 
 import love.forte.simboot.filter.RegexMatcherValue
-import org.junit.Test
+import kotlin.test.Test
 
 
 /**

--- a/boots/simboot-core-annotation/src/main/kotlin/love/forte/simboot/annotation/AnnotationEventFilterFactory.kt
+++ b/boots/simboot-core-annotation/src/main/kotlin/love/forte/simboot/annotation/AnnotationEventFilterFactory.kt
@@ -5,6 +5,13 @@ import love.forte.simbot.event.*
 import javax.inject.Singleton
 
 /**
+ *
+ */
+public interface AnnotationEventFilterFactory {
+    // TODO
+}
+
+/**
  * 应用于 [love.forte.simboot.annotation.Filter] 注解上用来直接处理对应注解的函数。
  *
  * 非挂起的阻塞实现参考 [BlockingAnnotationEventFilter].
@@ -12,6 +19,7 @@ import javax.inject.Singleton
  * @see BlockingAnnotationEventFilter
  * @author ForteScarlet
  */
+@Deprecated("Unused")
 @Suppress("KDocUnresolvedReference")
 public interface AnnotationEventFilter : EventFilter {
     
@@ -63,7 +71,7 @@ public interface AnnotationEventFilter : EventFilter {
      * @see InitType
      *
      */
-    public fun init(listener: EventListener, filter: Filter, filters: Filters): InitType
+    public fun init(listener: EventListener, filter: Filter, filters: Filters)
     
     
     /**
@@ -71,29 +79,10 @@ public interface AnnotationEventFilter : EventFilter {
      *
      * @see AnnotationEventFilter.init
      */
+    @Deprecated("Unused")
     public enum class InitType {
-        /**
-         * 完全独立的。
-         *
-         * 指此 [AnnotationEventFilter] 将不会自动解析任何内容，
-         * 包括针对于 [Filter.and] 和 [Filter.or]，注解的一切操作都将完全交给
-         * [AnnotationEventFilter] 的实现来完成。
-         */
         INDEPENDENT,
-        
-        /**
-         * 联合的。
-         *
-         * 指此 [AnnotationEventFilter] 初始化将会自行处理 [Filter] 注解中，
-         * **除了** [Filter.and] 和 [Filter.or] 参数以外的内容。
-         *
-         * 此过滤器会在初始化完成后，尝试继续与 [Filter.and] 和 [Filter.or]
-         * 的自动解析结果进行合并处理。
-         *
-         */
         UNITED
-        
-        
     }
     
     
@@ -113,6 +102,8 @@ public interface AnnotationEventFilter : EventFilter {
  * @see AnnotationEventFilter
  *
  */
+@Suppress("DEPRECATION")
+@Deprecated("Unused")
 @Api4J
 public interface BlockingAnnotationEventFilter : AnnotationEventFilter, BlockingEventFilter {
     

--- a/boots/simboot-core-annotation/src/main/kotlin/love/forte/simboot/annotation/Filter.kt
+++ b/boots/simboot-core-annotation/src/main/kotlin/love/forte/simboot/annotation/Filter.kt
@@ -126,17 +126,17 @@ public annotation class Filter(
 
 
     /**
-     * 指定一个对当前 [Filter] 的处理过滤器。当 [by] 指定了任意一个不直接等同于 [AnnotationEventFilter]
+     * 指定一个对当前 [Filter] 的处理过滤器。当 [by] 指定了任意一个不直接等同于 [AnnotationEventFilterFactory]
      * 的类型时，此注解的上述其他参数将不再继续被解析，而是直接交由指定目标进行处理。
      *
      *
      * ```kotlin
-     * @Filter(by = FooAnnotationEventFilter::class)
+     * @Filter(by = FooAnnotationEventFilterFactory::class)
      * suspend fun Event.onEvent() { ... }
      * ```
      *
      */
-    val by: KClass<out AnnotationEventFilter> = AnnotationEventFilter::class,
+    val by: KClass<out AnnotationEventFilterFactory> = AnnotationEventFilterFactory::class,
     
     )
 

--- a/boots/simboot-core/src/main/kotlin/love/forte/simboot/core/filter/CoreAnnotationEventFilterFactory.kt
+++ b/boots/simboot-core/src/main/kotlin/love/forte/simboot/core/filter/CoreAnnotationEventFilterFactory.kt
@@ -1,0 +1,134 @@
+package love.forte.simboot.core.filter
+
+import love.forte.simboot.annotation.AnnotationEventFilterFactory
+import love.forte.simboot.annotation.Filter
+import love.forte.simboot.annotation.Filters
+import love.forte.simboot.filter.EmptyKeyword
+import love.forte.simboot.filter.MatchType
+import love.forte.simbot.MutableAttributeMap
+import love.forte.simbot.event.*
+import love.forte.simbot.literal
+import love.forte.simbot.message.At
+import java.util.concurrent.CopyOnWriteArrayList
+
+public object CoreAnnotationEventFilterFactory : AnnotationEventFilterFactory {
+    override fun resolveFilter(
+        listener: EventListener,
+        listenerAttributes: MutableAttributeMap,
+        filter: Filter,
+        filters: Filters,
+    ): EventFilter? {
+        val value = filter.value
+        val target = filter.target.box()
+        
+        if (value.isEmpty() && target == null) {
+            return null
+        }
+        // 当前的普通过滤器
+        val currentFilter = AnnotationFilter(
+            target, value, filter.ifNullPass, filter.matchType
+        ) { it.textContent } // selector
+        
+        // put keyword.
+        listenerAttributes.computeIfAbsent(KeywordsAttribute) { CopyOnWriteArrayList() }.add(currentFilter.keyword)
+        
+        return currentFilter
+    }
+}
+
+
+private class AnnotationFilter(
+    target: FilterTarget?,
+    val value: String,
+    val ifNullPass: Boolean,
+    val matchType: MatchType,
+    val contentSelector: (EventListenerProcessingContext) -> String?,
+) : EventFilter {
+    val keyword = if (value.isEmpty()) EmptyKeyword else KeywordImpl(value)
+    val targetMatch: suspend (Event) -> Boolean = target?.toMatcher() ?: { true }
+    
+    override suspend fun test(context: EventListenerProcessingContext): Boolean {
+        val event = context.event
+        
+        // target
+        if (!targetMatch(event)) {
+            return false
+        }
+        
+        val textContent = contentSelector(context) //.textContent
+        
+        // match
+        // 存在匹配词, 尝试匹配
+        if (keyword !== EmptyKeyword) {
+            if (textContent != null) {
+                if (!matchType.match(textContent, keyword)) {
+                    return false
+                }
+            } else return ifNullPass
+        }
+        // 匹配关键词本身没有, 直接放行.
+        
+        
+        // maybe other match
+        
+        return true
+    }
+}
+
+
+private fun FilterTarget.toMatcher(): suspend (Event) -> Boolean {
+    return M@{ event ->
+        if (components.isNotEmpty()) {
+            if (event.component.id.literal !in components) {
+                return@M false
+            }
+        }
+        
+        if (bots.isNotEmpty()) {
+            if (event.bot.id.literal !in bots) {
+                return@M false
+            }
+        }
+        
+        if (authors.isNotEmpty()) {
+            if (event is ChatRoomMessageEvent) {
+                if (event.author().id.literal !in authors) {
+                    return@M false
+                }
+            }
+            if (event is ContactMessageEvent) {
+                if (event.source().id.literal !in authors) {
+                    return@M false
+                }
+            }
+        }
+        
+        if (groups.isNotEmpty() && event is GroupEvent) {
+            if (event.group().id.literal !in groups) {
+                return@M false
+            }
+        }
+        
+        if (channels.isNotEmpty() && event is ChannelEvent) {
+            if (event.channel().id.literal !in channels) {
+                return@M false
+            }
+        }
+        
+        if (guilds.isNotEmpty() && event is GuildEvent) {
+            if (event.guild().id.literal !in guilds) {
+                return@M false
+            }
+        }
+        
+        // atBot
+        if (atBot && event is ChatRoomMessageEvent) {
+            if (event.messageContent.messages.none { it is At && event.bot.isMe(it.target) }) {
+                return@M false
+            }
+        }
+        
+        true
+    }
+    
+}

--- a/boots/simboot-core/src/main/kotlin/love/forte/simboot/core/filter/CoreFilterAnnotationProcessor.kt
+++ b/boots/simboot-core/src/main/kotlin/love/forte/simboot/core/filter/CoreFilterAnnotationProcessor.kt
@@ -16,21 +16,18 @@
 
 package love.forte.simboot.core.filter
 
-import love.forte.simboot.annotation.AnnotationEventFilter
+import love.forte.simboot.annotation.AnnotationEventFilterFactory
 import love.forte.simboot.annotation.Filter
 import love.forte.simboot.annotation.Filters
 import love.forte.simboot.annotation.TargetFilter
 import love.forte.simboot.core.listener.FunctionalListenerProcessContext
-import love.forte.simboot.filter.EmptyKeyword
-import love.forte.simboot.filter.MatchType
 import love.forte.simbot.LoggerFactory
 import love.forte.simbot.MutableAttributeMap
 import love.forte.simbot.SimbotIllegalStateException
 import love.forte.simbot.core.event.coreFilter
-import love.forte.simbot.event.*
-import love.forte.simbot.literal
-import love.forte.simbot.message.At
-import java.util.concurrent.CopyOnWriteArrayList
+import love.forte.simbot.event.EventFilter
+import love.forte.simbot.event.EventListener
+import love.forte.simbot.event.EventListenerProcessingContext
 import kotlin.reflect.KAnnotatedElement
 import kotlin.reflect.KClass
 
@@ -41,44 +38,40 @@ import kotlin.reflect.KClass
 public object CoreFilterAnnotationProcessor {
     private val logger = LoggerFactory.getLogger(CoreFilterAnnotationProcessor::class)
     public fun process(filters: Filters, filter: Filter, context: FiltersAnnotationProcessContext): EventFilter? {
-        if (filter.by != AnnotationEventFilter::class) {
+        if (filter.by != AnnotationEventFilterFactory::class) {
             return process(filter.by, filters, filter, context)
         }
         
         
-        val value = filter.value
-        val target = filter.target.box()
-        // val and = filter.and.takeIf { it.value.isNotEmpty() }
-        // val or = filter.or.takeIf { it.value.isNotEmpty() }
+        return CoreAnnotationEventFilterFactory.resolveFilter(
+            context.listener, context.listenerAttributes, filter, filters
+        )
         
-        if (value.isEmpty() && target == null) {
-            return null
-        }
-        
-        // 当前的普通过滤器
-        val currentFilter = AnnotationFilter(
-            target,
-            value,
-            filter.ifNullPass,
-            filter.matchType
-        ) { it.textContent } // selector
-        
-        // put keyword.
-        context.listenerAttributes.computeIfAbsent(KeywordsAttribute) { CopyOnWriteArrayList() }
-            .add(currentFilter.keyword)
-        
-        return currentFilter //.processOrAnd(context, and, or)
+        //
+        // // 当前的普通过滤器
+        // val currentFilter = AnnotationFilter(
+        //     target,
+        //     value,
+        //     filter.ifNullPass,
+        //     filter.matchType
+        // ) { it.textContent } // selector
+        //
+        // // put keyword.
+        // context.listenerAttributes.computeIfAbsent(KeywordsAttribute) { CopyOnWriteArrayList() }
+        //     .add(currentFilter.keyword)
+        //
+        // return currentFilter //.processOrAnd(context, and, or)
     }
     
     
     private fun process(
-        type: KClass<out AnnotationEventFilter>,
+        type: KClass<out AnnotationEventFilterFactory>,
         filters: Filters,
         filter: Filter,
         context: FiltersAnnotationProcessContext,
-    ): EventFilter {
+    ): EventFilter? {
         val obj = type.objectInstance
-        val annotationEventFilter: AnnotationEventFilter = obj ?: run {
+        val annotationEventFilterFactory: AnnotationEventFilterFactory = obj ?: run {
             // from bean container
             val beanContainer = context.context.beanContainer
             val beanNames = beanContainer.getAll(type)
@@ -93,7 +86,7 @@ public object CoreFilterAnnotationProcessor {
                     }
                     else -> {
                         // get
-                        beanContainer[beanNames.first()] as? AnnotationEventFilter
+                        beanContainer[beanNames.first()] as? AnnotationEventFilterFactory
                     }
                 }
             }.getOrElse { e ->
@@ -117,40 +110,21 @@ public object CoreFilterAnnotationProcessor {
         }
         
         // init it.
-        annotationEventFilter.init(context.listener, filter, filters)
+        val eventFilter =
+            annotationEventFilterFactory.resolveFilter(context.listener, context.listenerAttributes, filter, filters)
         
-        logger.debug("Init annotation event filter: [{}]", annotationEventFilter)
+        logger.debug("Init annotation event filter: [{}]", eventFilter)
         
-        return annotationEventFilter
+        return eventFilter
     }
     
-}
-
-private fun Filters.process(context: FiltersAnnotationProcessContext): EventFilter? {
-    return takeIf { it.value.isNotEmpty() }
-        ?.let {
-            val filters = CoreFiltersAnnotationProcessor.process(context)
-            
-            when {
-                filters.isEmpty() -> null
-                filters.size == 1 -> filters.first()
-                else -> {
-                    val matcherList: List<suspend (EventListenerProcessingContext) -> Boolean> = filters.apply {
-                        sortedBy { f -> f.priority }
-                    }.map { f -> f::test }
-                    coreFilter { c ->
-                        multiMatchType.match(c, matcherList)
-                    }
-                }
-            }
-        }
 }
 
 
 /**
  * @see TargetFilter
  */
-private data class FilterTarget(
+internal data class FilterTarget(
     val components: Set<String>,
     val bots: Set<String>,
     val authors: Set<String>,
@@ -160,128 +134,17 @@ private data class FilterTarget(
     val atBot: Boolean,
 )
 
-
-private fun TargetFilter.box(): FilterTarget? {
-    if (
-        components.isEmpty() &&
-        bots.isEmpty() &&
-        authors.isEmpty() &&
-        groups.isEmpty() &&
-        channels.isEmpty() &&
-        guilds.isEmpty() &&
-        !atBot
-    ) {
+internal fun TargetFilter.box(): FilterTarget? {
+    if (components.isEmpty() && bots.isEmpty() && authors.isEmpty() && groups.isEmpty() && channels.isEmpty() && guilds.isEmpty() && !atBot) {
         return null
     }
     
     return FilterTarget(
-        components.toSet(),
-        bots.toSet(),
-        authors.toSet(),
-        groups.toSet(),
-        channels.toSet(),
-        guilds.toSet(),
-        atBot
+        components.toSet(), bots.toSet(), authors.toSet(), groups.toSet(), channels.toSet(), guilds.toSet(), atBot
     )
     
 }
 
-
-private class AnnotationFilter(
-    target: FilterTarget?,
-    val value: String,
-    val ifNullPass: Boolean,
-    val matchType: MatchType,
-    val contentSelector: (EventListenerProcessingContext) -> String?,
-) : EventFilter {
-    val keyword = if (value.isEmpty()) EmptyKeyword else KeywordImpl(value)
-    val targetMatch: suspend (Event) -> Boolean = target?.toMatcher() ?: { true }
-    
-    override suspend fun test(context: EventListenerProcessingContext): Boolean {
-        val event = context.event
-        
-        // target
-        if (!targetMatch(event)) {
-            return false
-        }
-        
-        val textContent = contentSelector(context) //.textContent
-        
-        // match
-        // 存在匹配词, 尝试匹配
-        if (keyword !== EmptyKeyword) {
-            if (textContent != null) {
-                if (!matchType.match(textContent, keyword)) {
-                    return false
-                }
-            } else return ifNullPass
-        }
-        // 匹配关键词本身没有, 直接放行.
-        
-        
-        // maybe other match
-        
-        return true
-    }
-}
-
-
-private fun FilterTarget.toMatcher(): suspend (Event) -> Boolean {
-    return M@{ event ->
-        if (components.isNotEmpty()) {
-            if (event.component.id.literal !in components) {
-                return@M false
-            }
-        }
-        
-        if (bots.isNotEmpty()) {
-            if (event.bot.id.literal !in bots) {
-                return@M false
-            }
-        }
-        
-        if (authors.isNotEmpty()) {
-            if (event is ChatRoomMessageEvent) {
-                if (event.author().id.literal !in authors) {
-                    return@M false
-                }
-            }
-            if (event is ContactMessageEvent) {
-                if (event.source().id.literal !in authors) {
-                    return@M false
-                }
-            }
-        }
-        
-        if (groups.isNotEmpty() && event is GroupEvent) {
-            if (event.group().id.literal !in groups) {
-                return@M false
-            }
-        }
-        
-        if (channels.isNotEmpty() && event is ChannelEvent) {
-            if (event.channel().id.literal !in channels) {
-                return@M false
-            }
-        }
-        
-        if (guilds.isNotEmpty() && event is GuildEvent) {
-            if (event.guild().id.literal !in guilds) {
-                return@M false
-            }
-        }
-        
-        // atBot
-        if (atBot && event is ChatRoomMessageEvent) {
-            if (event.messageContent.messages.none { it is At && event.bot.isMe(it.target) }) {
-                return@M false
-            }
-        }
-        
-        true
-    }
-    
-}
 
 public data class FiltersAnnotationProcessContext(
     val annotateElement: KAnnotatedElement,
@@ -315,8 +178,7 @@ public object CoreFiltersAnnotationProcessor {
         
         val multiMatchType = filters.multiMatchType
         
-        @Suppress("SuspiciousCallableReferenceInLambda")
-        val matcherList: List<suspend (EventListenerProcessingContext) -> Boolean> =
+        @Suppress("SuspiciousCallableReferenceInLambda") val matcherList: List<suspend (EventListenerProcessingContext) -> Boolean> =
             eventFilterList.sortedBy { it.priority }.map { f -> f::test }
         
         val filter = coreFilter {


### PR DESCRIPTION
删除 `@Filter` 的 `and`、`or` 参数，并调整 `@Filter.by` 参数的类型。

参考:
- [Spring Framework#28012#issuecomment-1154964509](https://github.com/spring-projects/spring-framework/issues/28012#issuecomment-1154964509)
- [KT-47932](https://youtrack.jetbrains.com/issue/KT-47932)

`@Filter.by` 参数类型调整：`KClass<out AnnotationEventFilter>` -> `KClass<out out AnnotationEventFilterFactory>`；

弃用 `AnnotationEventFilter`。