### PR TITLE
SpringBoot下优先使用Spring的AnnotationUtils

### DIFF
--- a/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/utils/SpringAnnotationTool.kt
+++ b/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/utils/SpringAnnotationTool.kt
@@ -86,7 +86,10 @@ public class SpringAnnotationTool(private val tool: KAnnotationTool = KAnnotatio
         try {
             val annotatedElement = element.javaAnnotatedElement
             if (annotatedElement != null) {
-                return AnnotatedElementUtils.findAllMergedAnnotations(annotatedElement, annotationType.java).toList()
+                val repeatedResult = AnnotatedElementUtils.findMergedRepeatableAnnotations(annotatedElement, annotationType.java)
+                val directedResult = AnnotatedElementUtils.findAllMergedAnnotations(annotatedElement, annotationType.java)
+                return (repeatedResult + directedResult).toList()
+                // return AnnotatedElementUtils.findAllMergedAnnotations(annotatedElement, annotationType.java).toList()
             }
         } catch (ignore: Throwable) {
         }

--- a/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/utils/SpringAnnotationTool.kt
+++ b/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/utils/SpringAnnotationTool.kt
@@ -1,0 +1,119 @@
+/*
+ *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ *
+ *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
+ *
+ *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ *
+ *  发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
+ *
+ *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ *  https://www.gnu.org/licenses
+ *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ *
+ */
+
+package love.forte.simboot.spring.autoconfigure.utils
+
+import love.forte.annotationtool.core.KAnnotationTool
+import org.springframework.core.annotation.AnnotatedElementUtils
+import org.springframework.core.annotation.AnnotationUtils
+import java.lang.reflect.AnnotatedElement
+import kotlin.reflect.*
+import kotlin.reflect.jvm.javaConstructor
+import kotlin.reflect.jvm.javaField
+import kotlin.reflect.jvm.javaGetter
+import kotlin.reflect.jvm.javaMethod
+
+/**
+ * 通过 [AnnotationUtils] 实现 [KAnnotationTool] 的功能。
+ *
+ * 其中一部分功能仍然需要使用到原本的 [KAnnotationTool] 实例, 比如 在当提供的 [KAnnotatedElement] 不支持转化为 [AnnotatedElement] 的情况下，
+ * 或者使用时出现了异常的情况下。
+ *
+ *
+ */
+public class SpringAnnotationTool(private val tool: KAnnotationTool = KAnnotationTool()) : KAnnotationTool {
+    override fun clearCache() {
+        tool.clearCache()
+        AnnotationUtils.clearCache()
+    }
+    
+    override fun <A : Annotation> createAnnotationInstance(
+        annotationType: KClass<A>,
+        properties: Map<String, Any>,
+        base: A?,
+    ): A {
+        try {
+            return AnnotationUtils.synthesizeAnnotation(properties, annotationType.java, null)
+        } catch (ignore: Throwable) {
+        }
+        return tool.createAnnotationInstance(annotationType, properties, base)
+    }
+    
+    override fun <A : Annotation> getAnnotation(
+        fromElement: KAnnotatedElement,
+        annotationType: KClass<A>,
+        excludes: Set<String>,
+    ): A? {
+        try {
+            val jae = fromElement.javaAnnotatedElement
+            val javaType = annotationType.java
+            if (jae != null) {
+                return AnnotationUtils.findAnnotation(jae, javaType)
+            }
+        } catch (ignore: Throwable) {
+        }
+        
+        return tool.getAnnotation(fromElement, annotationType, excludes)
+    }
+    
+    
+    override fun getAnnotationPropertyTypes(annotationType: KClass<out Annotation>): Map<String, KType> {
+        return tool.getAnnotationPropertyTypes(annotationType)
+    }
+    
+    override fun <A : Annotation> getAnnotationValues(annotation: A): Map<String, Any> {
+        return AnnotationUtils.getAnnotationAttributes(annotation)
+    }
+    
+    override fun <A : Annotation> getAnnotations(
+        element: KAnnotatedElement,
+        annotationType: KClass<A>,
+        excludes: Set<String>,
+    ): List<A> {
+        try {
+            val annotatedElement = element.javaAnnotatedElement
+            if (annotatedElement != null) {
+                return AnnotatedElementUtils.findAllMergedAnnotations(annotatedElement, annotationType.java).toList()
+            }
+        } catch (ignore: Throwable) {
+        }
+        return tool.getAnnotations(element, annotationType, excludes)
+    }
+    
+    override fun getPropertyNames(annotation: Annotation): Set<String> {
+        return AnnotationUtils.getAnnotationAttributes(annotation).keys
+    }
+}
+
+
+private val KAnnotatedElement.javaAnnotatedElement: AnnotatedElement?
+    get() {
+        return when (this) {
+            is KCallable<*> -> when (this) {
+                is KFunction<*> -> javaMethod ?: javaConstructor
+                is KProperty<*> -> javaField ?: javaGetter
+                else -> null
+            }
+            is KClass<*> -> java
+            is KType -> when (val classifier = classifier) {
+                is KClass<*> -> classifier.javaAnnotatedElement
+                else -> null
+            }
+            // not support for KParameter
+            is KParameter -> null
+            else -> null
+        }
+    }

--- a/simbot-boots/simboot-core-spring-boot-starter/src/test/kotlin/love/forli/test/spring/SpringBootApplicationTest.kt
+++ b/simbot-boots/simboot-core-spring-boot-starter/src/test/kotlin/love/forli/test/spring/SpringBootApplicationTest.kt
@@ -5,6 +5,7 @@ import love.forte.simboot.spring.autoconfigure.EnableSimbot
 import love.forte.simbot.application.Application
 import love.forte.simbot.core.event.buildSimpleListener
 import love.forte.simbot.event.EventListener
+import love.forte.simbot.event.EventListenerProcessingContext
 import love.forte.simbot.event.EventResult
 import love.forte.simbot.event.FriendMessageEvent
 import org.junit.jupiter.api.extension.ExtendWith
@@ -21,9 +22,8 @@ import kotlin.test.Test
  *
  * @author ForteScarlet
  */
-// @RunWith(SpringRunner::class)
 @ExtendWith(SpringExtension::class)
-@SpringBootTest
+@SpringBootTest("simbot.top-level-listener-scan-package=love.forli.test.spring")
 @SpringBootApplication
 @EnableSimbot
 open class SpringBootApplicationTest {
@@ -37,15 +37,6 @@ open class SpringBootApplicationTest {
     
     @Test
     fun test1() {
-        println("All: ${events?.size ?: 0}")
-        events?.forEach {
-            println(it)
-        }
-        println(application)
-        println(application.environment)
-        println(application.providers)
-        println(application.eventListenerManager)
-        println(application.botManagers)
     }
     
 }
@@ -54,61 +45,30 @@ open class SpringBootApplicationTest {
 @Component
 open class Listeners {
     @Listener
-    fun myListener() {
-    
-    }
+    suspend fun listener1(){}
+    @Listener
+    suspend fun FriendMessageEvent.listener2(){}
+    @Listener
+    suspend fun FriendMessageEvent.listener3(context: EventListenerProcessingContext){}
     
     @Listener
-    fun myListener2(foo: Foo) = buildSimpleListener(FriendMessageEvent) {
-        match { true }
-        handle {
-            println(foo)
-            EventResult.defaults()
-        }
-    }
-    
-    // @Bean
-    // fun defaultListener() = buildSimpleListener(FriendMessageEvent) {
-    //     match { true }
-    //     handle {
-    //         EventResult.defaults()
-    //     }
-    // }
+    fun listener4(){}
+    @Listener
+    fun FriendMessageEvent.listener5(){}
+    @Listener
+    fun FriendMessageEvent.listener6(context: EventListenerProcessingContext){}
 }
 
+@Listener
+suspend fun listener1(){}
+@Listener
+suspend fun FriendMessageEvent.listener2(){}
+@Listener
+suspend fun FriendMessageEvent.listener3(context: EventListenerProcessingContext){}
 
-@Component
-open class Foo {
-    @Listener
-    fun myListener() {
-    
-    }
-    
-    @Listener
-    fun myListener2() = buildSimpleListener(FriendMessageEvent) {
-        match { true }
-        handle {
-            EventResult.defaults()
-        }
-    }
-    
-    /*
-    ========
-    definition: Root bean: class [null]; scope=; abstract=false; lazyInit=null; autowireMode=3; dependencyCheck=0; autowireCandidate=true; primary=false; factoryBeanName=foo; factoryMethodName=getBar; initMethodName=null; destroyMethodName=(inferred); defined in class path resource [love/forli/test/spring/Foo.class]
-    definition.beanClassName: null
-    definition.resolvableType: ?
-    definition.parentName: null
-    definition.factoryBeanName: foo
-    definition.factoryMethodName: getBar
-    ========
-     */
-    
-    @Bean
-    fun getTar() = Tar()
-    
-    @Bean
-    fun getBar(tar: Tar) = Bar(tar)
-}
-
-open class Bar(val tar: Tar)
-open class Tar
+@Listener
+fun listener4(){}
+@Listener
+fun FriendMessageEvent.listener5(){}
+@Listener
+fun FriendMessageEvent.listener6(context: EventListenerProcessingContext){}

--- a/simbot-boots/simboot-core-spring-boot-starter/src/test/kotlin/love/forli/test/spring/SpringBootApplicationTest.kt
+++ b/simbot-boots/simboot-core-spring-boot-starter/src/test/kotlin/love/forli/test/spring/SpringBootApplicationTest.kt
@@ -1,5 +1,7 @@
 package love.forli.test.spring
 
+import love.forte.simboot.annotation.ContentTrim
+import love.forte.simboot.annotation.Filter
 import love.forte.simboot.annotation.Listener
 import love.forte.simboot.spring.autoconfigure.EnableSimbot
 import love.forte.simbot.application.Application
@@ -45,30 +47,62 @@ open class SpringBootApplicationTest {
 @Component
 open class Listeners {
     @Listener
-    suspend fun listener1(){}
-    @Listener
-    suspend fun FriendMessageEvent.listener2(){}
-    @Listener
-    suspend fun FriendMessageEvent.listener3(context: EventListenerProcessingContext){}
+    suspend fun listener1() {
+    }
     
     @Listener
-    fun listener4(){}
+    @ContentTrim
+    suspend fun FriendMessageEvent.listener2() {
+    }
+    
     @Listener
-    fun FriendMessageEvent.listener5(){}
+    @Filter("Hello")
+    @Filter("Hello World")
+    suspend fun FriendMessageEvent.listener3(context: EventListenerProcessingContext) {
+    }
+    
     @Listener
-    fun FriendMessageEvent.listener6(context: EventListenerProcessingContext){}
+    fun listener4() {
+    }
+    
+    @Listener
+    @ContentTrim
+    fun FriendMessageEvent.listener5() {
+    }
+    
+    @Listener
+    @Filter("Hello")
+    @Filter("Hello World")
+    fun FriendMessageEvent.listener6(context: EventListenerProcessingContext) {
+    }
 }
 
 @Listener
-suspend fun listener1(){}
-@Listener
-suspend fun FriendMessageEvent.listener2(){}
-@Listener
-suspend fun FriendMessageEvent.listener3(context: EventListenerProcessingContext){}
+suspend fun listener1() {
+}
 
 @Listener
-fun listener4(){}
+@ContentTrim
+suspend fun FriendMessageEvent.listener2() {
+}
+
 @Listener
-fun FriendMessageEvent.listener5(){}
+@Filter("Hello")
+@Filter("Hello World")
+suspend fun FriendMessageEvent.listener3(context: EventListenerProcessingContext) {
+}
+
 @Listener
-fun FriendMessageEvent.listener6(context: EventListenerProcessingContext){}
+fun listener4() {
+}
+
+@Listener
+@ContentTrim
+fun FriendMessageEvent.listener5() {
+}
+
+@Listener
+@Filter("Hello")
+@Filter("Hello World")
+fun FriendMessageEvent.listener6(context: EventListenerProcessingContext) {
+}

--- a/simbot-boots/simboot-core/src/main/kotlin/love/forte/simboot/core/listener/KFunctionListenerProcessor.kt
+++ b/simbot-boots/simboot-core/src/main/kotlin/love/forte/simboot/core/listener/KFunctionListenerProcessor.kt
@@ -97,23 +97,25 @@ public class KFunctionListenerProcessor(
         
         // filters
         val filters = function.filters(listener, listenerAttributeMap, context)
-        logger.debug("Size of resolved listener filters: {}", filters.size)
-        if (filters.isNotEmpty()) {
-            logger.debug("Resolved listener filters: {}", filters)
-        }
         
         // interceptors
         val interceptors: List<EventListenerInterceptorRelativeToFilter> = function.interceptors(context)
-        logger.debug("Size of resolved listener interceptors: {}", interceptors.size)
-        if (interceptors.isNotEmpty()) {
-            logger.debug("Resolved listener interceptors: {}", interceptors)
-        }
         
         // preparers
         val preparers = function.preparers(context)
-        logger.debug("Size of resolved listener preparers: {}", preparers.size)
-        if (preparers.isNotEmpty()) {
-            logger.debug("Resolved listener preparers: {}", preparers)
+        
+        // logger
+        logger.debug("The size of resolved listener filters: {}, interceptors: {}, preparers: {}", filters.size, interceptors.size, preparers.size)
+        if (logger.isDebugEnabled) {
+            if (filters.isNotEmpty()) {
+                logger.debug("Resolved listener filters: {}", filters)
+            }
+            if (interceptors.isNotEmpty()) {
+                logger.debug("Resolved listener interceptors: {}", interceptors)
+            }
+            if (preparers.isNotEmpty()) {
+                logger.debug("Resolved listener preparers: {}", preparers)
+            }
         }
         
         var resolvedListener: EventListener = listener
@@ -318,13 +320,13 @@ public class KFunctionListenerProcessor(
             bindList.sortBy { it.priority }
             bindSpareList.sortBy { it.priority }
             
-            logger.debug(
+            logger.trace(
                 "There are actually {} normal binders bound to parameter [{}]. the binders: {}",
                 bindList.size,
                 parameter,
                 bindList
             )
-            logger.debug(
+            logger.trace(
                 "There are actually {} spare binders bound to parameter [{}]. the binders: {}",
                 bindSpareList.size,
                 parameter,


### PR DESCRIPTION
在使用 Spring Boot Starter 的时候，对于监听函数、binder等需要解析注解的情况下，优先使用Spring中所提供的 AnnotationUtils 来进行注解解析而不是 KAnnotationTool 。