### PR TITLE
提供面向Java的`lambda`兼容转化工具

### DIFF
--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/utils/SuspendLambdaTransform.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/utils/SuspendLambdaTransform.kt
@@ -122,6 +122,20 @@ public fun interface Consumer5<T1, T2, T3, T4, T5> {
 
 // region providers & functions
 
+/**
+ * Kotlin api:
+ * ```kotlin
+ * fun foo(block: suspend () -> T) {  }
+ * ```
+ *
+ * Use it in Java:
+ * ```java
+ * foo(Lambdas.toSuspend(() -> new T()));
+ * foo(Lambdas.toSuspend(T::new));
+ * ```
+ *
+ *
+ */
 @JvmOverloads
 @Api4J
 @ExperimentalSimbotApi
@@ -132,7 +146,19 @@ public fun <R> toSuspend(function: Supplier<R>, isRunWithInterruptible: Boolean 
         { function.get() }
     }
 
-
+/**
+ * Kotlin api:
+ * ```kotlin
+ * fun foo(block: suspend (T) -> R) {  }
+ * ```
+ *
+ * Use it in Java:
+ * ```java
+ * foo(Lambdas.toSuspend(t -> new R()));
+ * ```
+ *
+ *
+ */
 @JvmOverloads
 @Api4J
 @ExperimentalSimbotApi

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/utils/SuspendLambdaTransform.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/utils/SuspendLambdaTransform.kt
@@ -1,0 +1,206 @@
+/*
+ *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ *
+ *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
+ *
+ *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ *
+ *  发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
+ *
+ *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ *  https://www.gnu.org/licenses
+ *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ *
+ */
+
+@file:JvmName("Lambdas")
+
+package love.forte.simbot.utils
+
+import love.forte.simbot.Api4J
+import love.forte.simbot.ExperimentalSimbotApi
+import java.util.function.*
+import java.util.function.Function
+
+
+// region consumers
+
+
+/**
+ * Kotlin api:
+ * ```kotlin
+ * fun foo(block: suspend (T) -> Unit) {  }
+ * fun bar(block: suspend (T) -> Unit) {  }
+ * ```
+ *
+ * Use it in Java:
+ * ```java
+ * foo(Lambdas.toSuspend(t -> {}));
+ * bar(Lambdas.toSuspend(t -> {}));
+ * ```
+ *
+ *
+ */
+@JvmOverloads
+@Api4J
+@ExperimentalSimbotApi
+public fun <T> toSuspend(function: Consumer<T>, isRunWithInterruptible: Boolean = true): suspend (T) -> Unit =
+    if (isRunWithInterruptible) {
+        { runWithInterruptible { function.accept(it) } }
+    } else {
+        { function.accept(it) }
+    }
+
+
+@JvmOverloads
+@Api4J
+@ExperimentalSimbotApi
+public fun <T1, T2> toSuspend(
+    function: BiConsumer<T1, T2>,
+    isRunWithInterruptible: Boolean = true,
+): suspend (T1, T2) -> Unit = if (isRunWithInterruptible) {
+    { a, b -> runWithInterruptible { function.accept(a, b) } }
+} else {
+    { a, b -> function.accept(a, b) }
+}
+
+@JvmOverloads
+@Api4J
+@ExperimentalSimbotApi
+public fun <T1, T2, T3> toSuspend(
+    function: Consumer3<T1, T2, T3>,
+    isRunWithInterruptible: Boolean = true,
+): suspend (T1, T2, T3) -> Unit = if (isRunWithInterruptible) {
+    { a, b, c -> runWithInterruptible { function.accept(a, b, c) } }
+} else {
+    { a, b, c -> function.accept(a, b, c) }
+}
+
+@JvmOverloads
+@Api4J
+@ExperimentalSimbotApi
+public fun <T1, T2, T3, T4> toSuspend(
+    function: Consumer4<T1, T2, T3, T4>,
+    isRunWithInterruptible: Boolean = true,
+): suspend (T1, T2, T3, T4) -> Unit = if (isRunWithInterruptible) {
+    { a, b, c, d -> runWithInterruptible { function.accept(a, b, c, d) } }
+} else {
+    { a, b, c, d -> function.accept(a, b, c, d) }
+}
+
+@JvmOverloads
+@Api4J
+@ExperimentalSimbotApi
+public fun <T1, T2, T3, T4, T5> toSuspend(
+    function: Consumer5<T1, T2, T3, T4, T5>,
+    isRunWithInterruptible: Boolean = true,
+): suspend (T1, T2, T3, T4, T5) -> Unit = if (isRunWithInterruptible) {
+    { a, b, c, d, e -> runWithInterruptible { function.accept(a, b, c, d, e) } }
+} else {
+    { a, b, c, d, e -> function.accept(a, b, c, d, e) }
+}
+
+@Api4J
+@ExperimentalSimbotApi
+public fun interface Consumer3<T1, T2, T3> {
+    public fun accept(t1: T1, t2: T2, t3: T3)
+}
+
+@Api4J
+@ExperimentalSimbotApi
+public fun interface Consumer4<T1, T2, T3, T4> {
+    public fun accept(t1: T1, t2: T2, t3: T3, t4: T4)
+}
+
+@Api4J
+@ExperimentalSimbotApi
+public fun interface Consumer5<T1, T2, T3, T4, T5> {
+    public fun accept(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5)
+}
+// endregion
+
+// region providers & functions
+
+@JvmOverloads
+@Api4J
+@ExperimentalSimbotApi
+public fun <R> toSuspend(function: Supplier<R>, isRunWithInterruptible: Boolean = true): suspend () -> R =
+    if (isRunWithInterruptible) {
+        { runWithInterruptible { function.get() } }
+    } else {
+        { function.get() }
+    }
+
+
+@JvmOverloads
+@Api4J
+@ExperimentalSimbotApi
+public fun <T, R> toSuspend(function: Function<T, R>, isRunWithInterruptible: Boolean = true): suspend (T) -> R =
+    if (isRunWithInterruptible) {
+        { runWithInterruptible { function.apply(it) } }
+    } else {
+        { function.apply(it) }
+    }
+
+
+@JvmOverloads
+@Api4J
+@ExperimentalSimbotApi
+public fun <T1, T2, R> toSuspend(
+    function: BiFunction<T1, T2, R>,
+    isRunWithInterruptible: Boolean = true,
+): suspend (T1, T2) -> R =
+    if (isRunWithInterruptible) {
+        { a, b -> runWithInterruptible { function.apply(a, b) } }
+    } else {
+        { a, b -> function.apply(a, b) }
+    }
+
+
+@JvmOverloads
+@Api4J
+@ExperimentalSimbotApi
+public fun <T1, T2, T3, R> toSuspend(
+    function: (T1, T2, T3) -> R,
+    isRunWithInterruptible: Boolean = true,
+): suspend (T1, T2, T3) -> R =
+    if (isRunWithInterruptible) {
+        { a, b, c -> runWithInterruptible { function(a, b, c) } }
+    } else {
+        { a, b, c -> function(a, b, c) }
+    }
+
+@JvmOverloads
+@Api4J
+@ExperimentalSimbotApi
+public fun <T1, T2, T3, T4, R> toSuspend(
+    function: (T1, T2, T3, T4) -> R,
+    isRunWithInterruptible: Boolean = true,
+): suspend (T1, T2, T3, T4) -> R =
+    if (isRunWithInterruptible) {
+        { a, b, c, d -> runWithInterruptible { function(a, b, c, d) } }
+    } else {
+        { a, b, c, d -> function(a, b, c, d) }
+    }
+
+
+@JvmOverloads
+@Api4J
+@ExperimentalSimbotApi
+public fun <T1, T2, T3, T4, T5, R> toSuspend(
+    function: (T1, T2, T3, T4, T5) -> R,
+    isRunWithInterruptible: Boolean = true,
+): suspend (T1, T2, T3, T4, T5) -> R =
+    if (isRunWithInterruptible) {
+        { a, b, c, d, e -> runWithInterruptible { function(a, b, c, d, e) } }
+    } else {
+        { a, b, c, d, e -> function(a, b, c, d, e) }
+    }
+// endregion
+
+
+
+
+
+

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/utils/SuspendLambdaTransform.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/utils/SuspendLambdaTransform.kt
@@ -31,13 +31,13 @@ import java.util.function.Function
  * Kotlin api:
  * ```kotlin
  * fun foo(block: suspend (T) -> Unit) {  }
- * fun bar(block: suspend (T) -> Unit) {  }
+ * fun bar(block: suspend T.() -> Unit) {  }
  * ```
  *
  * Use it in Java:
  * ```java
- * foo(Lambdas.toSuspend(t -> {}));
- * bar(Lambdas.toSuspend(t -> {}));
+ * foo(Lambdas.suspendConsumer(t -> {}));
+ * bar(Lambdas.suspendConsumer(t -> {}));
  * ```
  *
  *
@@ -45,7 +45,7 @@ import java.util.function.Function
 @JvmOverloads
 @Api4J
 @ExperimentalSimbotApi
-public fun <T> toSuspend(function: Consumer<T>, isRunWithInterruptible: Boolean = true): suspend (T) -> Unit =
+public fun <T> suspendConsumer(function: Consumer<T>, isRunWithInterruptible: Boolean = true): suspend (T) -> Unit =
     if (isRunWithInterruptible) {
         { runWithInterruptible { function.accept(it) } }
     } else {
@@ -56,7 +56,7 @@ public fun <T> toSuspend(function: Consumer<T>, isRunWithInterruptible: Boolean 
 @JvmOverloads
 @Api4J
 @ExperimentalSimbotApi
-public fun <T1, T2> toSuspend(
+public fun <T1, T2> suspendConsumer(
     function: BiConsumer<T1, T2>,
     isRunWithInterruptible: Boolean = true,
 ): suspend (T1, T2) -> Unit = if (isRunWithInterruptible) {
@@ -68,7 +68,7 @@ public fun <T1, T2> toSuspend(
 @JvmOverloads
 @Api4J
 @ExperimentalSimbotApi
-public fun <T1, T2, T3> toSuspend(
+public fun <T1, T2, T3> suspendConsumer(
     function: Consumer3<T1, T2, T3>,
     isRunWithInterruptible: Boolean = true,
 ): suspend (T1, T2, T3) -> Unit = if (isRunWithInterruptible) {
@@ -80,7 +80,7 @@ public fun <T1, T2, T3> toSuspend(
 @JvmOverloads
 @Api4J
 @ExperimentalSimbotApi
-public fun <T1, T2, T3, T4> toSuspend(
+public fun <T1, T2, T3, T4> suspendConsumer(
     function: Consumer4<T1, T2, T3, T4>,
     isRunWithInterruptible: Boolean = true,
 ): suspend (T1, T2, T3, T4) -> Unit = if (isRunWithInterruptible) {
@@ -92,7 +92,7 @@ public fun <T1, T2, T3, T4> toSuspend(
 @JvmOverloads
 @Api4J
 @ExperimentalSimbotApi
-public fun <T1, T2, T3, T4, T5> toSuspend(
+public fun <T1, T2, T3, T4, T5> suspendConsumer(
     function: Consumer5<T1, T2, T3, T4, T5>,
     isRunWithInterruptible: Boolean = true,
 ): suspend (T1, T2, T3, T4, T5) -> Unit = if (isRunWithInterruptible) {
@@ -100,6 +100,50 @@ public fun <T1, T2, T3, T4, T5> toSuspend(
 } else {
     { a, b, c, d, e -> function.accept(a, b, c, d, e) }
 }
+
+/**
+ * Kotlin api:
+ * ```kotlin
+ * fun foo(block: (T) -> Unit) {  }
+ * fun bar(block: T.() -> Unit) {  }
+ * ```
+ *
+ * Use it in Java:
+ * ```java
+ * foo(Lambdas.eliminateUnit(t -> {}));
+ * bar(Lambdas.eliminateUnit(t -> {}));
+ * ```
+ *
+ *
+ */
+@Api4J
+@ExperimentalSimbotApi
+public fun <T> eliminateUnit(function: Consumer<T>): (T) -> Unit = function::accept
+
+
+@Api4J
+@ExperimentalSimbotApi
+public fun <T1, T2> eliminateUnit(
+    function: BiConsumer<T1, T2>,
+): (T1, T2) -> Unit = function::accept
+
+@Api4J
+@ExperimentalSimbotApi
+public fun <T1, T2, T3> eliminateUnit(
+    function: Consumer3<T1, T2, T3>,
+): (T1, T2, T3) -> Unit = function::accept
+
+@Api4J
+@ExperimentalSimbotApi
+public fun <T1, T2, T3, T4> eliminateUnit(
+    function: Consumer4<T1, T2, T3, T4>,
+): (T1, T2, T3, T4) -> Unit = function::accept
+
+@Api4J
+@ExperimentalSimbotApi
+public fun <T1, T2, T3, T4, T5> eliminateUnit(
+    function: Consumer5<T1, T2, T3, T4, T5>,
+): (T1, T2, T3, T4, T5) -> Unit = function::accept
 
 @Api4J
 @ExperimentalSimbotApi
@@ -130,8 +174,8 @@ public fun interface Consumer5<T1, T2, T3, T4, T5> {
  *
  * Use it in Java:
  * ```java
- * foo(Lambdas.toSuspend(() -> new T()));
- * foo(Lambdas.toSuspend(T::new));
+ * foo(Lambdas.suspendSupplier(() -> new T()));
+ * foo(Lambdas.suspendSupplier(T::new));
  * ```
  *
  *
@@ -139,7 +183,7 @@ public fun interface Consumer5<T1, T2, T3, T4, T5> {
 @JvmOverloads
 @Api4J
 @ExperimentalSimbotApi
-public fun <R> toSuspend(function: Supplier<R>, isRunWithInterruptible: Boolean = true): suspend () -> R =
+public fun <R> suspendSupplier(function: Supplier<R>, isRunWithInterruptible: Boolean = true): suspend () -> R =
     if (isRunWithInterruptible) {
         { runWithInterruptible { function.get() } }
     } else {
@@ -150,11 +194,13 @@ public fun <R> toSuspend(function: Supplier<R>, isRunWithInterruptible: Boolean 
  * Kotlin api:
  * ```kotlin
  * fun foo(block: suspend (T) -> R) {  }
+ * fun bar(block: suspend T.() -> R) {  }
  * ```
  *
  * Use it in Java:
  * ```java
- * foo(Lambdas.toSuspend(t -> new R()));
+ * foo(Lambdas.suspendFunction(t -> new R()));
+ * bar(Lambdas.suspendFunction(t -> new R()));
  * ```
  *
  *
@@ -162,7 +208,7 @@ public fun <R> toSuspend(function: Supplier<R>, isRunWithInterruptible: Boolean 
 @JvmOverloads
 @Api4J
 @ExperimentalSimbotApi
-public fun <T, R> toSuspend(function: Function<T, R>, isRunWithInterruptible: Boolean = true): suspend (T) -> R =
+public fun <T, R> suspendFunction(function: Function<T, R>, isRunWithInterruptible: Boolean = true): suspend (T) -> R =
     if (isRunWithInterruptible) {
         { runWithInterruptible { function.apply(it) } }
     } else {
@@ -173,7 +219,7 @@ public fun <T, R> toSuspend(function: Function<T, R>, isRunWithInterruptible: Bo
 @JvmOverloads
 @Api4J
 @ExperimentalSimbotApi
-public fun <T1, T2, R> toSuspend(
+public fun <T1, T2, R> suspendFunction(
     function: BiFunction<T1, T2, R>,
     isRunWithInterruptible: Boolean = true,
 ): suspend (T1, T2) -> R =
@@ -187,7 +233,7 @@ public fun <T1, T2, R> toSuspend(
 @JvmOverloads
 @Api4J
 @ExperimentalSimbotApi
-public fun <T1, T2, T3, R> toSuspend(
+public fun <T1, T2, T3, R> suspendFunction(
     function: (T1, T2, T3) -> R,
     isRunWithInterruptible: Boolean = true,
 ): suspend (T1, T2, T3) -> R =
@@ -200,7 +246,7 @@ public fun <T1, T2, T3, R> toSuspend(
 @JvmOverloads
 @Api4J
 @ExperimentalSimbotApi
-public fun <T1, T2, T3, T4, R> toSuspend(
+public fun <T1, T2, T3, T4, R> suspendFunction(
     function: (T1, T2, T3, T4) -> R,
     isRunWithInterruptible: Boolean = true,
 ): suspend (T1, T2, T3, T4) -> R =
@@ -214,7 +260,7 @@ public fun <T1, T2, T3, T4, R> toSuspend(
 @JvmOverloads
 @Api4J
 @ExperimentalSimbotApi
-public fun <T1, T2, T3, T4, T5, R> toSuspend(
+public fun <T1, T2, T3, T4, T5, R> suspendFunction(
     function: (T1, T2, T3, T4, T5) -> R,
     isRunWithInterruptible: Boolean = true,
 ): suspend (T1, T2, T3, T4, T5) -> R =
@@ -223,6 +269,8 @@ public fun <T1, T2, T3, T4, T5, R> toSuspend(
     } else {
         { a, b, c, d, e -> function(a, b, c, d, e) }
     }
+
+
 // endregion
 
 

--- a/simbot-cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleListenerBuilder.kt
+++ b/simbot-cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleListenerBuilder.kt
@@ -16,9 +16,11 @@
 
 package love.forte.simbot.core.event
 
-import love.forte.simbot.*
+import love.forte.simbot.Api4J
+import love.forte.simbot.ExperimentalSimbotApi
+import love.forte.simbot.PriorityConstant
+import love.forte.simbot.SimbotIllegalStateException
 import love.forte.simbot.event.*
-import love.forte.simbot.message.At
 import love.forte.simbot.message.Message
 import love.forte.simbot.utils.randomIdStr
 import love.forte.simbot.utils.runWithInterruptible
@@ -454,14 +456,5 @@ public inline fun <E : MessageEvent, reified M : Message.Element<M>> SimpleListe
         }
         
         !require || index >= 0
-    }
-}
-
-public fun a() {
-    buildSimpleListener(MessageEvent) {
-        matchMessage(At) { e, m, i ->
-            m.target.literal != "123"
-            true
-        }
     }
 }


### PR DESCRIPTION
```kotlin
val foo(block: suspend T.() -> Unit)
```
可以在Java中使用：

```java
foo(Lambdas.suspendSupplier(t -> { /* ... */ }));
```

更多内容参阅 `Lambdas` 。