### PR TITLE
为 `Organization`  提供对children的精准获取api

### DIFF
--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Group.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Group.kt
@@ -20,7 +20,6 @@ import love.forte.simbot.Api4J
 import love.forte.simbot.ID
 import love.forte.simbot.Timestamp
 import love.forte.simbot.utils.item.Items
-import love.forte.simbot.utils.runInBlocking
 
 
 /**
@@ -63,7 +62,7 @@ public interface Group : ChatRoom, GroupInfo {
      * 根据ID获取到指定的成员。
      */
     @Api4J
-    override fun getMember(id: ID): GroupMember? = runInBlocking { member(id) }
+    override fun getMember(id: ID): GroupMember?
     // endregion
     
 }

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Guild.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Guild.kt
@@ -20,7 +20,6 @@ import love.forte.simbot.Api4J
 import love.forte.simbot.ID
 import love.forte.simbot.Timestamp
 import love.forte.simbot.utils.item.Items
-import love.forte.simbot.utils.runInBlocking
 
 /**
  * 一个频道服务器，或者说一个集会。
@@ -59,13 +58,56 @@ public interface Guild : Organization, GuildInfo {
      * 根据ID查询指定的成员对象。
      */
     @Api4J
-    override fun getMember(id: ID): GuildMember? = runInBlocking { member(id) }
-    
+    override fun getMember(id: ID): GuildMember?
     
     /**
      * 频道服务器的子集为 [子频道][Channel] 序列。
      */
+    public val channels: Items<Channel>
+    
+    /**
+     * 尝试根据指定ID获取匹配的[子频道][Channel]。
+     *
+     * 未找到时得到null。
+     */
+    @JvmSynthetic
+    public suspend fun channel(id: ID): Channel?
+    
+    /**
+     * 尝试根据指定ID阻塞的获取匹配的[子频道][Channel]。
+     *
+     * 未找到时得到null。
+     */
+    @Api4J
+    public fun getChannel(id: ID): Channel?
+    
+    
+    /**
+     * 频道服务器的子集为 [子频道][Channel] 序列。
+     *
+     * @see channels
+     */
     override val children: Items<Channel>
+    
+    /**
+     * 尝试根据指定ID获取匹配的[子频道][Channel]。
+     *
+     * 未找到时得到null。
+     *
+     * @see channel
+     */
+    @JvmSynthetic
+    override suspend fun child(id: ID): Channel?
+    
+    /**
+     * 尝试根据指定ID阻塞的获取匹配的[子频道][Channel]。
+     *
+     * 未找到时得到null。
+     *
+     * @see getChannel
+     */
+    @Api4J
+    override fun getChild(id: ID): Channel?
 }
 
 

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Organization.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Organization.kt
@@ -133,7 +133,7 @@ public interface Organization : Objective, OrganizationInfo, MuteSupport, BotCon
      * 当然，也有可能不存在。不存在的时候，那么这个组织就是顶层。
      */
     @Api4J
-    public val previous: Organization? get() = runInBlocking { previous() }
+    public val previous: Organization?
     
     
     /**
@@ -142,6 +142,21 @@ public interface Organization : Objective, OrganizationInfo, MuteSupport, BotCon
      */
     public val children: Items<Organization>
     
+    /**
+     * 根据指定ID尝试获取一个匹配的下级[组织][Organization]。
+     *
+     * 当无法获取时得到null。
+     */
+    @JvmSynthetic
+    public suspend fun child(id: ID): Organization?
+    
+    /**
+     * 根据指定ID尝试阻塞的获取一个匹配的下级[组织][Organization]。
+     *
+     * 当无法获取时得到null。
+     */
+    @Api4J
+    public fun getChild(id: ID): Organization?
     
     /**
      * 获取当前组织中的成员列表。
@@ -160,7 +175,7 @@ public interface Organization : Objective, OrganizationInfo, MuteSupport, BotCon
      * 尝试通过ID获取一个成员，无法获取则得到null。
      */
     @Api4J
-    public fun getMember(id: ID): Member? = runInBlocking { member(id) }
+    public fun getMember(id: ID): Member?
     // endregion
     
     


### PR DESCRIPTION
为 `Organization` 的 `children` 提供额外的 `child(ID)`（`getChild(ID)`）来支持精准获取； 并且为 `Guild` 提供 `children` 同功能但是语义更清晰的 `channels` 相关api。

```kotiln
val org = ...
val child = org.child(123.ID)
```

```kotlin
val guild = ...
val channels = guild.channels // Items<Channel>
val channel = guild.channel(123.ID)
```