### PR TITLE
提高所有过时内容（`@Deprecated`）的过时等级为 `ERROR`

### DIFF
--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/Attribute.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/Attribute.kt
@@ -86,7 +86,7 @@ public class Attribute<T : Any> private constructor(
         
         
         @Suppress("UNUSED_PARAMETER")
-        @Deprecated("Use of(name)", ReplaceWith("of(name)"))
+        @Deprecated("Use of(name)", ReplaceWith("of(name)"), level = DeprecationLevel.ERROR)
         @JvmSynthetic
         public fun <T : Any> of(name: String, type: KClass<T>): Attribute<T> = of(name)
         
@@ -117,7 +117,7 @@ public class Attribute<T : Any> private constructor(
 
 @Suppress("UNUSED_PARAMETER")
 @JvmSynthetic
-@Deprecated("Use attribute(name)", ReplaceWith("attribute(name)"))
+@Deprecated("Use attribute(name)", ReplaceWith("attribute(name)"), level = DeprecationLevel.ERROR)
 public fun <T : Any> attribute(name: String, type: KClass<T>): Attribute<T> = attribute(name)
 
 /**
@@ -130,7 +130,7 @@ public fun <T : Any> attribute(name: String, type: KClass<T>): Attribute<T> = at
  */
 public fun <T : Any> attribute(name: String): Attribute<T> = Attribute.of(name)
 
-@Deprecated("Use attribute(name)", ReplaceWith("attribute(name)"))
+@Deprecated("Use attribute(name)", ReplaceWith("attribute(name)"), level = DeprecationLevel.ERROR)
 public inline fun <reified T : Any> attribute(): Attribute<T> =
     with(T::class) { Attribute.of(this.qualifiedName ?: this.simpleName ?: this.jvmName) }
 

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/Scope.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/Scope.kt
@@ -1,7 +1,7 @@
 /*
  *  Copyright (c) 2021-2022 ForteScarlet <ForteScarlet@163.com>
  *
- *  本文件是 simply-robot (即 simple robot的v3版本，因此亦可称为 simple-robot v3 、simbot v3 等) 的一部分。
+ *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
  *
  *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
  *
@@ -11,7 +11,6 @@
  *  https://www.gnu.org/licenses
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
- *
  *
  */
 
@@ -32,7 +31,7 @@ import love.forte.simbot.definition.IDContainer
  *
  * @author ForteScarlet
  */
-@Deprecated("No longer used")
+@Deprecated("No longer used", level = DeprecationLevel.ERROR)
 public interface Scope : IDContainer {
     
     /**
@@ -48,7 +47,7 @@ public interface Scope : IDContainer {
     /**
      * 判断提供的 [作用域][scope] 是否囊括在当前作用域范围内。
      */
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION_ERROR")
     public operator fun contains(scope: Scope): Boolean
     
 }
@@ -64,9 +63,9 @@ public interface Scope : IDContainer {
  *
  * @see love.forte.simbot.definition.Category
  */
-@Suppress("DEPRECATION")
+@Suppress("DEPRECATION_ERROR")
 @Serializable
-@Deprecated("No longer used, function replaced by Category", ReplaceWith("Category", "love.forte.simbot.definition.Category"))
+@Deprecated("No longer used, function replaced by Category", ReplaceWith("Category", "love.forte.simbot.definition.Category"), level = DeprecationLevel.ERROR)
 public open class Grouping(
     @Serializable(ID.AsCharSequenceIDSerializer::class)
     override val id: ID,

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/action/SendSupport.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/action/SendSupport.kt
@@ -174,7 +174,7 @@ public interface ReplySupport {
 /**
  * “回复”回执。
  */
-@Deprecated("No longer use")
+@Deprecated("No longer use", level = DeprecationLevel.ERROR)
 public interface MessageReplyReceipt : MessageReceipt {
     override val id: ID
     override val isSuccess: Boolean
@@ -223,7 +223,7 @@ public interface MessageReactSupport {
  * 对于标记回执的 [id][ReactReceipt.id]，有可能是这个回执所属ID，也有可能是被标记消息的ID。
  *
  */
-@Deprecated("No longer use")
+@Deprecated("No longer use", level = DeprecationLevel.ERROR)
 public interface ReactReceipt : MessageReceipt {
     override val id: ID
     override val isSuccess: Boolean
@@ -323,7 +323,7 @@ public suspend fun Event.replyIfSupport(message: String): MessageReceipt? =
  */
 @JvmSynthetic
 @Suppress("DeprecatedCallableAddReplaceWith")
-@Deprecated("ReplySupport通常由Event类型实现")
+@Deprecated("ReplySupport通常由Event类型实现", level = DeprecationLevel.ERROR)
 public suspend fun Objective.replyIfSupport(message: Message): MessageReceipt? =
     if (this is ReplySupport) reply(message) else null
 
@@ -333,7 +333,7 @@ public suspend fun Objective.replyIfSupport(message: Message): MessageReceipt? =
  */
 @JvmSynthetic
 @Suppress("DeprecatedCallableAddReplaceWith")
-@Deprecated("ReplySupport通常由Event类型实现")
+@Deprecated("ReplySupport通常由Event类型实现", level = DeprecationLevel.ERROR)
 public suspend fun MessageContainer.replyIfSupport(message: Message): MessageReceipt? =
     if (this is ReplySupport) reply(message) else null
 
@@ -342,7 +342,7 @@ public suspend fun MessageContainer.replyIfSupport(message: Message): MessageRec
  */
 @JvmSynthetic
 @Suppress("DeprecatedCallableAddReplaceWith")
-@Deprecated("ReplySupport通常由Event类型实现")
+@Deprecated("ReplySupport通常由Event类型实现", level = DeprecationLevel.ERROR)
 public suspend inline fun Objective.replyIfSupport(message: () -> Message): MessageReceipt? =
     if (this is ReplySupport) reply(message()) else null
 
@@ -352,7 +352,7 @@ public suspend inline fun Objective.replyIfSupport(message: () -> Message): Mess
  */
 @JvmSynthetic
 @Suppress("DeprecatedCallableAddReplaceWith")
-@Deprecated("ReplySupport通常由Event类型实现")
+@Deprecated("ReplySupport通常由Event类型实现", level = DeprecationLevel.ERROR)
 public suspend inline fun MessageContainer.replyIfSupport(message: () -> Message): MessageReceipt? =
     if (this is ReplySupport) reply(message()) else null
 
@@ -362,7 +362,7 @@ public suspend inline fun MessageContainer.replyIfSupport(message: () -> Message
  */
 @JvmSynthetic
 @Suppress("DeprecatedCallableAddReplaceWith")
-@Deprecated("ReplySupport通常由Event类型实现")
+@Deprecated("ReplySupport通常由Event类型实现", level = DeprecationLevel.ERROR)
 public suspend fun Objective.replyIfSupport(message: MessageContent): MessageReceipt? =
     if (this is ReplySupport) reply(message) else null
 
@@ -372,7 +372,7 @@ public suspend fun Objective.replyIfSupport(message: MessageContent): MessageRec
  */
 @JvmSynthetic
 @Suppress("DeprecatedCallableAddReplaceWith")
-@Deprecated("ReplySupport通常由Event类型实现")
+@Deprecated("ReplySupport通常由Event类型实现", level = DeprecationLevel.ERROR)
 public suspend fun MessageContainer.replyIfSupport(message: MessageContent): MessageReceipt? =
     if (this is ReplySupport) reply(message) else null
 
@@ -382,7 +382,7 @@ public suspend fun MessageContainer.replyIfSupport(message: MessageContent): Mes
  */
 @JvmSynthetic
 @Suppress("DeprecatedCallableAddReplaceWith")
-@Deprecated("ReplySupport通常由Event类型实现")
+@Deprecated("ReplySupport通常由Event类型实现", level = DeprecationLevel.ERROR)
 public suspend fun Objective.replyIfSupport(message: String): MessageReceipt? =
     if (this is ReplySupport) reply(message) else null
 
@@ -392,7 +392,7 @@ public suspend fun Objective.replyIfSupport(message: String): MessageReceipt? =
  */
 @JvmSynthetic
 @Suppress("DeprecatedCallableAddReplaceWith")
-@Deprecated("ReplySupport通常由Event类型实现")
+@Deprecated("ReplySupport通常由Event类型实现", level = DeprecationLevel.ERROR)
 public suspend fun MessageContainer.replyIfSupport(message: String): MessageReceipt? =
     if (this is ReplySupport) reply(message) else null
 //endregion

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/application/Application.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/application/Application.kt
@@ -66,7 +66,8 @@ public interface Application : CoroutineScope {
          */
         @Deprecated(
             "Use getComponentOrNull(String)",
-            ReplaceWith("getComponent(id.literal)", "love.forte.simbot.literal")
+            ReplaceWith("getComponent(id.literal)", "love.forte.simbot.literal"),
+            level = DeprecationLevel.ERROR
         )
         public fun getComponent(id: ID): Component = getComponent(id.literal)
         
@@ -75,7 +76,8 @@ public interface Application : CoroutineScope {
          */
         @Deprecated(
             "Use getComponentOrNull(String)",
-            ReplaceWith("getComponentOrNull(id.literal)", "love.forte.simbot.literal")
+            ReplaceWith("getComponentOrNull(id.literal)", "love.forte.simbot.literal"),
+            level = DeprecationLevel.ERROR
         )
         public fun getComponentOrNull(id: ID): Component? = getComponentOrNull(id.literal)
         

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/bot/Bot.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/bot/Bot.kt
@@ -109,7 +109,8 @@ public interface Bot : User, Survivable,
     @JvmSynthetic
     @Deprecated(
         "Just use Resource.toImage",
-        ReplaceWith("resource.toImage()", "love.forte.simbot.message.Image.Key.toImage")
+        ReplaceWith("resource.toImage()", "love.forte.simbot.message.Image.Key.toImage"),
+        level = DeprecationLevel.ERROR
     )
     public suspend fun uploadImage(resource: Resource): Image<*> = resource.toImage()
     
@@ -119,7 +120,11 @@ public interface Bot : User, Survivable,
      * @see uploadImage
      */
     @Api4J
-    @Deprecated("Just use Image.of(Resource)", ReplaceWith("resource.toImage()", "love.forte.simbot.message.Image.Key.toImage"))
+    @Deprecated(
+        "Just use Image.of(Resource)",
+        ReplaceWith("resource.toImage()", "love.forte.simbot.message.Image.Key.toImage"),
+        level = DeprecationLevel.ERROR
+    )
     public fun uploadImageBlocking(resource: Resource): Image<*> = resource.toImage()
     
     

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/bot/OriginBotManager.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/bot/OriginBotManager.kt
@@ -164,7 +164,8 @@ public object OriginBotManager : Set<BotManager<*>> {
      */
     @Deprecated(
         "Use getManagers(String)",
-        ReplaceWith("getManagers(componentId.literal)", "love.forte.simbot.bot.OriginBotManager.getManagers")
+        ReplaceWith("getManagers(componentId.literal)", "love.forte.simbot.bot.OriginBotManager.getManagers"),
+        level = DeprecationLevel.ERROR
     )
     public fun getManagers(componentId: ID): List<BotManager<*>> = getManagers(componentId.literal)
     
@@ -200,7 +201,8 @@ public object OriginBotManager : Set<BotManager<*>> {
         "Use getFirstManagerOrNull(String)", ReplaceWith(
             "getFirstManagerOrNull(componentId.literal)",
             "love.forte.simbot.bot.OriginBotManager.getFirstManagerOrNull"
-        )
+        ),
+        level = DeprecationLevel.ERROR
     )
     public fun getFirstManager(componentId: ID): BotManager<*>? = getFirstManagerOrNull(componentId.literal)
     
@@ -249,7 +251,7 @@ public object OriginBotManager : Set<BotManager<*>> {
         "Use getBot(ID, String?)", ReplaceWith(
             "getBotOrNull(id, componentId?.literal)",
             "love.forte.simbot.bot.OriginBotManager.getBotOrNull"
-        )
+        ), level = DeprecationLevel.ERROR
     )
     public fun getBot(id: ID, componentId: ID? = null): Bot? = getBotOrNull(id, componentId?.literal)
     

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Contact.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Contact.kt
@@ -52,7 +52,7 @@ public interface Contact : User, SendSupport, BotContainer {
      * 直接使用 [sendBlocking].
      */
     @Api4J
-    @Deprecated("Just use sendBlocking.", ReplaceWith("sendBlocking(message)"))
+    @Deprecated("Just use sendBlocking.", ReplaceWith("sendBlocking(message)"), level = DeprecationLevel.ERROR)
     override fun sendIfSupportBlocking(message: Message): MessageReceipt = sendBlocking(message)
     
 }

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Friend.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Friend.kt
@@ -48,10 +48,10 @@ public interface FriendInfo : UserInfo {
      *
      * @see category
      */
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION_ERROR")
     @Deprecated(
         "No longer used and will be removed. Please refer to 'love.forte.simbot.definition.Category'",
-        ReplaceWith("category", "love.forte.simbot.definition.Category")
+        ReplaceWith("category", "love.forte.simbot.definition.Category"), level = DeprecationLevel.ERROR
     )
     public val grouping: love.forte.simbot.Grouping get() = love.forte.simbot.Grouping.EMPTY
     

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Objective.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Objective.kt
@@ -79,7 +79,7 @@ public sealed interface Objective : BotContainer, IDContainer {
             "if (this is SendSupport) runInBlocking { send(message) } else null",
             "love.forte.simbot.action.SendSupport",
             "love.forte.simbot.utils.runInBlocking"
-        )
+        ), level = DeprecationLevel.ERROR
     )
     public fun sendIfSupportBlocking(message: Message): MessageReceipt? =
         if (this is SendSupport) runInBlocking { send(message) } else null

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Structured.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/Structured.kt
@@ -26,7 +26,7 @@ import love.forte.simbot.utils.runInBlocking
  *
  * @author ForteScarlet
  */
-@Deprecated("No longer use")
+@Deprecated("No longer use", level = DeprecationLevel.ERROR)
 public interface Structured<P, N> {
 
     /**

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/Event.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/Event.kt
@@ -88,8 +88,8 @@ public interface Event : BotContainer, IDContainer, ComponentContainer {
      * 此属性意义不大，未来可能会移除。
      *
      */
-    @Suppress("DEPRECATION")
-    @Deprecated("此属性意义不大，未来可能会移除。", ReplaceWith("VisibleScope.PUBLIC", "love.forte.simbot.event.Event.VisibleScope"))
+    @Suppress("DEPRECATION_ERROR")
+    @Deprecated("此属性意义不大，未来可能会移除。", ReplaceWith("VisibleScope.PUBLIC", "love.forte.simbot.event.Event.VisibleScope"), level = DeprecationLevel.ERROR)
     public val visibleScope: VisibleScope get() = VisibleScope.PUBLIC
 
 
@@ -256,7 +256,7 @@ public interface Event : BotContainer, IDContainer, ComponentContainer {
      *
      * _Deprecated: 含义不明确，缺少应用场景，未来可能会移除_
      */
-    @Deprecated("Ambiguous meaning, lack of application scenarios, may be removed in the future")
+    @Deprecated("Ambiguous meaning, lack of application scenarios, may be removed in the future", level = DeprecationLevel.ERROR)
     public enum class VisibleScope {
 
         /**
@@ -365,7 +365,7 @@ public fun <T : Event> KClass<T>.getKey(): Event.Key<T> = Event.Key.getKey(this)
  *
  */
 @Deprecated("Just use '... isSub ...'",
-    ReplaceWith("this isSub parentMaybe", "love.forte.simbot.event.Event.Key.Companion.isSub"))
+    ReplaceWith("this isSub parentMaybe", "love.forte.simbot.event.Event.Key.Companion.isSub"), level = DeprecationLevel.ERROR)
 public infix fun Event.Key<*>.isSubFrom(parentMaybe: Event.Key<*>): Boolean {
     return this isSub parentMaybe
 }

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/EventListenerManagers.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/EventListenerManagers.kt
@@ -34,7 +34,7 @@ public interface EventListenerContainer {
      */
     public operator fun get(id: String): EventListener?
     
-    @Deprecated("Just use get(String)", ReplaceWith("get(id.literal)", "love.forte.simbot.literal"))
+    @Deprecated("Just use get(String)", ReplaceWith("get(id.literal)", "love.forte.simbot.literal"), level = DeprecationLevel.ERROR)
     public operator fun get(id: ID): EventListener? = get(id.literal)
     
 }

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/EventProcessingContext.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/EventProcessingContext.kt
@@ -79,7 +79,7 @@ public interface EventProcessingContext : CoroutineContext.Element, InstantScope
      */
     @Deprecated(
         "Just use love.forte.simbot.core.scope.SimpleScope",
-        ReplaceWith("SimpleScope", "love.forte.simbot.core.scope.SimpleScope")
+        ReplaceWith("SimpleScope", "love.forte.simbot.core.scope.SimpleScope"), level = DeprecationLevel.ERROR
     )
     public object Scope {
         /**

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/MessageEvents.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/MessageEvents.kt
@@ -219,7 +219,7 @@ public interface ChatRoomMessageEvent : MessageEvent, OrganizationEvent, RemoteM
      * @see messageContent
      */
     @JvmSynthetic
-    @Deprecated("Use messageContent.delete()", ReplaceWith("messageContent.delete()"))
+    @Deprecated("Use messageContent.delete()", ReplaceWith("messageContent.delete()"), level = DeprecationLevel.ERROR)
     public suspend fun delete(): Boolean = messageContent.delete()
 
     /**
@@ -230,7 +230,7 @@ public interface ChatRoomMessageEvent : MessageEvent, OrganizationEvent, RemoteM
      * @see messageContent
      */
     @Api4J
-    @Deprecated("Use getMessageContent().deleteBlocking()", ReplaceWith("messageContent.deleteBlocking()"))
+    @Deprecated("Use getMessageContent().deleteBlocking()", ReplaceWith("messageContent.deleteBlocking()"), level = DeprecationLevel.ERROR)
     public fun deleteBlocking(): Boolean = messageContent.deleteBlocking()
 
     

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/message/BaseStandardMessage.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/message/BaseStandardMessage.kt
@@ -180,7 +180,7 @@ public data class At @JvmOverloads constructor(
     override val key: Message.Key<At> get() = Key
     
     
-    @Deprecated("Please use type", ReplaceWith("type"))
+    @Deprecated("Please use type", ReplaceWith("type"), level = DeprecationLevel.ERROR)
     public val atType: String get() = type
     
     override fun equals(other: Any?): Boolean {
@@ -357,8 +357,8 @@ public data class Face(
  * [RemoteResource] 代表一个携带 [url] 信息的远程资源。常见为文件或图片等形式。
  *
  */
-@Suppress("DEPRECATION")
-@Deprecated("Unused type")
+@Suppress("DEPRECATION_ERROR")
+@Deprecated("Unused type", level = DeprecationLevel.ERROR)
 public interface RemoteResource<E : RemoteResource<E>> : StandardMessage<E>, IDContainer {
     
     /**

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/message/MessageReceipt.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/message/MessageReceipt.kt
@@ -50,7 +50,7 @@ public interface MessageReceipt : IDContainer, DeleteSupport {
      * @return 删除成功为true，失败或不可删除均为null。
      */
     @Api4J
-    @Deprecated("Just use deleteBlocking()", ReplaceWith("deleteBlocking()"))
+    @Deprecated("Just use deleteBlocking()", ReplaceWith("deleteBlocking()"), level = DeprecationLevel.ERROR)
     public fun deleteIfSupportBlocking(): Boolean = deleteBlocking() // if (this is DeleteSupport) runInBlocking { delete() } else false
 }
 
@@ -63,5 +63,5 @@ public interface MessageReceipt : IDContainer, DeleteSupport {
  * @return 删除成功为true，失败或不可删除均为null。
  */
 @JvmSynthetic
-@Deprecated("Just use delete()", ReplaceWith("delete()"))
+@Deprecated("Just use delete()", ReplaceWith("delete()"), level = DeprecationLevel.ERROR)
 public suspend fun MessageReceipt.deleteIfSupport(): Boolean = delete()

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/message/Messages.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/message/Messages.kt
@@ -38,7 +38,7 @@ import love.forte.simbot.message.Message.Element as MsgElement
  *
  * @see Messages
  */
-@Deprecated("将会被弃用")
+@Deprecated("将会被弃用", level = DeprecationLevel.ERROR)
 public interface MessageElementPolymorphicRegistrar {
     public fun registrar(builderAction: PolymorphicModuleBuilder<MsgElement<*>>.() -> Unit)
 }
@@ -88,7 +88,7 @@ public sealed interface Messages : List<MsgElement<*>>, RandomAccess, Message {
     
     /**
      */
-    @Suppress("DEPRECATION")
+    @Suppress("DEPRECATION_ERROR")
     public companion object : MessageElementPolymorphicRegistrar {
         
         @JvmSynthetic
@@ -128,7 +128,7 @@ public sealed interface Messages : List<MsgElement<*>>, RandomAccess, Message {
          * 将 [Messages.serializersModule] 与目标 [serializersModule] 进行合并。
          */
         @Synchronized
-        @Deprecated("此方式的序列化将会被弃用")
+        @Deprecated("此方式的序列化将会被弃用", level = DeprecationLevel.ERROR)
         public fun mergeSerializersModule(serializersModule: SerializersModule) {
             _serializersModule += serializersModule
             setJson()
@@ -138,7 +138,7 @@ public sealed interface Messages : List<MsgElement<*>>, RandomAccess, Message {
          * 将 [Messages.serializersModule] 与目标 [serializersModule] 进行合并。
          */
         @Suppress("MemberVisibilityCanBePrivate")
-        @Deprecated("此方式的序列化将会被弃用")
+        @Deprecated("此方式的序列化将会被弃用", level = DeprecationLevel.ERROR)
         public fun mergeSerializersModule(builderAction: SerializersModuleBuilder.() -> Unit) {
             mergeSerializersModule(SerializersModule(builderAction))
         }
@@ -146,7 +146,7 @@ public sealed interface Messages : List<MsgElement<*>>, RandomAccess, Message {
         /**
          * 向 [serializersModule] 中注册一个 [MsgElement] 的多态信息。
          */
-        @Deprecated("此方式的序列化将会被弃用")
+        @Deprecated("此方式的序列化将会被弃用", level = DeprecationLevel.ERROR)
         public override fun registrar(builderAction: PolymorphicModuleBuilder<MsgElement<*>>.() -> Unit) {
             registrarPolymorphic(builderAction)
         }
@@ -216,7 +216,7 @@ public sealed interface Messages : List<MsgElement<*>>, RandomAccess, Message {
          */
         @Api4J
         @JvmStatic
-        @Deprecated("Use MessageSerializationUtil.")
+        @Deprecated("Use MessageSerializationUtil.", level = DeprecationLevel.ERROR)
         public fun toJsonString(messages: Messages): String {
             return json.encodeToString(serializer, messages)
         }
@@ -228,7 +228,7 @@ public sealed interface Messages : List<MsgElement<*>>, RandomAccess, Message {
          */
         @Api4J
         @JvmStatic
-        @Deprecated("Use MessageSerializationUtil.")
+        @Deprecated("Use MessageSerializationUtil.", level = DeprecationLevel.ERROR)
         public fun fromJsonString(jsonString: String): Messages {
             return json.decodeFromString(serializer, jsonString)
         }

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/message/MessagesBuilder.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/message/MessagesBuilder.kt
@@ -110,7 +110,7 @@ public class MessagesBuilder
      */
     @Suppress("UNUSED_PARAMETER", "RedundantSuspendModifier")
     @JvmSynthetic
-    @Deprecated("Just use image(resource, id)", ReplaceWith("image(resource)"))
+    @Deprecated("Just use image(resource, id)", ReplaceWith("image(resource)"), level = DeprecationLevel.ERROR)
     public suspend fun image(bot: Bot, resource: Resource): MessagesBuilder = image(resource)
     
     /**
@@ -138,7 +138,7 @@ public class MessagesBuilder
     @Api4J
     @JvmName("image")
     @Suppress("UNUSED_PARAMETER")
-    @Deprecated("Just use image(resource, id)", ReplaceWith("image(resource)"))
+    @Deprecated("Just use image(resource, id)", ReplaceWith("image(resource)"), level = DeprecationLevel.ERROR)
     public fun image4J(bot: Bot, resource: Resource): MessagesBuilder = image(resource)
     
     

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/utils/item/ItemsFactories.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/utils/item/ItemsFactories.kt
@@ -33,7 +33,7 @@ import kotlin.experimental.ExperimentalTypeInference
  *
  * @see itemsByFlow
  */
-@Deprecated("Use itemsByFlow(...)", ReplaceWith("itemsByFlow(flowFactory)"))
+@Deprecated("Use itemsByFlow(...)", ReplaceWith("itemsByFlow(flowFactory)"), level = DeprecationLevel.ERROR)
 public inline fun <T> CoroutineScope.items(crossinline flowFactory: (Items.PreprocessingProperties) -> Flow<T>): Items<T> {
     return itemsByFlow(flowFactory)
 }
@@ -43,7 +43,7 @@ public inline fun <T> CoroutineScope.items(crossinline flowFactory: (Items.Prepr
  *
  * @see flowItems
  */
-@Deprecated("Use flowItems(...)", ReplaceWith("flowItems(block)"))
+@Deprecated("Use flowItems(...)", ReplaceWith("flowItems(block)"), level = DeprecationLevel.ERROR)
 public inline fun <T> CoroutineScope.items(crossinline block: suspend FlowCollector<T>.(Items.PreprocessingProperties) -> Unit): Items<T> {
     return flowItems(block)
 }
@@ -68,7 +68,7 @@ public fun <T> itemsBy(factory: (Items.PreprocessingProperties) -> ChannelIterat
  *
  * @see produceItems
  */
-@Deprecated("Use produceItems", ReplaceWith("produceItems(context, capacity, block)"))
+@Deprecated("Use produceItems", ReplaceWith("produceItems(context, capacity, block)"), level = DeprecationLevel.ERROR)
 public inline fun <T> CoroutineScope.items(
     context: CoroutineContext = EmptyCoroutineContext,
     capacity: Int = 0,

--- a/simbot-boots/simboot-core-annotation/src/main/kotlin/love/forte/simboot/annotation/AnnotationEventFilterFactory.kt
+++ b/simbot-boots/simboot-core-annotation/src/main/kotlin/love/forte/simboot/annotation/AnnotationEventFilterFactory.kt
@@ -61,14 +61,14 @@ public interface AnnotationEventFilterFactory {
  * @see BlockingAnnotationEventFilter
  * @author ForteScarlet
  */
-@Deprecated("Unused")
+@Deprecated("TODO")
 @Suppress("KDocUnresolvedReference")
 public interface AnnotationEventFilter : EventFilter {
     
     public fun init(listener: EventListener, filter: Filter, filters: Filters)
     
     
-    @Deprecated("Unused")
+    @Deprecated("TODO")
     public enum class InitType {
         INDEPENDENT,
         UNITED
@@ -89,7 +89,7 @@ public interface AnnotationEventFilter : EventFilter {
  *
  */
 @Suppress("DEPRECATION")
-@Deprecated("Unused")
+@Deprecated("TODO")
 @Api4J
 public interface BlockingAnnotationEventFilter : AnnotationEventFilter, BlockingEventFilter {
     

--- a/simbot-boots/simboot-core-annotation/src/main/kotlin/love/forte/simboot/annotation/Filter.kt
+++ b/simbot-boots/simboot-core-annotation/src/main/kotlin/love/forte/simboot/annotation/Filter.kt
@@ -112,8 +112,8 @@ public annotation class Filter(
      *
      * @see [targets]
      */
-    @Suppress("DEPRECATION")
-    @Deprecated("Use targets", ReplaceWith("targets"))
+    @Suppress("DEPRECATION_ERROR")
+    @Deprecated("Use targets", ReplaceWith("targets"), level = DeprecationLevel.ERROR)
     val target: TargetFilter = TargetFilter(),
     
     /*
@@ -259,7 +259,7 @@ public annotation class Filter(
 @Target(allowedTargets = [])
 @Deprecated(
     "Use @Filter.Target",
-    ReplaceWith("Filter.Targets", "love.forte.simboot.annotation.Filter.Targets")
+    ReplaceWith("Filter.Targets", "love.forte.simboot.annotation.Filter.Targets"), level = DeprecationLevel.ERROR
 )
 public annotation class TargetFilter(
     /**

--- a/simbot-boots/simboot-core/src/main/kotlin/love/forte/simboot/core/SimbootApp.kt
+++ b/simbot-boots/simboot-core/src/main/kotlin/love/forte/simboot/core/SimbootApp.kt
@@ -232,7 +232,7 @@ private inline fun preStack(className: String, methodName: String, inlineMark: (
 /**
  * @see simbootApp
  */
-@Deprecated("Use top-level fun simbootApp(...)", ReplaceWith("simbootApp<T>(args = args, configurator)"))
+@Deprecated("Use top-level fun simbootApp(...)", ReplaceWith("simbootApp<T>(args = args, configurator)"), level = DeprecationLevel.ERROR)
 public suspend inline operator fun <reified T> SimbootApp.invoke(
     vararg args: String,
     crossinline configurator: BootApplicationConfiguration.() -> Unit = {},

--- a/simbot-boots/simboot-core/src/main/kotlin/love/forte/simboot/core/filter/CoreAnnotationEventFilterFactory.kt
+++ b/simbot-boots/simboot-core/src/main/kotlin/love/forte/simboot/core/filter/CoreAnnotationEventFilterFactory.kt
@@ -40,10 +40,10 @@ public object CoreAnnotationEventFilterFactory : AnnotationEventFilterFactory {
         val value = filter.value
         var target = filter.targets.box()
         if (target == null) {
-            @Suppress("DEPRECATION")
+            @Suppress("DEPRECATION_ERROR")
             target = filter.target.box0()
             if (target != null) {
-                logger.warn("The @Filter(target = TargetFilter(...)) is deprecated. please use the @Filter(targets = Filter.Targets(...)).")
+                throw UnsupportedOperationException("The @Filter(target = TargetFilter(...)) is deprecated(level=ERROR). please use the @Filter(targets = Filter.Targets(...)) on your listener: $listener")
             }
             
         }

--- a/simbot-boots/simboot-core/src/main/kotlin/love/forte/simboot/core/listener/BootListenerAttributes.kt
+++ b/simbot-boots/simboot-core/src/main/kotlin/love/forte/simboot/core/listener/BootListenerAttributes.kt
@@ -221,21 +221,21 @@ public object BootListenerAttributes {
 /**
  * @see BootListenerAttributes.RawFunction
  */
-@Deprecated("Use BootListenerAttributes.rawFunction", ReplaceWith("BootListenerAttributes.RawFunction"))
+@Deprecated("Use BootListenerAttributes.rawFunction", ReplaceWith("BootListenerAttributes.RawFunction"), level = DeprecationLevel.ERROR)
 public inline val RAW_FUNCTION: Attribute<KFunction<*>> get() = BootListenerAttributes.RawFunction
 
 
 /**
  * @see BootListenerAttributes.RawBinders
  */
-@Deprecated("Use BootListenerAttributes.rawBinders", ReplaceWith("BootListenerAttributes.RawBinders"))
+@Deprecated("Use BootListenerAttributes.rawBinders", ReplaceWith("BootListenerAttributes.RawBinders"), level = DeprecationLevel.ERROR)
 public inline val RAW_BINDERS: Attribute<Collection<ParameterBinder>> get() = BootListenerAttributes.RawBinders
 
 
 /**
  * @see BootListenerAttributes.RawListenTargets
  */
-@Deprecated("Use BootListenerAttributes.RawListenTargets", ReplaceWith("BootListenerAttributes.RawListenTargets"))
+@Deprecated("Use BootListenerAttributes.RawListenTargets", ReplaceWith("BootListenerAttributes.RawListenTargets"), level = DeprecationLevel.ERROR)
 public val RAW_LISTEN_TARGETS: Attribute<Collection<Event.Key<*>>> get() = BootListenerAttributes.RawListenTargets
 
 

--- a/simbot-boots/simboot-core/src/main/kotlin/love/forte/simboot/core/utils/ResourcesScanner.kt
+++ b/simbot-boots/simboot-core/src/main/kotlin/love/forte/simboot/core/utils/ResourcesScanner.kt
@@ -48,9 +48,7 @@ public class ResourcesScanner<T>(
         mutableListOf<(model: ResourceModel, resource: String, loader: ClassLoader, url: URL) -> Sequence<T>>()
     private val visitors = mutableListOf<(ResourceVisitValue<*>) -> Sequence<T>>()
     
-    @Deprecated("Unused")
     override fun close() {
-        // clear()
     }
     
     public fun clear() {

--- a/simbot-cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/CoreListeners.kt
+++ b/simbot-cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/CoreListeners.kt
@@ -63,7 +63,7 @@ public operator fun EventListener.plus(filters: Iterable<EventFilter>): EventLis
  */
 @Suppress("UNUSED_PARAMETER")
 @JvmSynthetic
-@Deprecated("Use simpleListener(...)")
+@Deprecated("Use simpleListener(...)", level = DeprecationLevel.ERROR)
 public fun <E : Event> coreListener(
     eventKey: Event.Key<E>,
     id: ID = randomID(),
@@ -97,10 +97,10 @@ public fun <E : Event> coreListener(
  *
  * @see simpleListener
  */
-@Suppress("DeprecatedCallableAddReplaceWith", "DEPRECATION")
+@Suppress("DeprecatedCallableAddReplaceWith", "DEPRECATION_ERROR")
 @JvmSynthetic
 @FragileSimbotApi
-@Deprecated("Use simpleListener(...)")
+@Deprecated("Use simpleListener(...)", level = DeprecationLevel.ERROR)
 public inline fun <reified E : Event> coreListener(
     id: ID = randomID(),
     blockNext: Boolean = false,
@@ -128,7 +128,7 @@ public inline fun <reified E : Event> coreListener(
 @Api4J
 @JvmOverloads
 @JvmName("newCoreListener")
-@Deprecated("use simpleListener(...)")
+@Deprecated("use simpleListener(...)", level = DeprecationLevel.ERROR)
 public fun <E : Event> blockingCoreListener(
     eventKey: Event.Key<E>,
     id: ID = UUID.randomUUID().ID,
@@ -169,7 +169,7 @@ public fun <E : Event> blockingCoreListener(
 @Api4J
 @JvmOverloads
 @JvmName("newCoreListener")
-@Deprecated("use simpleListener(...)")
+@Deprecated("use simpleListener(...)", level = DeprecationLevel.ERROR)
 public fun <E : Event> blockingCoreListener(
     eventKey: Event.Key<E>,
     id: ID = randomID(),
@@ -202,7 +202,7 @@ public fun <E : Event> blockingCoreListener(
 @Api4J
 @JvmOverloads
 @JvmName("newCoreListener")
-@Deprecated("use simpleListener(...)")
+@Deprecated("use simpleListener(...)", level = DeprecationLevel.ERROR)
 public fun <E : Event> blockingCoreListener(
     eventType: Class<E>,
     id: ID = randomID(),
@@ -234,7 +234,7 @@ public fun <E : Event> blockingCoreListener(
 @Api4J
 @JvmOverloads
 @JvmName("newCoreListener")
-@Deprecated("use simpleListener(...)")
+@Deprecated("use simpleListener(...)", level = DeprecationLevel.ERROR)
 public fun <E : Event> blockingCoreListener(
     eventType: Class<E>,
     id: ID = UUID.randomUUID().ID,

--- a/simbot-cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/EventListenersGenerator.kt
+++ b/simbot-cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/EventListenersGenerator.kt
@@ -1,7 +1,7 @@
 /*
  *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
  *
- *  本文件是 simply-robot (即 simple robot的v3版本，因此亦可称为 simple-robot v3 、simbot v3 等) 的一部分。
+ *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
  *
  *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
  *
@@ -11,7 +11,6 @@
  *  https://www.gnu.org/licenses
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
- *
  *
  */
 
@@ -119,7 +118,7 @@ public class EventListenersGenerator @InternalSimbotApi constructor() {
     }
     
     
-    @Deprecated("Use listen(Event.Key){ ... }", ReplaceWith("listen(eventKey, block)"))
+    @Deprecated("Use listen(Event.Key){ ... }", ReplaceWith("listen(eventKey, block)"), level = DeprecationLevel.ERROR)
     public fun <E : Event> listener(
         eventKey: Event.Key<E>,
         block: SimpleListenerBuilder<E>.() -> Unit,
@@ -427,11 +426,11 @@ public class EventListenersGenerator @InternalSimbotApi constructor() {
  * @see SimpleListenerBuilder
  * @author ForteScarlet
  */
-@Suppress("DEPRECATION")
+@Suppress("DEPRECATION_ERROR")
 @SimpleListenerBuilderDSL
 @Deprecated(
     "Just use SimpleListenerBuilder",
-    ReplaceWith("SimpleListenerBuilder<E>", "love.forte.simbot.core.event.SimpleListenerBuilder")
+    ReplaceWith("SimpleListenerBuilder<E>", "love.forte.simbot.core.event.SimpleListenerBuilder"), level = DeprecationLevel.ERROR
 )
 public class ListenerGenerator<E : Event> @InternalSimbotApi constructor(private val eventKey: Event.Key<E>) :
     EventListenerBuilder {

--- a/simbot-cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleEventInterceptors.kt
+++ b/simbot-cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleEventInterceptors.kt
@@ -25,7 +25,7 @@ import love.forte.simbot.PriorityConstant
 import love.forte.simbot.event.*
 import java.util.function.Function
 
-@Deprecated("Just use SimpleInterceptUtil for java")
+@Deprecated("Just use SimpleInterceptUtil for java", level = DeprecationLevel.ERROR)
 public object CoreInterceptUtil
 
 @DslMarker
@@ -77,7 +77,7 @@ public fun simpleProcessingInterceptor(
 
 @Deprecated(
     "Just use simpleProcessingInterceptor",
-    ReplaceWith("simpleProcessingInterceptor(priority, interceptFunction)")
+    ReplaceWith("simpleProcessingInterceptor(priority, interceptFunction)"), level = DeprecationLevel.ERROR
 )
 @SimpleFunctionalProcessingInterceptorDSL
 public fun coreProcessingInterceptor(
@@ -102,7 +102,7 @@ public fun simpleListenerInterceptor(
 
 
 @Deprecated("Just use simpleListenerInterceptor",
-    ReplaceWith("simpleListenerInterceptor(point, priority, interceptFunction)")
+    ReplaceWith("simpleListenerInterceptor(point, priority, interceptFunction)"), level = DeprecationLevel.ERROR
 )
 @SimpleFunctionalListenerInterceptorDSL
 public fun coreListenerInterceptor(


### PR DESCRIPTION
除了 `TODO` 性质的过时标记以外，所有的过时内容均提升过时等级为 `ERROR`，并会在 beta 版本删除。