### PR TITLE
调整 `ApplicationBuilder` 对 `Application` 的构建流程

### DIFF
--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/application/ApplicationFactory.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/application/ApplicationFactory.kt
@@ -99,13 +99,42 @@ public interface ApplicationBuilder<A : Application> : CompletionPerceivable<A> 
 
 
 /**
+ * 应用于 [ApplicationBuilder.bots] 中的bot注册函数,
+ * 提供一个通过 [BotVerifyInfo] 注册的通用bot注册函数。
  *
- * TODO 补注释
+ * [BotRegistrar] 会通过 [BotVerifyInfo] 中的 [组件id][BotVerifyInfo.componentId]
+ * 去当前环境中寻找对应组件的、实现了 [Bot注册器][love.forte.simbot.BotRegistrar] 的 [事件提供者][EventProvider],
+ * 并尝试注册此bot。
+ *
  */
 public interface BotRegistrar {
     
     /**
-     * TODO 补注释
+     * 当前环境中的所有事件提供者。
+     *
+     * 你可以通过 [providers] 寻找你所需要的指定 [Bot注册器][love.forte.simbot.BotRegistrar]。
+     *
+     * ```kotlin
+     * providers.filterIsInstance<FooBotRegistrar>().forEach {
+     *    // ...
+     * }
+     * ```
+     *
+     * 当然，根据组件和事件提供者的注册机制来讲，通常情况下同一个类型的注册器环境中只会存在一个。
+     * ```kotlin
+     * providers.firstOrNull { it is FooBotRegistrar } as FooBotRegistrar?
+     * ```
+     *
+     */
+    public val providers: List<EventProvider>
+    
+    
+    /**
+     * 通过 [BotVerifyInfo] 中的 [组件信息][BotVerifyInfo.componentId]
+     * 去当前环境中寻找对应组件的、实现了 [Bot注册器][love.forte.simbot.BotRegistrar] 的 [事件提供者][EventProvider],
+     * 并尝试注册此bot。
+     *
+     * 如果没有找到符合组件id的 [Bot注册器][love.forte.simbot.BotRegistrar] 存在，则返回null。
      */
     public fun register(botVerifyInfo: BotVerifyInfo): Bot?
 }

--- a/boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/application/SpringBootApplication.kt
+++ b/boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/application/SpringBootApplication.kt
@@ -183,9 +183,16 @@ private class SpringBootApplicationBuilderImpl : SpringBootApplicationBuilder,
             logger.debug("The built providers: {}", providers)
         }
         
-        logger.debug("Registering bots...")
-        val bots = registerBots(providers.filterIsInstance<love.forte.simbot.BotRegistrar>())
+        val application = SpringBootApplicationImpl(configuration, environment, listenerManager, providers)
         
+        // complete.
+        complete(application)
+    
+        //region register bots
+        // after complete.
+        logger.debug("Registering bots...")
+        val bots = registerBots(providers)
+    
         logger.info("Bots all registered. The size of bots: {}", bots.size)
         if (bots.isNotEmpty()) {
             logger.debug("The all registered bots: {}", bots)
@@ -205,11 +212,7 @@ private class SpringBootApplicationBuilderImpl : SpringBootApplicationBuilder,
         if (isAutoStartBots && bots.isEmpty()) {
             logger.debug("But the registered bots are empty.")
         }
-        
-        val application = SpringBootApplicationImpl(configuration, environment, listenerManager, providers)
-        
-        // complete.
-        complete(application)
+        //endregion
         
         return application
     }

--- a/boots/simboot-core/src/main/kotlin/love/forte/simboot/core/application/BootApplication.kt
+++ b/boots/simboot-core/src/main/kotlin/love/forte/simboot/core/application/BootApplication.kt
@@ -525,8 +525,8 @@ private class BootApplicationBuilderImpl : BootApplicationBuilder, BaseStandardA
         
         // endregion
         
-        // region register bots
-        logger.debug("Registering bots...")
+        // region scan bots verify info and decoders
+        logger.debug("Resolving bot verify infos and bot verify decoders...")
         // scan and auto register bot
         
         val botVerifyDecoderFactories = configuration.botVerifyDecodersOrDefaultStandards()
@@ -547,8 +547,18 @@ private class BootApplicationBuilderImpl : BootApplicationBuilder, BaseStandardA
                 )
             }
         }
+        // endregion
         
-        val bots = registerBots(providers.filterIsInstance<love.forte.simbot.BotRegistrar>())
+        // create application
+        val application = BootApplicationImpl(configuration, environment, listenerManager, beanContainer, providers)
+        
+        // complete.
+        complete(application)
+    
+        // region register bots
+        // after complete.
+        logger.debug("Registing bots...")
+        val bots = registerBots(providers)
         logger.info("Bots all registered. The size of bots: {}", bots.size)
         if (bots.isNotEmpty()) {
             logger.debug("The all registered bots: {}", bots)
@@ -569,13 +579,8 @@ private class BootApplicationBuilderImpl : BootApplicationBuilder, BaseStandardA
             logger.debug("But the registered bots are empty.")
         }
         // endregion
