### PR TITLE
调整 `SocialRelationsContainer` 及其子接口的包路径

### DIFF
--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/bot/Bot.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/bot/Bot.kt
@@ -22,8 +22,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import love.forte.simbot.*
 import love.forte.simbot.ability.Survivable
-import love.forte.simbot.definition.User
-import love.forte.simbot.definition.UserInfo
+import love.forte.simbot.definition.*
 import love.forte.simbot.event.EventProcessor
 import love.forte.simbot.message.Image
 import love.forte.simbot.message.Image.Key.toImage

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/SocialRelationsContainers.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/SocialRelationsContainers.kt
@@ -14,7 +14,7 @@
  *
  */
 
-package love.forte.simbot.bot
+package love.forte.simbot.definition
 
 import love.forte.simbot.Api4J
 import love.forte.simbot.ID

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/SocialRelationsContainers.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/SocialRelationsContainers.kt
@@ -18,9 +18,8 @@ package love.forte.simbot.definition
 
 import love.forte.simbot.Api4J
 import love.forte.simbot.ID
-import love.forte.simbot.definition.*
 import love.forte.simbot.utils.item.Items
-
+import love.forte.simbot.bot.Bot
 
 /**
  * 社交关系容器。


### PR DESCRIPTION
由 `love.forte.simbot.bot.*` 变更为 `love.forte.simbot.definition.*`