### PR TITLE
弃用 `@TargetFilter`, 以 `@Filter.Targets` 取代

### DIFF
--- a/simbot-boots/simboot-core-annotation/src/main/kotlin/love/forte/simboot/annotation/Filter.kt
+++ b/simbot-boots/simboot-core-annotation/src/main/kotlin/love/forte/simboot/annotation/Filter.kt
@@ -16,7 +16,8 @@
 
 package love.forte.simboot.annotation
 
-import love.forte.simboot.annotation.TargetFilter.Companion.NON_PREFIX
+import love.forte.simboot.annotation.Filter.Targets
+import love.forte.simboot.annotation.Filter.Targets.Companion.NON_PREFIX
 import love.forte.simboot.filter.MatchType
 import love.forte.simboot.filter.MultiFilterMatchType
 import love.forte.simbot.event.ChannelEvent
@@ -107,24 +108,29 @@ public annotation class Filter(
      *
      * 整合了常见的一些过滤参数，例如群号或者发送人账号。
      *
-     * @see [TargetFilter]
+     * _Deprecated: 使用 [targets]_
+     *
+     * @see [targets]
      */
+    @Suppress("DEPRECATION")
+    @Deprecated("Use targets", ReplaceWith("targets"))
     val target: TargetFilter = TargetFilter(),
-
+    
     /*
-        val and: Filters = Filters(),
-        val or: Filters = Filters(),
-        
-        since: 3.0.0.preview.15.0
-        不再支持上述 `and` 和 `or` 的嵌套注解。这个特性将会在Kotlin 1.7 中发出警告、在Kotlin 1.9 中被视为错误。
-        不过移除后，SpringFramework 的版本将不再受到限制。
-        
-        参考:
-        - [Spring Framework#28012#issuecomment-1154964509](https://github.com/spring-projects/spring-framework/issues/28012#issuecomment-1154964509)
-        - [KT-47932](https://youtrack.jetbrains.com/issue/KT-47932)
-    */
-
-
+        在 target 还存在的情况下，
+        当使用了 targets, 则不会使用 target。
+     */
+    
+    /**
+     * 目标过滤内容。
+     *
+     * 整合了常见的一些过滤参数，例如群号或者发送人账号。
+     *
+     * @see [Targets]
+     */
+    val targets: Targets = Targets(),
+    
+    
     /**
      * 指定一个对当前 [Filter] 的处理过滤器。当 [by] 指定了任意一个不直接等同于 [AnnotationEventFilterFactory]
      * 的类型时，此注解的上述其他参数将不再继续被解析，而是直接交由指定目标进行处理。
@@ -138,26 +144,123 @@ public annotation class Filter(
      */
     val by: KClass<out AnnotationEventFilterFactory> = AnnotationEventFilterFactory::class,
     
-    )
+    ) {
+    
+    /**
+     * 通用属性过滤规则。
+     *
+     * 针对目标对象（例如事件组件、bot、群、联系人等）的匹配规则，不可标记在任何地方，作为 [Filter] 的参数 [targets][Filter.targets] 使用.
+     *
+     * 以下所有属性的匹配结果为并集，即**全部**匹配成功后得到true。假如某参数为空，则认为其为 `true`.
+     *
+     * ## “非”前缀
+     *
+     * 下述所有属性中，如果某个值的前缀为 [NON_PREFIX], 则其代表的意思与正常相反：即需要不等于。
+     * 例如一个 `@TargetFilter(bots = ["forliy"])`, 其代表此事件只能由 `bot.id == "forliy"` 的bot匹配。
+     * 而如果使用 `@TargetFilter(bots = ["!forliy"])`, 则代表由所有 `bot.id != "forliy"` 的bot匹配。
+     *
+     * @see Filter
+     */
+    @Retention(AnnotationRetention.SOURCE)
+    @Target(allowedTargets = [])
+    public annotation class Targets(
+        /**
+         * 对接收事件的组件匹配. 大多数情况下，对于组件的唯一ID，组件实现库都应当有所说明或通过常量提供。 `["comp1", "comp2"]`
+         *
+         * 相当于:
+         * ```kotlin
+         *  event.component.id.literal in components
+         * ```
+         *
+         * 除了通过此 [components] 作为组件的筛选条件，直接监听一个组件下特有的事件类型能够更好的起到组件过滤的作用。
+         */
+        val components: Array<String> = [],
+        
+        /**
+         * 对接收事件的botID匹配。
+         *
+         * 相当于:
+         * ```kotlin
+         * event.bot.id.literal in bots
+         * ```
+         */
+        val bots: Array<String> = [],
+        
+        /**
+         * 对消息发送者的ID匹配。
+         *
+         * 相当于:
+         * ```kotlin
+         * event.author().id.literal in authors
+         * ```
+         */
+        val authors: Array<String> = [],
+        
+        /**
+         * 如果这是个[群相关事件][GroupEvent] ，则对群ID匹配。
+         *
+         * 相当于:
+         * ```kotlin
+         * event.group().id.literal in groups
+         * ```
+         *
+         */
+        val groups: Array<String> = [],
+        
+        /**
+         * 如果是个[子频道相关事件][ChannelEvent], 则对频道ID匹配。
+         *
+         * 相当于:
+         * ```kotlin
+         * event.channel().id.literal in channels
+         * ```
+         */
+        val channels: Array<String> = [],
+        
+        /**
+         * 如果是个[频道服务器相关事件][GuildEvent], 则对频道服务器ID匹配。
+         */
+        val guilds: Array<String> = [],
+        
+        /**
+         * 只有当前消息中存在任意一个 [At.target][love.forte.simbot.message.At.target] == event.bot.id 的 [At][love.forte.simbot.message.At] 消息的时候才会通过匹配。
+         *
+         * 相当于:
+         * ```kotlin
+         * event.messageContent.messages.any { it is At && it.target == event.bot.id }
+         * ```
+         * 此参数只有在当前事件类型为 [ChatroomMessageEvent][love.forte.simbot.event.ChatRoomMessageEvent] 的时候才会生效，且建议配合 [ContentTrim] 一起使用。
+         *
+         * 需要注意的是, [atBot] 的匹配结果**不一定准确**，例如当 bot.id 与实际的at目标ID不一致的时候。是否准确由对应组件下Bot、At等相关内容的构建与实现方式有关。此问题或许会在后续版本提供一个约定接口来完善相关匹配。
+         *
+         */
+        val atBot: Boolean = false,
+    ) {
+        public companion object {
+            /**
+             * [TargetFilter] 中的“非”前缀。
+             *
+             */
+            public const val NON_PREFIX: String = "!"
+        }
+    }
+}
 
 
 /**
  * 通用属性过滤规则。
  *
- * 针对目标对象（例如事件组件、bot、群、联系人等）的匹配规则，不可标记在任何地方，作为 [Filter] 的参数 [target][Filter.target] 使用.
- *
- * 以下所有属性的匹配结果为并集，即**全部**匹配成功后得到true。假如某参数为空，则认为其为 `true`.
- *
- * ## “非”前缀
- *
- * 下述所有属性中，如果某个值的前缀为 [NON_PREFIX], 则其代表的意思与正常相反：即需要不等于。
- * 例如一个 `@TargetFilter(bots = ["forliy"])`, 其代表此事件只能由 `bot.id == "forliy"` 的bot匹配。
- * 而如果使用 `@TargetFilter(bots = ["!forliy"])`, 则代表由所有 `bot.id != "forliy"` 的bot匹配。
+ * 已弃用并重命名迁移至 [Filter.Targets].
  *
  * @see Filter
+ * @see Filter.Targets
  */
 @Retention(AnnotationRetention.SOURCE)
 @Target(allowedTargets = [])