-        
-        // create application
-        val application = BootApplicationImpl(configuration, environment, listenerManager, beanContainer, providers)
-        
-        // complete.
-        complete(application)
-        
+    
+    
         return application
     }
     

--- a/cores/simbot-core/src/main/kotlin/love/forte/simbot/core/application/SimpleApplication.kt
+++ b/cores/simbot-core/src/main/kotlin/love/forte/simbot/core/application/SimpleApplication.kt
@@ -30,7 +30,8 @@ import kotlin.time.Duration.Companion.nanoseconds
 /**
  * 由核心所提供的最基础的 [ApplicationFactory] 实现。
  */
-public object Simple : ApplicationFactory<SimpleApplicationConfiguration, SimpleApplicationBuilder, SimpleApplication> {
+public object Simple :
+    ApplicationFactory<SimpleApplicationConfiguration, SimpleApplicationBuilder, SimpleApplication> {
     private val logger = LoggerFactory.getLogger<Simple>()
     
     override suspend fun create(
@@ -47,10 +48,11 @@ public object Simple : ApplicationFactory<SimpleApplicationConfiguration, Simple
         val appBuilder = SimpleApplicationBuilderImpl().apply {
             builder(config)
         }
-        
         return appBuilder.build(config).also {
             val duration = (System.nanoTime() - startTime).nanoseconds
-            logger.info("Simple Application built in {}", duration.toString())
+            if (logger.isInfoEnabled) {
+                logger.info("Simple Application built in {}", duration.toString())
+            }
         }
     }
 }
@@ -132,7 +134,8 @@ private class SimpleApplicationImpl(
 /**
  * [SimpleApplication]所使用的构建器。
  */
-private class SimpleApplicationBuilderImpl : SimpleApplicationBuilder, BaseStandardApplicationBuilder<SimpleApplication>() {
+private class SimpleApplicationBuilderImpl : SimpleApplicationBuilder,
+    BaseStandardApplicationBuilder<SimpleApplication>() {
     
     
     suspend fun build(appConfig: SimpleApplicationConfiguration): SimpleApplication {
@@ -159,16 +162,21 @@ private class SimpleApplicationBuilderImpl : SimpleApplicationBuilder, BaseStand
         logger.debug("Providers are built: {}", providers)
         logger.info("The size of providers built is {}", providers.size)
         
-        // register bots
-        logger.debug("Registing bots...")
-        val bots = registerBots(providers.filterIsInstance<love.forte.simbot.BotRegistrar>())
-        logger.debug("All bot registers: {}", bots)
-        logger.info("The size of bots registered: {}", bots.size)
-        
         val application = SimpleApplicationImpl(appConfig, environment, listenerManager, providers)
         
         // complete.
         complete(application)
+        logger.info("Application [{}] is built and completed.", application)
+        
+        // region register bots
+        // registing bot after complete.
+        
+        logger.debug("Registing bots...")
+        val bots = registerBots(providers)
+        logger.debug("All bot registers: {}", bots)
+        logger.info("The size of bots registered: {}", bots.size)
+        // endregion
+        
         
         return application
     }

--- a/cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleListenerManagerConfiguration.kt
+++ b/cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleListenerManagerConfiguration.kt
@@ -43,14 +43,6 @@ internal annotation class SimpleEventManagerConfigDSL
  * [SimpleEventListenerManager] 的配置文件.
  * 当配置文件作为构建参数的时候，他会被立即使用。
  *
- * ### 拦截器
- * 通过 [interceptors] [addListenerInterceptors] [addListenerInterceptors] 等相关函数来向配置中追加对应作用域的拦截器。
- * ```kotlin
- * coreListenerManager {
- *
- * }
- * ```
- *
  *
  * @see SimpleEventListenerManager.newInstance
  * @see simpleListenerManager


### PR DESCRIPTION
现在默认提供的所有 `ApplicationBuilder` 默认实现中，对bot的自动注册顺序进行了调整，将其置于了 Application 构建之后。

这样可以实现当application构建完成后才有可能发生事件处理，通过这种方式可以允许通过 `onCompletion { ... }` 来为监听函数提前准备 `Application` 实例。 

同时，为 `bots { ... }` 函数中的 `BotRegistrar` 提供额外属性 `providers` 来允许自行寻找所需的 `EventProvider`。通过此方式将废除所有组件实现中的自定义bot配置、变为组件直接提供针对性的扩展函数。