### PR TITLE
⚠ 变更与 `Bot` 相关内容的包路径

### DIFF
--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/application/Application.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/application/Application.kt
@@ -19,6 +19,7 @@ package love.forte.simbot.application
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.serialization.modules.SerializersModule
 import love.forte.simbot.*
+import love.forte.simbot.bot.BotManager
 import love.forte.simbot.event.EventListenerManager
 import love.forte.simbot.utils.runInBlocking
 

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/application/ApplicationFactory.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/application/ApplicationFactory.kt
@@ -16,8 +16,8 @@
 
 package love.forte.simbot.application
 
-import love.forte.simbot.Bot
-import love.forte.simbot.BotVerifyInfo
+import love.forte.simbot.bot.Bot
+import love.forte.simbot.bot.BotVerifyInfo
 import love.forte.simbot.Component
 import love.forte.simbot.ComponentFactory
 import love.forte.simbot.ability.CompletionPerceivable

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/application/EventProviderFactory.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/application/EventProviderFactory.kt
@@ -19,7 +19,7 @@
 package love.forte.simbot.application
 
 import love.forte.simbot.Attribute
-import love.forte.simbot.BotManager
+import love.forte.simbot.bot.BotManager
 import love.forte.simbot.Component
 import love.forte.simbot.ComponentAutoRegistrarFactory
 import love.forte.simbot.ability.Survivable

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/bot/Bot.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/bot/Bot.kt
@@ -14,12 +14,13 @@
  *
  */
 
-package love.forte.simbot
+package love.forte.simbot.bot
 
 import kotlinx.coroutines.CompletionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
+import love.forte.simbot.*
 import love.forte.simbot.ability.Survivable
 import love.forte.simbot.definition.User
 import love.forte.simbot.definition.UserInfo

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/bot/BotContainers.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/bot/BotContainers.kt
@@ -14,8 +14,10 @@
  *
  */
 
-package love.forte.simbot
+package love.forte.simbot.bot
 
+import love.forte.simbot.Api4J
+import love.forte.simbot.ID
 import love.forte.simbot.definition.*
 import love.forte.simbot.utils.item.Items
 

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/bot/BotManager.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/bot/BotManager.kt
@@ -14,8 +14,9 @@
  *
  */
 
-package love.forte.simbot
+package love.forte.simbot.bot
 
+import love.forte.simbot.*
 import love.forte.simbot.application.EventProvider
 
 

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/bot/BotVerifyInfo.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/bot/BotVerifyInfo.kt
@@ -14,7 +14,7 @@
  *
  */
 
-package love.forte.simbot
+package love.forte.simbot.bot
 
 import com.charleskorn.kaml.Yaml
 import com.charleskorn.kaml.YamlConfiguration
@@ -23,6 +23,8 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonBuilder
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.properties.Properties
+import love.forte.simbot.ExperimentalSimbotApi
+import love.forte.simbot.LoggerFactory
 import love.forte.simbot.resources.DeserializableResource
 import love.forte.simbot.resources.DeserializableResourceDecoder
 import love.forte.simbot.resources.SerialFormatDeserializableResourceDecoder
