### PR TITLE
持续会话对事件的处理机制变更

### DIFF
--- a/apis/simbot-api/src/main/kotlin/love/forte/simbot/event/ContinuousSessionFunctions.kt
+++ b/apis/simbot-api/src/main/kotlin/love/forte/simbot/event/ContinuousSessionFunctions.kt
@@ -31,6 +31,7 @@ import love.forte.simbot.utils.runWithInterruptible
  * @see BlockingContinuousSessionSelector
  */
 public fun interface ContinuousSessionSelector<T> {
+    @JvmSynthetic
     public suspend operator fun EventProcessingContext.invoke(provider: ContinuousSessionProvider<T>)
 }
 

--- a/boots/simboot-core-spring-boot-starter/build.gradle.kts
+++ b/boots/simboot-core-spring-boot-starter/build.gradle.kts
@@ -67,7 +67,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-webflux:2.7.0")
     
     @Suppress("VulnerableLibrariesLocal")
-    testImplementation("love.forte.simbot.component:simbot-component-mirai-boot:3.0.0.0.preview.9.0")
+    testImplementation("love.forte.simbot.component:simbot-component-mirai-boot:3.0.0.0.preview.10.0")
     // testImplementation(V.Kotlinx.Coroutines.Reactor.notation)
 }
 repositories {

--- a/cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleEventListenerManager.kt
+++ b/cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleEventListenerManager.kt
@@ -162,9 +162,11 @@ public interface EventProcessingContextResolver<C : EventProcessingContext> {
     /**
      * 根据一个事件得到对应的流程上下文。
      * 只有在对应事件存在至少一个对应的监听函数的时候才会被触发。
+     *
+     * @return 如果结果为null，则代表跳过本次推送
      */
     @JvmSynthetic
-    public suspend fun resolveEventToContext(event: Event, listenerSize: Int): C
+    public suspend fun resolveEventToContext(event: Event, listenerSize: Int): C?
     
     /**
      * 向提供的上下文 [C] 的 [EventProcessingContext.results] 中追加一个 [EventResult].

--- a/cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleEventListenerManagerImpl.kt
+++ b/cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleEventListenerManagerImpl.kt
@@ -163,7 +163,10 @@ internal class SimpleEventListenerManagerImpl internal constructor(
             return EventProcessingResult
         }
         
-        return doInvoke(resolveToContext(event, invokers.size), invokers)
+        return resolveToContext(event, invokers.size)?.let {
+            doInvoke(it, invokers)
+        } ?: EventProcessingResult
+        
     }
     
     @Api4J
@@ -181,7 +184,12 @@ internal class SimpleEventListenerManagerImpl internal constructor(
         }
         
         
-        val deferred = managerScope.async { doInvoke(resolveToContext(event, invokers.size), invokers) }
+        val deferred = managerScope.async {
+            resolveToContext(event, invokers.size)?.let { context ->
+                doInvoke(context, invokers)
+            } ?: EventProcessingResult
+        }
+        
         return deferred.asCompletableFuture()
     }
     
@@ -266,7 +274,7 @@ internal class SimpleEventListenerManagerImpl internal constructor(
     /**
      * 通过 [Event] 得到一个 [EventProcessingContext].
      */
-    private suspend fun resolveToContext(event: Event, listenerSize: Int): SimpleEventProcessingContext {
+    private suspend fun resolveToContext(event: Event, listenerSize: Int): SimpleEventProcessingContext? {
         return resolver.resolveEventToContext(event, listenerSize)
     }
     

--- a/cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleEventProcessingContextResolver.kt
+++ b/cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleEventProcessingContextResolver.kt
@@ -18,7 +18,6 @@ package love.forte.simbot.core.event
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactor.awaitSingleOrNull
 import kotlinx.coroutines.rx2.asFlow
@@ -40,7 +39,7 @@ import java.util.concurrent.ConcurrentHashMap
  * 核心默认的事件上下文处理器。
  */
 internal class SimpleEventProcessingContextResolver(
-    private val coroutineScope: CoroutineScope,
+    coroutineScope: CoroutineScope,
 ) : EventProcessingContextResolver<SimpleEventProcessingContext> {
     private val continuousSessionListenerManager = ContinuousSessionListenerManager()
     
@@ -63,7 +62,7 @@ internal class SimpleEventProcessingContextResolver(
      * 根据一个事件和当前事件对应的监听函数数量得到一个事件上下文实例。
      */
     @OptIn(ExperimentalSimbotApi::class, ExperimentalSerializationApi::class)
-    override suspend fun resolveEventToContext(event: Event, listenerSize: Int): SimpleEventProcessingContext {
+    override suspend fun resolveEventToContext(event: Event, listenerSize: Int): SimpleEventProcessingContext? {
         
         val context = SimpleEventProcessingContext(
             event,
@@ -72,9 +71,12 @@ internal class SimpleEventProcessingContextResolver(
             continuousSessionContext,
             listenerSize
         )
+        // coroutineScope.launch {
+        //     continuousSessionListenerManager.process(context)
+        // }
         
-        coroutineScope.launch {
-            continuousSessionListenerManager.process(context)
+        if (continuousSessionListenerManager.process(context)) {
+            return null
         }
         
         return context


### PR DESCRIPTION
持续会话不再是异步独立的被检测了， 而是在正常处理流程之前**依次顺序**执行，且每次应当至多只被**一个**持续会话取用。

当一个持续会话成功取用了当前事件，则此事件将不会再参与到其他持续会话或者正常的监听流程中。