### PR TITLE
变更 `EventListener.id` 属性类型 `ID` -> `String`

### DIFF
--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/event/EventListener.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/event/EventListener.kt
@@ -18,7 +18,6 @@ package love.forte.simbot.event
 
 import kotlinx.coroutines.Deferred
 import love.forte.simbot.*
-import love.forte.simbot.definition.IDContainer
 import love.forte.simbot.utils.runWithInterruptible
 import org.slf4j.Logger
 
@@ -67,13 +66,13 @@ public fun interface BlockingEventListenerFunction : EventListenerFunction {
  *
  * @author ForteScarlet
  */
-public interface EventListener : java.util.EventListener, AttributeContainer, LoggerContainer, IDContainer,
+public interface EventListener : java.util.EventListener, AttributeContainer, LoggerContainer,
     EventListenerFunction {
     
     /**
      * 监听器必须是唯一的. 通过 [id] 进行唯一性确认。
      */
-    override val id: ID
+    public val id: String
     
     /**
      * 当前监听函数内部存在的日志对象。
@@ -162,7 +161,7 @@ public interface EventListener : java.util.EventListener, AttributeContainer, Lo
  */
 @Api4J
 public interface BlockingEventListener : EventListener, BlockingEventListenerFunction {
-    override val id: ID
+    override val id: String
     override val logger: Logger
     override val isAsync: Boolean
     override fun isTarget(eventType: Event.Key<*>): Boolean

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/event/EventListenerManagers.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/event/EventListenerManagers.kt
@@ -18,6 +18,7 @@ package love.forte.simbot.event
 
 import love.forte.simbot.FragileSimbotApi
 import love.forte.simbot.ID
+import love.forte.simbot.literal
 
 
 /**
@@ -31,7 +32,10 @@ public interface EventListenerContainer {
     /**
      * 通过一个ID得到一个当前监听函数下的对应函数。
      */
-    public operator fun get(id: ID): EventListener?
+    public operator fun get(id: String): EventListener?
+    
+    @Deprecated("Just use get(String)", ReplaceWith("get(id.literal)", "love.forte.simbot.literal"))
+    public operator fun get(id: ID): EventListener? = get(id.literal)
     
 }
 

--- a/boots/simboot-api/src/main/kotlin/love/forte/simboot/listener/GenericListener.kt
+++ b/boots/simboot-api/src/main/kotlin/love/forte/simboot/listener/GenericListener.kt
@@ -16,7 +16,6 @@
 
 package love.forte.simboot.listener
 
-import love.forte.simbot.ID
 import love.forte.simbot.event.Event
 import love.forte.simbot.event.EventListener
 import love.forte.simbot.event.EventListenerProcessingContext
@@ -35,7 +34,7 @@ import love.forte.simbot.utils.runWithInterruptible
  * @author ForteScarlet
  */
 public interface GenericBootEventListener : EventListener {
-    override val id: ID
+    override val id: String
     override val isAsync: Boolean
     override fun isTarget(eventType: Event.Key<*>): Boolean
     override suspend fun match(context: EventListenerProcessingContext): Boolean

--- a/boots/simboot-core/src/main/kotlin/love/forte/simboot/core/listener/KFunctionEventListener.kt
+++ b/boots/simboot-core/src/main/kotlin/love/forte/simboot/core/listener/KFunctionEventListener.kt
@@ -21,7 +21,6 @@ import love.forte.simboot.listener.FunctionalBindableEventListener
 import love.forte.simboot.listener.ParameterBinder
 import love.forte.simbot.Attribute
 import love.forte.simbot.AttributeMutableMap
-import love.forte.simbot.ID
 import love.forte.simbot.event.Event
 import love.forte.simbot.event.Event.Key.Companion.isSub
 import love.forte.simbot.event.EventListenerProcessingContext
@@ -34,7 +33,7 @@ import kotlin.reflect.KParameter
  * 使用 [KFunction] 并可提供 [binders] 的 [FunctionalBindableEventListener] 实现。
  */
 public class KFunctionEventListener<R>(
-    override val id: ID,
+    override val id: String,
     override val priority: Int,
     override val isAsync: Boolean,
     private val targets: Set<Event.Key<*>>,

--- a/boots/simboot-core/src/main/kotlin/love/forte/simboot/core/listener/KFunctionListenerProcessor.kt
+++ b/boots/simboot-core/src/main/kotlin/love/forte/simboot/core/listener/KFunctionListenerProcessor.kt
@@ -85,7 +85,7 @@ public class KFunctionListenerProcessor(
         listenerAttributeMap[RAW_LISTEN_TARGETS] = listenTargets
         
         val listener = KFunctionEventListener(
-            id = functionId.ID,
+            id = functionId,
             priority = context.priority,
             isAsync = context.isAsync,
             targets = listenTargets.toSet(),

--- a/cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/CoreListeners.kt
+++ b/cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/CoreListeners.kt
@@ -72,12 +72,12 @@ public fun <E : Event> coreListener(
     func: suspend EventListenerProcessingContext.(E) -> Any?,
 ): EventListener {
     return if (blockNext) {
-        simpleListener(eventKey, id, isAsync, logger) {
+        simpleListener(eventKey, id.literal, isAsync, logger) {
             val result = func(it)
             if (result is EventResult) result else EventResult.of(result, isTruncated = true)
         }
     } else {
-        simpleListener(eventKey, id, isAsync, logger) {
+        simpleListener(eventKey, id.literal, isAsync, logger) {
             val result = func(it)
             if (result is EventResult) result else EventResult.of(result)
         }
@@ -137,7 +137,7 @@ public fun <E : Event> blockingCoreListener(
     func: BiFunction<EventListenerProcessingContext, E, Any?>,
 ): EventListener = blockingSimpleListener(
     target = eventKey,
-    id = id,
+    id = id.literal,
     isAsync = isAsync,
     logger = logger,
 ) { t, u ->
@@ -179,7 +179,7 @@ public fun <E : Event> blockingCoreListener(
     func: BiConsumer<EventListenerProcessingContext, E>,
 ): EventListener = blockingSimpleListener(
     target = eventKey,
-    id = id,
+    id = id.literal,
     isAsync = isAsync,
     logger = logger,
 ) { t, u ->
@@ -213,7 +213,7 @@ public fun <E : Event> blockingCoreListener(
     func: BiFunction<EventListenerProcessingContext, E, Any?>,
 ): EventListener = blockingSimpleListener(
     target = Event.Key.getKey(eventType),
-    id = id,
+    id = id.literal,
     isAsync = isAsync,
     logger = logger
 ) { t, u ->
@@ -246,7 +246,7 @@ public fun <E : Event> blockingCoreListener(
     func: BiConsumer<EventListenerProcessingContext, E>,
 ): EventListener = blockingSimpleListener(
     target = Event.Key.getKey(eventType),
-    id = id,
+    id = id.literal,
     isAsync = isAsync,
     logger = logger
 ) { t, u ->

--- a/cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/EventListenersGenerator.kt
+++ b/cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/EventListenersGenerator.kt
@@ -16,11 +16,15 @@
 
 package love.forte.simbot.core.event
 
-import love.forte.simbot.*
+import love.forte.simbot.Api4J
+import love.forte.simbot.InternalSimbotApi
+import love.forte.simbot.LoggerFactory
+import love.forte.simbot.SimbotIllegalStateException
 import love.forte.simbot.event.Event
 import love.forte.simbot.event.EventListener
 import love.forte.simbot.event.EventListenerProcessingContext
 import love.forte.simbot.event.EventResult
+import love.forte.simbot.utils.randomIdStr
 import love.forte.simbot.utils.runWithInterruptible
 import org.slf4j.Logger
 import java.util.function.BiConsumer
@@ -318,7 +322,7 @@ public class ListenerGenerator<E : Event> @InternalSimbotApi constructor(private
      * 设置listener的ID
      */
     @ListenerGeneratorDSL
-    public var id: ID? = null
+    public var id: String? = null
     
     
     /**
@@ -466,7 +470,7 @@ public class ListenerGenerator<E : Event> @InternalSimbotApi constructor(private
     }
     
     internal fun build(): EventListener {
-        val id0 = id ?: randomID()
+        val id0 = id ?: randomIdStr()
         return simpleListener(
             target = eventKey,
             id = id0,

--- a/cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleEventListenerManagerImpl.kt
+++ b/cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleEventListenerManagerImpl.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 ForteScarlet <ForteScarlet@163.com>
+ *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
  *
  *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
  *
@@ -61,7 +61,7 @@ internal class SimpleEventListenerManagerImpl internal constructor(
     /**
      * 监听函数列表。ID唯一
      */
-    private val listeners: MutableMap<CharSequenceID, EventListener>
+    private val listeners: MutableMap<String, EventListener>
     
     
     /**
@@ -86,7 +86,7 @@ internal class SimpleEventListenerManagerImpl internal constructor(
         
         listenerIntercepts = simpleListenerManagerConfig.listenerInterceptors.values.sortedBy { it.priority }
         
-        listeners = simpleListenerManagerConfig.listeners.associateByTo(mutableMapOf()) { it.id.toCharSequenceID() }
+        listeners = simpleListenerManagerConfig.listeners.associateByTo(mutableMapOf()) { it.id }
     }
     
     
@@ -122,7 +122,7 @@ internal class SimpleEventListenerManagerImpl internal constructor(
     @FragileSimbotApi
     override fun register(listener: EventListener) {
         synchronized(this) {
-            val id = listener.id.toCharSequenceID()
+            val id = listener.id
             listeners.compute(id) { _, old ->
                 if (old != null) throw IllegalStateException("The event listener with ID $id already exists")
                 listener.also {
@@ -135,7 +135,7 @@ internal class SimpleEventListenerManagerImpl internal constructor(
     /**
      * 获取一个监听函数。
      */
-    override fun get(id: ID): EventListener? = synchronized(this) { listeners[id.toCharSequenceID()] }
+    override fun get(id: String): EventListener? = synchronized(this) { listeners[id] }
     
     /**
      * 判断指定事件类型在当前事件管理器中是否能够被执行（存在任意对应的监听函数）。

--- a/cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleListener.kt
+++ b/cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleListener.kt
@@ -18,7 +18,6 @@ package love.forte.simbot.core.event
 
 import love.forte.simbot.Attribute
 import love.forte.simbot.AttributeContainer
-import love.forte.simbot.ID
 import love.forte.simbot.event.Event
 import love.forte.simbot.event.Event.Key.Companion.isSub
 import love.forte.simbot.event.EventListener
@@ -36,7 +35,7 @@ import org.slf4j.Logger
  * @author ForteScarlet
  */
 public class SimpleListener(
-    override val id: ID,
+    override val id: String,
     override val logger: Logger,
     override val isAsync: Boolean,
     
@@ -79,7 +78,7 @@ public class SimpleListener(
      * 提供一个新的 [id], 以及其他可选参数，并构建一个新的 [SimpleListener].
      */
     public fun copy(
-        id: ID = this.id,
+        id: String = this.id,
         logger: Logger = this.logger,
         isAsync: Boolean = this.isAsync,
         targets: Set<Event.Key<*>> = this.targets.toSet(),

--- a/cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleListenerCreate.kt
+++ b/cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleListenerCreate.kt
@@ -21,6 +21,7 @@ package love.forte.simbot.core.event
 
 import love.forte.simbot.*
 import love.forte.simbot.event.*
+import love.forte.simbot.utils.randomIdStr
 import love.forte.simbot.utils.runWithInterruptible
 import org.slf4j.Logger
 import java.util.function.BiConsumer
@@ -55,7 +56,7 @@ internal suspend fun <E : Event> EventListenerProcessingContext.defaultMatcher(e
 @JvmSynthetic
 public inline fun <E : Event> simpleListener(
     target: Event.Key<E>,
-    id: ID = randomID(),
+    id: String = randomIdStr(),
     isAsync: Boolean = false,
     logger: Logger = LoggerFactory.getLogger("love.forte.core.listener.$id"),
     attributes: AttributeContainer? = null,
@@ -64,8 +65,6 @@ public inline fun <E : Event> simpleListener(
 ): EventListener {
     return SimpleListener(id, logger, isAsync, setOf(target), attributes, matcher = {
         val event: E = target.safeCast(event)
-            // 事件类型[${event.key}]不在当前监听函数(${id})的目标中:
-            // The event type [{event.key}] is not in the target of the current listener function ({id}):
             ?: throw SimbotIllegalArgumentException("The event type [${event.key}] is not in the target of the current listener function ({id}): [$target]")
         matcher(event)
     }) {
@@ -92,7 +91,7 @@ public inline fun <E : Event> simpleListener(
 @JvmSynthetic
 public inline fun simpleListener(
     targets: Collection<Event.Key<*>>,
-    id: ID = randomID(),
+    id: String = randomIdStr(),
     isAsync: Boolean = false,
     logger: Logger = LoggerFactory.getLogger("love.forte.core.listener.$id"),
     attributes: AttributeContainer? = null,
@@ -135,7 +134,7 @@ public inline fun simpleListener(
 @JvmSynthetic
 @FragileSimbotApi
 public inline fun <reified E : Event> simpleListener(
-    id: ID = randomID(),
+    id: String = randomIdStr(),
     isAsync: Boolean = false,
     logger: Logger = LoggerFactory.getLogger("love.forte.core.listener.$id"),
     attributes: AttributeContainer? = null,
@@ -159,7 +158,7 @@ public inline fun <reified E : Event> simpleListener(
 @FragileSimbotApi
 public inline fun <E : Event> EventListenerRegistrar.listen(
     eventKey: Event.Key<E>,
-    id: ID = randomID(),
+    id: String = randomIdStr(),
     isAsync: Boolean = false,
     logger: Logger = LoggerFactory.getLogger("love.forte.core.listener.$id"),
     attributes: AttributeContainer? = null,
@@ -188,7 +187,7 @@ public inline fun <E : Event> EventListenerRegistrar.listen(
 @JvmSynthetic
 @FragileSimbotApi
 public inline fun <reified E : Event> EventListenerRegistrar.listen(
-    id: ID = randomID(),
+    id: String = randomIdStr(),
     isAsync: Boolean = false,
     logger: Logger = LoggerFactory.getLogger("love.forte.core.listener.$id"),
     attributes: AttributeContainer? = null,
@@ -215,7 +214,7 @@ public inline fun <reified E : Event> EventListenerRegistrar.listen(
 @JvmOverloads
 public fun <E : Event> blockingSimpleListener(
     target: Event.Key<E>,
-    id: ID = randomID(),
+    id: String = randomIdStr(),
     isAsync: Boolean = false,
     logger: Logger = LoggerFactory.getLogger("love.forte.core.listener.$id"),
     matcher: BiPredicate<EventListenerProcessingContext, E>? = null, // = BiPredicate { _, _ -> true }, // EventListenerProcessingContext.(E) -> Boolean = EventListenerProcessingContext::defaultMatcher, // 必须使用函数引用方式。
@@ -251,7 +250,7 @@ public fun <E : Event> blockingSimpleListener(
 @JvmOverloads
 public fun <E : Event> blockingSimpleListenerWithoutResult(
     target: Event.Key<E>,
-    id: ID = randomID(),
+    id: String = randomIdStr(),
     isAsync: Boolean = false,
     logger: Logger = LoggerFactory.getLogger("love.forte.core.listener.$id"),
     matcher: BiPredicate<EventListenerProcessingContext, E>? = null, // = BiPredicate { _, _ -> true }, // EventListenerProcessingContext.(E) -> Boolean = EventListenerProcessingContext::defaultMatcher, // 必须使用函数引用方式。
@@ -270,4 +269,133 @@ public fun <E : Event> blockingSimpleListenerWithoutResult(
         EventResult.defaults()
     }
 }
+// endregion
+
+
+// region deprecated functions
+
+@Deprecated(
+    "Just use simpleListener(..., id: String, ...)", ReplaceWith(
+        "simpleListener(target, id.literal, isAsync, logger, attributes, matcher, function)",
+        "love.forte.simbot.literal"
+    )
+)
+@JvmSynthetic
+public inline fun <E : Event> simpleListener(
+    target: Event.Key<E>,
+    id: ID = randomID(),
+    isAsync: Boolean = false,
+    logger: Logger = LoggerFactory.getLogger("love.forte.core.listener.$id"),
+    attributes: AttributeContainer? = null,
+    crossinline matcher: suspend EventListenerProcessingContext.(E) -> Boolean = EventListenerProcessingContext::defaultMatcher, // 必须使用函数引用方式。
+    crossinline function: suspend EventListenerProcessingContext.(E) -> EventResult,
+): EventListener = simpleListener(target, id.literal, isAsync, logger, attributes, matcher, function)
+
+@Deprecated(
+    "Just use simpleListener(..., id: String, ...)", ReplaceWith(
+        "simpleListener(targets, id.literal, isAsync, logger, attributes, matcher, function)",
+        "love.forte.simbot.literal"
+    )
+)
+@JvmSynthetic
+public inline fun simpleListener(
+    targets: Collection<Event.Key<*>>,
+    id: ID = randomID(),
+    isAsync: Boolean = false,
+    logger: Logger = LoggerFactory.getLogger("love.forte.core.listener.$id"),
+    attributes: AttributeContainer? = null,
+    crossinline matcher: suspend EventListenerProcessingContext.() -> Boolean = { true },
+    crossinline function: suspend EventListenerProcessingContext.() -> EventResult,
+): EventListener = simpleListener(targets, id.literal, isAsync, logger, attributes, matcher, function)
+
+
+@JvmSynthetic
+@FragileSimbotApi
+@Deprecated(
+    "Just use simpleListener(..., id: String, ...)", ReplaceWith(
+        "simpleListener(id.literal, isAsync, logger, attributes, matcher, function)",
+        "love.forte.simbot.literal"
+    )
+)
+public inline fun <reified E : Event> simpleListener(
+    id: ID = randomID(),
+    isAsync: Boolean = false,
+    logger: Logger = LoggerFactory.getLogger("love.forte.core.listener.$id"),
+    attributes: AttributeContainer? = null,
+    crossinline matcher: suspend EventListenerProcessingContext.(E) -> Boolean = { true },
+    crossinline function: suspend EventListenerProcessingContext.(E) -> EventResult,
+): EventListener = simpleListener(id.literal, isAsync, logger, attributes, matcher, function)
+
+
+@JvmSynthetic
+@FragileSimbotApi
+@Deprecated(
+    "Just use EventListenerRegistrar.listen(..., id: String, ...)", ReplaceWith(
+        "listen(eventKey, id.literal, isAsync, logger, attributes, matcher, func).also(::register)",
+        "love.forte.simbot.literal"
+    )
+)
+public inline fun <E : Event> EventListenerRegistrar.listen(
+    eventKey: Event.Key<E>,
+    id: ID = randomID(),
+    isAsync: Boolean = false,
+    logger: Logger = LoggerFactory.getLogger("love.forte.core.listener.$id"),
+    attributes: AttributeContainer? = null,
+    crossinline matcher: suspend EventListenerProcessingContext.(E) -> Boolean = { true },
+    crossinline func: suspend EventListenerProcessingContext.(E) -> EventResult,
+): EventListener = listen(eventKey, id.literal, isAsync, logger, attributes, matcher, func).also(::register)
+
+@JvmSynthetic
+@FragileSimbotApi
+@Deprecated(
+    "Just use EventListenerRegistrar.listen(..., id: String, ...)", ReplaceWith(
+        "listen(id.literal, isAsync, logger, attributes, matcher, func)",
+        "love.forte.simbot.literal"
+    )
+)
+public inline fun <reified E : Event> EventListenerRegistrar.listen(
+    id: ID = randomID(),
+    isAsync: Boolean = false,
+    logger: Logger = LoggerFactory.getLogger("love.forte.core.listener.$id"),
+    attributes: AttributeContainer? = null,
+    crossinline matcher: suspend EventListenerProcessingContext.(E) -> Boolean = { true },
+    crossinline func: suspend EventListenerProcessingContext.(E) -> EventResult,
+): EventListener = listen(id.literal, isAsync, logger, attributes, matcher, func)
+
+@Api4J
+@JvmName("listener")
+@JvmOverloads
+@Deprecated(
+    "Just use blockingSimpleListener(..., id: String, ...)", ReplaceWith(
+        "blockingSimpleListener(target, id.literal, isAsync, logger, matcher, function)",
+        "love.forte.simbot.literal"
+    )
+)
+public fun <E : Event> blockingSimpleListener(
+    target: Event.Key<E>,
+    id: ID,
+    isAsync: Boolean = false,
+    logger: Logger = LoggerFactory.getLogger("love.forte.core.listener.$id"),
+    matcher: BiPredicate<EventListenerProcessingContext, E>? = null, // = BiPredicate { _, _ -> true }, // EventListenerProcessingContext.(E) -> Boolean = EventListenerProcessingContext::defaultMatcher, // 必须使用函数引用方式。
+    function: BiFunction<EventListenerProcessingContext, E, EventResult>,
+): EventListener = blockingSimpleListener(target, id.literal, isAsync, logger, matcher, function)
+
+
+@Api4J
+@JvmName("listener")
+@JvmOverloads
+@Deprecated(
+    "Just use blockingSimpleListenerWithoutResult(..., id: String, ...)", ReplaceWith(
+        "blockingSimpleListenerWithoutResult(target, id.literal, isAsync, logger, matcher, function)",
+        "love.forte.simbot.literal"
+    )
+)
+public fun <E : Event> blockingSimpleListenerWithoutResult(
+    target: Event.Key<E>,
+    id: ID,
+    isAsync: Boolean = false,
+    logger: Logger = LoggerFactory.getLogger("love.forte.core.listener.$id"),
+    matcher: BiPredicate<EventListenerProcessingContext, E>? = null, // = BiPredicate { _, _ -> true }, // EventListenerProcessingContext.(E) -> Boolean = EventListenerProcessingContext::defaultMatcher, // 必须使用函数引用方式。
+    function: BiConsumer<EventListenerProcessingContext, E>,
+): EventListener = blockingSimpleListenerWithoutResult(target, id.literal, isAsync, logger, matcher, function)
 // endregion


### PR DESCRIPTION
`EventListener` 作为simbot内部使用的类型，将 `id` 作为 `ID` 类型是多此一举的。