@@ -174,7 +176,7 @@ public sealed class StandardBotVerifyInfoDecoderFactory<C : Any, D : BotVerifyIn
     BotVerifyInfoDecoderFactory<C, D> {
 
     public companion object {
-        private val logger: Logger = LoggerFactory.getLogger("love.forte.simbot.StandardBotVerifyInfoDecoderFactory")
+        private val logger: Logger = LoggerFactory.getLogger("love.forte.simbot.bot.StandardBotVerifyInfoDecoderFactory")
 
         /**
          * 支持`Json`格式的bot配置文件。

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/bot/BotVerifyInfos.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/bot/BotVerifyInfos.kt
@@ -16,9 +16,10 @@
 
 @file:JvmName("BotVerifyInfos")
 
-package love.forte.simbot
+package love.forte.simbot.bot
 
 import kotlinx.serialization.DeserializationStrategy
+import love.forte.simbot.NoSuchComponentException
 import love.forte.simbot.resources.Resource
 import java.io.InputStream
 import java.net.URL

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/bot/OriginBotManager.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/bot/OriginBotManager.kt
@@ -14,9 +14,10 @@
  *
  */
 
-package love.forte.simbot
+package love.forte.simbot.bot
 
-import love.forte.simbot.OriginBotManager.cancel
+import love.forte.simbot.*
+import love.forte.simbot.bot.OriginBotManager.cancel
 import love.forte.simbot.utils.runInBlocking
 import java.util.*
 import java.util.concurrent.locks.ReentrantReadWriteLock
@@ -163,7 +164,7 @@ public object OriginBotManager : Set<BotManager<*>> {
      */
     @Deprecated(
         "Use getManagers(String)",
-        ReplaceWith("getManagers(componentId.literal)", "love.forte.simbot.OriginBotManager.getManagers")
+        ReplaceWith("getManagers(componentId.literal)", "love.forte.simbot.bot.OriginBotManager.getManagers")
     )
     public fun getManagers(componentId: ID): List<BotManager<*>> = getManagers(componentId.literal)
     
@@ -198,7 +199,7 @@ public object OriginBotManager : Set<BotManager<*>> {
     @Deprecated(
         "Use getFirstManagerOrNull(String)", ReplaceWith(
             "getFirstManagerOrNull(componentId.literal)",
-            "love.forte.simbot.OriginBotManager.getFirstManagerOrNull"
+            "love.forte.simbot.bot.OriginBotManager.getFirstManagerOrNull"
         )
     )
     public fun getFirstManager(componentId: ID): BotManager<*>? = getFirstManagerOrNull(componentId.literal)
@@ -247,7 +248,7 @@ public object OriginBotManager : Set<BotManager<*>> {
     @Deprecated(
         "Use getBot(ID, String?)", ReplaceWith(
             "getBotOrNull(id, componentId?.literal)",
-            "love.forte.simbot.OriginBotManager.getBotOrNull"
+            "love.forte.simbot.bot.OriginBotManager.getBotOrNull"
         )
     )
     public fun getBot(id: ID, componentId: ID? = null): Bot? = getBotOrNull(id, componentId?.literal)

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Contact.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Contact.kt
@@ -17,7 +17,7 @@
 package love.forte.simbot.definition
 
 import love.forte.simbot.Api4J
-import love.forte.simbot.Bot
+import love.forte.simbot.bot.Bot
 import love.forte.simbot.action.SendSupport
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.MessageReceipt

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Container.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Container.kt
@@ -17,7 +17,7 @@
 package love.forte.simbot.definition
 
 import love.forte.simbot.Api4J
-import love.forte.simbot.Bot
+import love.forte.simbot.bot.Bot
 import love.forte.simbot.ID
 import love.forte.simbot.resources.Resource
 

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Friend.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Friend.kt
@@ -16,7 +16,7 @@
 
 package love.forte.simbot.definition
 
-import love.forte.simbot.Bot
+import love.forte.simbot.bot.Bot
 import love.forte.simbot.Grouping
 import love.forte.simbot.ID
 

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Member.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Member.kt
@@ -18,7 +18,7 @@ package love.forte.simbot.definition
 
 import kotlinx.coroutines.flow.firstOrNull
 import love.forte.simbot.Api4J
-import love.forte.simbot.Bot
+import love.forte.simbot.bot.Bot
 import love.forte.simbot.ID
 import love.forte.simbot.Timestamp
 import love.forte.simbot.action.MuteSupport

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Objective.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Objective.kt
@@ -17,7 +17,7 @@
 package love.forte.simbot.definition
 
 import love.forte.simbot.Api4J
-import love.forte.simbot.Bot
+import love.forte.simbot.bot.Bot
 import love.forte.simbot.ID
 import love.forte.simbot.action.SendSupport
 import love.forte.simbot.action.sendIfSupport

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/OrganizationBot.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/OrganizationBot.kt
@@ -17,7 +17,7 @@
 package love.forte.simbot.definition
 
 import love.forte.simbot.Api4J
-import love.forte.simbot.Bot
+import love.forte.simbot.bot.Bot
 
 
 /**

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Stranger.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Stranger.kt
@@ -16,7 +16,7 @@
 
 package love.forte.simbot.definition
 
-import love.forte.simbot.Bot
+import love.forte.simbot.bot.Bot
 import love.forte.simbot.ID
 
 

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/User.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/User.kt
@@ -18,7 +18,7 @@
 
 package love.forte.simbot.definition
 
-import love.forte.simbot.Bot
+import love.forte.simbot.bot.Bot
 import love.forte.simbot.ID
 
 /**

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/ContinuousSessionContext.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/ContinuousSessionContext.kt
@@ -1,7 +1,7 @@
 /*
  *  Copyright (c) 2021-2022 ForteScarlet <ForteScarlet@163.com>
  *
- *  本文件是 simply-robot (即 simple robot的v3版本，因此亦可称为 simple-robot v3 、simbot v3 等) 的一部分。
+ *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
  *
  *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
  *
@@ -12,7 +12,6 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
- *
  */
 
 package love.forte.simbot.event
@@ -21,7 +20,7 @@ import kotlinx.coroutines.*
 import love.forte.simbot.Api4J
 import love.forte.simbot.ExperimentalSimbotApi
 import love.forte.simbot.JavaDuration
-import love.forte.simbot.isNotMe
+import love.forte.simbot.bot.isNotMe
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.MessageContent
 import love.forte.simbot.utils.randomIdStr

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/Event.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/Event.kt
@@ -18,6 +18,7 @@
 package love.forte.simbot.event
 
 import love.forte.simbot.*
+import love.forte.simbot.bot.Bot
 import love.forte.simbot.definition.BotContainer
 import love.forte.simbot.definition.IDContainer
 import love.forte.simbot.event.Event.Key.Companion.getKey

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/FriendChangedEvent.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/FriendChangedEvent.kt
@@ -17,7 +17,7 @@
 package love.forte.simbot.event
 
 import love.forte.simbot.Api4J
-import love.forte.simbot.Bot
+import love.forte.simbot.bot.Bot
 import love.forte.simbot.definition.Friend
 import love.forte.simbot.message.doSafeCast
 

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/MessageEvents.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/MessageEvents.kt
@@ -17,7 +17,7 @@
 package love.forte.simbot.event
 
 import love.forte.simbot.Api4J
-import love.forte.simbot.Bot
+import love.forte.simbot.bot.Bot
 import love.forte.simbot.ID
 import love.forte.simbot.action.ReplySupport
 import love.forte.simbot.action.SendSupport

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/ObjectiveEvents.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/ObjectiveEvents.kt
@@ -17,7 +17,7 @@
 package love.forte.simbot.event
 
 import love.forte.simbot.Api4J
-import love.forte.simbot.Bot
+import love.forte.simbot.bot.Bot
 import love.forte.simbot.definition.*
 import love.forte.simbot.message.doSafeCast
 

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/RequestEvents.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/RequestEvents.kt
@@ -18,7 +18,7 @@ package love.forte.simbot.event
 
 import kotlinx.coroutines.launch
 import love.forte.simbot.Api4J
-import love.forte.simbot.Bot
+import love.forte.simbot.bot.Bot
 import love.forte.simbot.ExperimentalSimbotApi
 import love.forte.simbot.ID
 import love.forte.simbot.definition.*

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/internal/InternalBotEvent.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/internal/InternalBotEvent.kt
@@ -16,7 +16,7 @@
 
 package love.forte.simbot.event.internal
 
-import love.forte.simbot.Bot
+import love.forte.simbot.bot.Bot
 import love.forte.simbot.ID
 import love.forte.simbot.definition.BotContainer
 import love.forte.simbot.message.doSafeCast

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/internal/InternalEvent.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/internal/InternalEvent.kt
@@ -16,7 +16,7 @@
 
 package love.forte.simbot.event.internal
 
-import love.forte.simbot.Bot
+import love.forte.simbot.bot.Bot
 import love.forte.simbot.CharSequenceID
 import love.forte.simbot.ID
 import love.forte.simbot.event.Event

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/message/MessagesBuilder.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/message/MessagesBuilder.kt
@@ -17,7 +17,7 @@
 package love.forte.simbot.message
 
 import love.forte.simbot.Api4J
-import love.forte.simbot.Bot
+import love.forte.simbot.bot.Bot
 import love.forte.simbot.ID
 import love.forte.simbot.message.Image.Key.toImage
 import love.forte.simbot.resources.Resource

--- a/simbot-apis/simbot-api/src/test/java/DelayScopeTest.java
+++ b/simbot-apis/simbot-api/src/test/java/DelayScopeTest.java
@@ -1,6 +1,6 @@
 import kotlin.coroutines.CoroutineContext;
 import kotlin.coroutines.EmptyCoroutineContext;
-import love.forte.simbot.Bot;
+import love.forte.simbot.bot.Bot;
 import love.forte.simbot.ability.DelayableCompletableFuture;
 import love.forte.simbot.ability.DelayableCoroutineScope;
 import org.jetbrains.annotations.NotNull;

--- a/simbot-apis/simbot-api/src/test/kotlin/BotVerifyInfoPropertySerializerTest.kt
+++ b/simbot-apis/simbot-api/src/test/kotlin/BotVerifyInfoPropertySerializerTest.kt
@@ -14,8 +14,8 @@
  *
  */
 
-import love.forte.simbot.StandardBotVerifyInfoDecoderFactory
-import love.forte.simbot.toBotVerifyInfo
+import love.forte.simbot.bot.StandardBotVerifyInfoDecoderFactory
+import love.forte.simbot.bot.toBotVerifyInfo
 import kotlin.test.Test
 
 

--- a/simbot-boots/simboot-api/src/main/kotlin/love/forte/simboot/factory/BeanContainerFactory.kt
+++ b/simbot-boots/simboot-api/src/main/kotlin/love/forte/simboot/factory/BeanContainerFactory.kt
@@ -18,8 +18,8 @@ package love.forte.simboot.factory
 
 import love.forte.di.BeanContainer
 import love.forte.simboot.Configuration
-import love.forte.simbot.Bot
-import love.forte.simbot.BotManager
+import love.forte.simbot.bot.Bot
+import love.forte.simbot.bot.BotManager
 
 /**
  *

--- a/simbot-boots/simboot-api/src/main/kotlin/love/forte/simboot/factory/BotRegistrarFactory.kt
+++ b/simbot-boots/simboot-api/src/main/kotlin/love/forte/simboot/factory/BotRegistrarFactory.kt
@@ -16,7 +16,7 @@
 
 package love.forte.simboot.factory
 
-import love.forte.simbot.BotRegistrar
+import love.forte.simbot.bot.BotRegistrar
 import love.forte.simbot.event.EventProcessor
 
 /**

--- a/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/SimbotSpringBootBotAutoRegisterBuildConfigure.kt
+++ b/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/SimbotSpringBootBotAutoRegisterBuildConfigure.kt
@@ -20,6 +20,10 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import love.forte.simboot.spring.autoconfigure.application.SpringBootApplicationBuilder
 import love.forte.simboot.spring.autoconfigure.application.SpringBootApplicationConfiguration
 import love.forte.simbot.*
+import love.forte.simbot.bot.BotVerifyInfo
+import love.forte.simbot.bot.BotVerifyInfoDecoderFactory
+import love.forte.simbot.bot.StandardBotVerifyInfoDecoderFactory
+import love.forte.simbot.bot.toBotVerifyInfo
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver
 import java.io.FileNotFoundException

--- a/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/application/SpringBootApplicationConfiguration.kt
+++ b/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/application/SpringBootApplicationConfiguration.kt
@@ -19,7 +19,7 @@ package love.forte.simboot.spring.autoconfigure.application
 import love.forte.simboot.core.application.BootApplicationConfiguration
 import love.forte.simboot.core.application.BootApplicationConfiguration.Companion.DEFAULT_BOT_VERIFY_GLOB
 import love.forte.simboot.listener.ParameterBinderFactory
-import love.forte.simbot.Bot
+import love.forte.simbot.bot.Bot
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.boot.ApplicationArguments

--- a/simbot-boots/simboot-core/src/main/kotlin/love/forte/simboot/core/application/BootApplication.kt
+++ b/simbot-boots/simboot-core/src/main/kotlin/love/forte/simboot/core/application/BootApplication.kt
@@ -37,6 +37,10 @@ import love.forte.simboot.listener.ParameterBinderFactory
 import love.forte.simbot.*
 import love.forte.simbot.application.*
 import love.forte.simbot.application.BotRegistrar
+import love.forte.simbot.bot.BotVerifyInfoDecoder
+import love.forte.simbot.bot.BotVerifyInfoDecoderFactory
+import love.forte.simbot.bot.StandardBotVerifyInfoDecoderFactory
+import love.forte.simbot.bot.toBotVerifyInfo
 import love.forte.simbot.core.application.*
 import love.forte.simbot.core.event.EventInterceptorsGenerator
 import love.forte.simbot.core.event.EventListenersGenerator

--- a/simbot-cores/simbot-core/src/main/kotlin/love/forte/simbot/core/application/BaseApplicationBuilder.kt
+++ b/simbot-cores/simbot-core/src/main/kotlin/love/forte/simbot/core/application/BaseApplicationBuilder.kt
@@ -21,6 +21,10 @@ import love.forte.simbot.*
 import love.forte.simbot.ability.CompletionPerceivable
 import love.forte.simbot.application.*
 import love.forte.simbot.application.BotRegistrar
+import love.forte.simbot.bot.Bot
+import love.forte.simbot.bot.BotManager
+import love.forte.simbot.bot.BotVerifyInfo
+import love.forte.simbot.bot.ComponentMismatchException
 import love.forte.simbot.event.EventProcessor
 import love.forte.simbot.utils.view
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -210,7 +214,7 @@ public abstract class BaseApplicationBuilder<A : Application> :
         override fun register(botVerifyInfo: BotVerifyInfo): Bot? {
             logger.info("Registering bot with verify info [{}]", botVerifyInfo)
             for (manager in providers) {
-                if (manager !is love.forte.simbot.BotRegistrar) {
+                if (manager !is love.forte.simbot.bot.BotRegistrar) {
                     continue
                 }
                 

--- a/simbot-cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleListenerManagerConfiguration.kt
+++ b/simbot-cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleListenerManagerConfiguration.kt
@@ -171,6 +171,7 @@ public open class SimpleListenerManagerConfiguration {
     /**
      * 进入到拦截器配置域。
      */
+    @OptIn(InternalSimbotApi::class)
     @Suppress("MemberVisibilityCanBePrivate")
     public fun interceptors(): EventInterceptorsGenerator = EventInterceptorsGenerator()
     
@@ -224,6 +225,7 @@ public open class SimpleListenerManagerConfiguration {
     /**
      * 进入到监听函数配置域。
      */
+    @OptIn(InternalSimbotApi::class)
     private fun listeners(): EventListenersGenerator = EventListenersGenerator()
     
     // endregion


### PR DESCRIPTION
变更涉及到 `Bot` 相关内容的包路径。涉及内容有：


| 原路径                                                          | 调整后                                                            |
|--------------------------------------------------------------|----------------------------------------------------------------|
| `love.forte.simbot.BotInfo`                                  | love.forte.simbot.bot.BotInfo                                  |
| `love.forte.simbot.Bot`                                      | love.forte.simbot.bot.Bot                                      |
| `love.forte.simbot.SocialRelationsContainer`                 | love.forte.simbot.definition.SocialRelationsContainer                 |
| `love.forte.simbot.FriendsContainer`                         | love.forte.simbot.definition.FriendsContainer                         |
| `love.forte.simbot.ContactsContainer`                        | love.forte.simbot.definition.ContactsContainer                        |
| `love.forte.simbot.GroupsContainer`                          | love.forte.simbot.definition.GroupsContainer                          |
| `love.forte.simbot.GuildsContainer`                          | love.forte.simbot.definition.GuildsContainer                          |
| `love.forte.simbot.BotRegistrar`                             | love.forte.simbot.bot.BotRegistrar                             |
| `love.forte.simbot.ComponentMismatchException`               | love.forte.simbot.bot.ComponentMismatchException               |
| `love.forte.simbot.VerifyFailureException`                   | love.forte.simbot.bot.VerifyFailureException                   |
| `love.forte.simbot.BotManager`                               | love.forte.simbot.bot.BotManager                               |
| `love.forte.simbot.BotAlreadyRegisteredException`            | love.forte.simbot.bot.BotAlreadyRegisteredException            |
| `love.forte.simbot.ComponentModel`                           | love.forte.simbot.bot.ComponentModel                           |
| `love.forte.simbot.BotVerifyInfo`                            | love.forte.simbot.bot.BotVerifyInfo                            |
| `love.forte.simbot.BotVerifyInfoDecoderFactory`              | love.forte.simbot.bot.BotVerifyInfoDecoderFactory              |
| `love.forte.simbot.BotVerifyInfoDecoder`                     | love.forte.simbot.bot.BotVerifyInfoDecoder                     |
| `love.forte.simbot.StandardBotVerifyInfoDecoderFactory`      | love.forte.simbot.bot.StandardBotVerifyInfoDecoderFactory      |
| `love.forte.simbot.StandardSerialFormatBotVerifyInfoDecoder` | love.forte.simbot.bot.StandardSerialFormatBotVerifyInfoDecoder |
| `love.forte.simbot.StandardStringFormatBotVerifyInfoDecoder` | love.forte.simbot.bot.StandardStringFormatBotVerifyInfoDecoder |
| `love.forte.simbot.StandardBinaryFormatBotVerifyInfoDecoder` | love.forte.simbot.bot.StandardBinaryFormatBotVerifyInfoDecoder |
| `love.forte.simbot.JsonBotVerifyInfoDecoder`                 | love.forte.simbot.bot.JsonBotVerifyInfoDecoder                 |
| `love.forte.simbot.YamlBotVerifyInfoDecoder`                 | love.forte.simbot.bot.YamlBotVerifyInfoDecoder                 |
| `love.forte.simbot.PropertiesBotVerifyInfoDecoder`           | love.forte.simbot.bot.PropertiesBotVerifyInfoDecoder           |
| `love.forte.simbot.DecoderBotVerifyInfo`                     | love.forte.simbot.bot.DecoderBotVerifyInfo                     |
| `love.forte.simbot.ByteArrayBotVerifyInfo`                   | love.forte.simbot.bot.ByteArrayBotVerifyInfo                   |
| `love.forte.simbot.OriginBotManager`                         | love.forte.simbot.bot.OriginBotManager                         |