+@Deprecated(
+    "Use @Filter.Target",
+    ReplaceWith("Filter.Targets", "love.forte.simboot.annotation.Filter.Targets")
+)
 public annotation class TargetFilter(
     /**
      * 对接收事件的组件匹配. 大多数情况下，对于组件的唯一ID，组件实现库都应当有所说明或通过常量提供。 `["comp1", "comp2"]`

--- a/simbot-boots/simboot-core/src/main/kotlin/love/forte/simboot/core/filter/CoreAnnotationEventFilterFactory.kt
+++ b/simbot-boots/simboot-core/src/main/kotlin/love/forte/simboot/core/filter/CoreAnnotationEventFilterFactory.kt
@@ -21,6 +21,7 @@ import love.forte.simboot.annotation.Filter
 import love.forte.simboot.annotation.Filters
 import love.forte.simboot.filter.EmptyKeyword
 import love.forte.simboot.filter.MatchType
+import love.forte.simbot.LoggerFactory
 import love.forte.simbot.MutableAttributeMap
 import love.forte.simbot.event.*
 import love.forte.simbot.literal
@@ -28,6 +29,8 @@ import love.forte.simbot.message.At
 import java.util.concurrent.CopyOnWriteArrayList
 
 public object CoreAnnotationEventFilterFactory : AnnotationEventFilterFactory {
+    private val logger = LoggerFactory.getLogger<CoreAnnotationEventFilterFactory>()
+    
     override fun resolveFilter(
         listener: EventListener,
         listenerAttributes: MutableAttributeMap,
@@ -35,7 +38,15 @@ public object CoreAnnotationEventFilterFactory : AnnotationEventFilterFactory {
         filters: Filters,
     ): EventFilter? {
         val value = filter.value
-        val target = filter.target.box()
+        var target = filter.targets.box()
+        if (target == null) {
+            @Suppress("DEPRECATION")
+            target = filter.target.box0()
+            if (target != null) {
+                logger.warn("The @Filter(target = TargetFilter(...)) is deprecated. please use the @Filter(targets = Filter.Targets(...)).")
+            }
+            
+        }
         
         if (value.isEmpty() && target == null) {
             return null

--- a/simbot-boots/simboot-core/src/main/kotlin/love/forte/simboot/core/filter/CoreFilterAnnotationProcessor.kt
+++ b/simbot-boots/simboot-core/src/main/kotlin/love/forte/simboot/core/filter/CoreFilterAnnotationProcessor.kt
@@ -122,7 +122,7 @@ public object CoreFilterAnnotationProcessor {
 
 
 /**
- * @see TargetFilter
+ * @see Filter.Targets
  */
 internal data class FilterTarget(
     val components: Set<String>,
@@ -134,7 +134,20 @@ internal data class FilterTarget(
     val atBot: Boolean,
 )
 
-internal fun TargetFilter.box(): FilterTarget? {
+internal fun Filter.Targets.box(): FilterTarget? {
+    if (components.isEmpty() && bots.isEmpty() && authors.isEmpty() && groups.isEmpty() && channels.isEmpty() && guilds.isEmpty() && !atBot) {
+        return null
+    }
+    
+    return FilterTarget(
+        components.toSet(), bots.toSet(), authors.toSet(), groups.toSet(), channels.toSet(), guilds.toSet(), atBot
+    )
+    
+}
+
+
+@Suppress("DEPRECATION")
+internal fun TargetFilter.box0(): FilterTarget? {
     if (components.isEmpty() && bots.isEmpty() && authors.isEmpty() && groups.isEmpty() && channels.isEmpty() && guilds.isEmpty() && !atBot) {
         return null
     }


### PR DESCRIPTION
弃用 `@Filter(target = TargetFilter(...))`, 以 `@Filter(targets = Filter.Targets(...))` 取代之