### PR TITLE
实现新特性 `DelayableCoroutineScope`

### DIFF
--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/Bot.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/Bot.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.CompletionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
-import love.forte.simbot.ability.DelayableCoroutineScope
 import love.forte.simbot.ability.Survivable
 import love.forte.simbot.definition.User
 import love.forte.simbot.definition.UserInfo
@@ -55,7 +54,7 @@ import kotlin.coroutines.CoroutineContext
  *
  * @author ForteScarlet
  */
-public interface Bot : User, DelayableCoroutineScope, Survivable,
+public interface Bot : User, Survivable,
     LoggerContainer, ComponentContainer,
     ContactsContainer, GroupsContainer, GuildsContainer {
     override val coroutineContext: CoroutineContext

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/Bot.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/Bot.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.CompletionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
+import love.forte.simbot.ability.DelayableCoroutineScope
 import love.forte.simbot.ability.Survivable
 import love.forte.simbot.definition.User
 import love.forte.simbot.definition.UserInfo
@@ -31,7 +32,7 @@ import love.forte.simbot.utils.runInBlocking
 import org.slf4j.Logger
 import kotlin.coroutines.CoroutineContext
 
-
+// Delayable // 可延迟的
 /**
  *
  * 一个 [Bot]. 同时, [Bot] 也属于一个用户 [User]。
@@ -54,7 +55,7 @@ import kotlin.coroutines.CoroutineContext
  *
  * @author ForteScarlet
  */
-public interface Bot : User, CoroutineScope, Survivable,
+public interface Bot : User, DelayableCoroutineScope, Survivable,
     LoggerContainer, ComponentContainer,
     ContactsContainer, GroupsContainer, GuildsContainer {
     override val coroutineContext: CoroutineContext
@@ -107,7 +108,8 @@ public interface Bot : User, CoroutineScope, Survivable,
      * _Deprecated: 直接通过 [Resource.asImage][Image.toImage] 构建 [Image] 实例即可。_
      */
     @JvmSynthetic
-    @Deprecated("Just use Resource.asImage",
+    @Deprecated(
+        "Just use Resource.asImage",
         ReplaceWith("resource.asImage()", "love.forte.simbot.message.Image.Key.asImage")
     )
     public suspend fun uploadImage(resource: Resource): Image<*> = resource.toImage()

--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/ability/DelayableCoroutineScope.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/ability/DelayableCoroutineScope.kt
@@ -1,0 +1,210 @@
+/*
+ *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ *
+ *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
+ *
+ *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ *
+ *  发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
+ *
+ *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ *  https://www.gnu.org/licenses
+ *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ *
+ */
+package love.forte.simbot.ability
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.future.asCompletableFuture
+import love.forte.simbot.Api4J
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
+import java.util.function.Function
+import java.util.function.Supplier
+
+/**
+ *
+ * 可延迟的 [CoroutineScope]。
+ * [DelayableCoroutineScope] 继承并扩展 [CoroutineScope], 对外提供部分服务于 Java 开发者的“延迟”函数。
+ *
+ * 对外提供的这些延时函数本质上是通过当前作用域所构建的异步函数，并通过 [delay] 实现非阻塞的延时效果。
+ * Java 开发者可以通过这些延时函数来更高效的通过异步回调手段类似于 [Thread.sleep] 的效果。
+ *
+ * 需要注意的是，本质上这些延迟任务都是 **异步** 的，所以需要依靠回调函数进行进一步的逻辑。
+ *
+ * @author ForteScarlet
+ */
+public interface DelayableCoroutineScope : CoroutineScope {
+    
+    @Api4J
+    public fun delay(time: Long, timeUnit: TimeUnit, runnable: Runnable): DelayableFuture<Void?> =
+        delay0(time, timeUnit, runnable)
+    
+    @Api4J
+    public fun delay(time: Long, runnable: Runnable): DelayableFuture<Void?> =
+        delay(time, TimeUnit.MILLISECONDS, runnable)
+    
+    
+    @Api4J
+    public fun <V> delayAndCompute(time: Long, timeUnit: TimeUnit, supplier: Supplier<V>): DelayableFuture<V> =
+        delayAndCompute0(time, timeUnit, supplier)
+    
+    @Api4J
+    public fun <V> delayAndCompute(time: Long, supplier: Supplier<V>): DelayableFuture<V> =
+        delayAndCompute(time, TimeUnit.MILLISECONDS, supplier)
+    
+}
+
+
+/**
+ * 可以链式调用延迟函数的 [Future] 函数实现。
+ *
+ */
+public interface DelayableFuture<V> : Future<V> {
+    
+    @Api4J
+    public fun delay(time: Long, timeUnit: TimeUnit, runnable: Runnable): DelayableFuture<V>
+    
+    @Api4J
+    public fun delay(time: Long, runnable: Runnable): DelayableFuture<V> = delay(time, TimeUnit.MILLISECONDS, runnable)
+    
+    @Api4J
+    public fun <T> delayAndCompute(time: Long, timeUnit: TimeUnit, function: Function<V, T>): DelayableFuture<T>
+    
+    @Api4J
+    public fun <T> delayAndCompute(time: Long, function: Function<V, T>): DelayableFuture<T> =
+        delayAndCompute(time, TimeUnit.MILLISECONDS, function)
+    
+    @Api4J
+    public fun <T> map(function: Function<V, T>): DelayableFuture<T>
+}
+
+
+public fun <T> Deferred<T>.asDelayableFuture(scope: CoroutineScope): DelayableFuture<T> =
+    DelayableFutureImpl(this, scope)
+
+
+private fun CoroutineScope.delay0(time: Long, timeUnit: TimeUnit, runnable: Runnable): DelayableFuture<Void?> {
+    return DelayableFutureImpl(
+        async {
+            delay(timeUnit.toMillis(time))
+            runInterruptible { runnable.run() }
+            null
+        }, this
+    )
+}
+
+private fun <V> CoroutineScope.delayAndCompute0(
+    time: Long,
+    timeUnit: TimeUnit,
+    supplier: Supplier<V>,
+): DelayableFuture<V> {
+    return DelayableFutureImpl(
+        async {
+            delay(timeUnit.toMillis(time))
+            runInterruptible { supplier.get() }
+        }, this
+    )
+}
+
+
+private class DelayableFutureImpl<V>(private val deferred: Deferred<V>, private val scope: CoroutineScope) :
+    DelayableFuture<V> {
+    private val future = deferred.asCompletableFuture()
+    
+    @Api4J
+    override fun delay(time: Long, timeUnit: TimeUnit, runnable: Runnable): DelayableFuture<V> {
+        return DelayableFutureImpl(
+            scope.async {
+                deferred.await().also {
+                    delay(timeUnit.toMillis(time))
+                    runInterruptible { runnable.run() }
+                }
+            }, scope
+        )
+    }
+    
+    @Api4J
+    override fun <T> delayAndCompute(time: Long, timeUnit: TimeUnit, function: Function<V, T>): DelayableFuture<T> {
+        return DelayableFutureImpl(
+            scope.async {
+                deferred.await().let { v ->
+                    delay(timeUnit.toMillis(time))
+                    runInterruptible { function.apply(v) }
+                }
+            }, scope
+        )
+    }
+    
+    @Api4J
+    override fun <T> map(function: Function<V, T>): DelayableFuture<T> {
+        return TransformDelayableFutureImpl(this, function)
+    }
+    
+    override fun isCancelled(): Boolean {
+        return future.isCancelled
+    }
+    
+    override fun cancel(mayInterruptIfRunning: Boolean): Boolean {
+        return future.cancel(mayInterruptIfRunning)
+    }
+    
+    override fun isDone(): Boolean {
+        return future.isDone
+    }
+    
+    override fun get(): V {
+        return future.get()
+    }
+    
+    override fun get(timeout: Long, unit: TimeUnit): V {
+        return future.get(timeout, unit)
+    }
+}
+
+
+private class TransformDelayableFutureImpl<From, To>(
+    private val future: DelayableFuture<From>,
+    private val mapper: Function<From, To>,
+) : DelayableFuture<To> {
+    
+    @Api4J
+    override fun delay(time: Long, timeUnit: TimeUnit, runnable: Runnable): DelayableFuture<To> {
+        return TransformDelayableFutureImpl(future.delay(time, timeUnit, runnable), mapper)
+    }
+    
+    @Api4J
+    override fun <T> delayAndCompute(time: Long, timeUnit: TimeUnit, function: Function<To, T>): DelayableFuture<T> {
+        return future.delayAndCompute(time, timeUnit) { v ->
+            function.apply(mapper.apply(v))
+        }
+    }
+    
+    @Api4J
+    override fun <T> map(function: Function<To, T>): DelayableFuture<T> {
+        return TransformDelayableFutureImpl(this, function)
+    }
+    
+    override fun cancel(mayInterruptIfRunning: Boolean): Boolean {
+        return future.cancel(mayInterruptIfRunning)
+    }
+    
+    override fun isCancelled(): Boolean {
+        return future.isCancelled
+    }
+    
+    override fun isDone(): Boolean {
+        return future.isDone
+    }
+    
+    override fun get(): To {
+        val value = future.get()
+        return mapper.apply(value)
+    }
+    
+    override fun get(timeout: Long, unit: TimeUnit): To {
+        val value = future.get(timeout, unit)
+        return mapper.apply(value)
+    }
+}

--- a/apis/simbot-api/src/test/java/DelayScopeTest.java
+++ b/apis/simbot-api/src/test/java/DelayScopeTest.java
@@ -1,0 +1,37 @@
+import kotlin.coroutines.CoroutineContext;
+import kotlin.coroutines.EmptyCoroutineContext;
+import love.forte.simbot.ability.DelayableCoroutineScope;
+import love.forte.simbot.ability.DelayableFuture;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.LocalTime;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author ForteScarlet
+ */
+public class DelayScopeTest {
+
+    // @Test
+    public void test() throws ExecutionException, InterruptedException {
+        final FooDelayableCoroutineScope scope = new FooDelayableCoroutineScope();
+        final DelayableFuture<LocalTime> whole = scope.delay(5, TimeUnit.SECONDS, () -> {
+            System.out.println(LocalTime.now());
+        }).delay(5, TimeUnit.SECONDS, () -> {
+            System.out.println(LocalTime.now());
+        }).delayAndCompute(5, TimeUnit.SECONDS, (v) -> LocalTime.now()).map(t -> t.plusSeconds(5));
+
+        System.out.println("whole.get() = " + whole.get());
+    }
+
+}
+
+
+class FooDelayableCoroutineScope implements DelayableCoroutineScope {
+    @NotNull
+    @Override
+    public CoroutineContext getCoroutineContext() {
+        return EmptyCoroutineContext.INSTANCE;
+    }
+}

--- a/apis/simbot-api/src/test/java/DelayScopeTest.java
+++ b/apis/simbot-api/src/test/java/DelayScopeTest.java
@@ -1,8 +1,10 @@
 import kotlin.coroutines.CoroutineContext;
 import kotlin.coroutines.EmptyCoroutineContext;
+import love.forte.simbot.Bot;
+import love.forte.simbot.ability.DelayableCompletableFuture;
 import love.forte.simbot.ability.DelayableCoroutineScope;
-import love.forte.simbot.ability.DelayableFuture;
 import org.jetbrains.annotations.NotNull;
+import org.testng.annotations.Test;
 
 import java.time.LocalTime;
 import java.util.concurrent.ExecutionException;
@@ -13,16 +15,58 @@ import java.util.concurrent.TimeUnit;
  */
 public class DelayScopeTest {
 
-    // @Test
+    @Test
     public void test() throws ExecutionException, InterruptedException {
         final FooDelayableCoroutineScope scope = new FooDelayableCoroutineScope();
-        final DelayableFuture<LocalTime> whole = scope.delay(5, TimeUnit.SECONDS, () -> {
+        final DelayableCompletableFuture<LocalTime> whole = scope.delay(5, TimeUnit.SECONDS, () -> {
+            System.out.println(LocalTime.now());
+        }).delay(5, TimeUnit.SECONDS, () -> {
+            throw new IllegalStateException();
+            // System.out.println(LocalTime.now());
+        }).delay(5, TimeUnit.SECONDS, () -> {
             System.out.println(LocalTime.now());
         }).delay(5, TimeUnit.SECONDS, () -> {
             System.out.println(LocalTime.now());
-        }).delayAndCompute(5, TimeUnit.SECONDS, (v) -> LocalTime.now()).map(t -> t.plusSeconds(5));
+        }).delay(5, TimeUnit.SECONDS, () -> {
+            System.out.println(LocalTime.now());
+        }).delay(5, TimeUnit.SECONDS, () -> {
+            System.out.println(LocalTime.now());
+        }).delay(5, TimeUnit.SECONDS, () -> {
+            System.out.println(LocalTime.now());
+        }).delay(5, TimeUnit.SECONDS, () -> {
+            System.out.println(LocalTime.now());
+        }).delay(5, TimeUnit.SECONDS, () -> {
+            System.out.println(LocalTime.now());
+        }).delay(5, TimeUnit.SECONDS, () -> {
+            System.out.println(LocalTime.now());
+        }).delay(5, TimeUnit.SECONDS, () -> {
+            System.out.println(LocalTime.now());
+        }).delay(5, TimeUnit.SECONDS, () -> {
+            System.out.println(LocalTime.now());
+        }).delay(5, TimeUnit.SECONDS, () -> {
+            System.out.println(LocalTime.now());
+        }).delayAndCompute(5, TimeUnit.SECONDS, (v) -> LocalTime.now()); //.map(t -> t.plusSeconds(5));
 
+        Thread.sleep(TimeUnit.SECONDS.toMillis(10));
+        System.out.println("wake up!");
         System.out.println("whole.get() = " + whole.get());
+    }
+
+    // @Test
+    public void foo(Bot bot) {
+        final DelayableCompletableFuture<LocalTime> whole = bot
+                // (1). 延时5秒，打印当前时间
+                .delay(5, TimeUnit.SECONDS, () -> {
+                    System.out.println(LocalTime.now());
+                })
+                // (2). 流程(1)结束后，再延时5秒，打印当前时间
+                .delay(5, TimeUnit.SECONDS, () -> {
+                    throw new IllegalStateException();
+                    // System.out.println(LocalTime.now());
+                })
+                // (3). 流程(2)结束后，再延时5秒，返回当前时间
+                .delayAndCompute(5, TimeUnit.SECONDS, (v) -> LocalTime.now());
+
     }
 
 }


### PR DESCRIPTION
提供一个新的 `DelayableCoroutineScope` 来服务 Java 开发者更便捷的使用非阻塞延时函数来代替 `Thread.sleep`。

