### PR TITLE
`EventResult` 结构优化; 响应值支持处理`CompletableFuture`与`Deferred`

### DIFF
--- a/buildSrc/src/main/kotlin/P.kt
+++ b/buildSrc/src/main/kotlin/P.kt
@@ -60,7 +60,7 @@ object P {
         
         val version = Version(
             "3", 0, 0,
-            status = VersionStatus.beta(2, null, null),
+            status = VersionStatus.beta(3, null, null),
             isSnapshot = isSnapshot()
         )
         

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/bot/Bot.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/bot/Bot.kt
@@ -132,7 +132,7 @@ public interface Bot : User, BotInfo, Survivable,
     /**
      *  尝试通过解析一个 [ID] 并得到对应的可用于发送的图片实例。
      *  这个 [Image] 不一定是真正远端图片结果，它有可能只是一个预处理类型。
-     *  在执行 [resolveImage] 的过程中也不一定出现真正的挂起行为，具体细节请参考具体实现。
+     *  在执行 [resolveImage] 的过程中也不一定出现真正地挂起行为，具体细节请参考具体实现。
      */
     @JvmBlocking
     @JvmAsync

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/EventResult.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/EventResult.kt
@@ -259,6 +259,7 @@ public abstract class ReactivelyCollectableEventResult : SpecialEventResult() {
      *
      * 支持的收集类型有：
      * - [java.util.concurrent.CompletionStage] ([java.util.concurrent.CompletableFuture])
+     * - [kotlinx.coroutines.Deferred] (不支持 [kotlinx.coroutines.Job])
      * - [kotlinx.coroutines.flow.Flow]
      * - [org.reactivestreams.Publisher]
      * - [reactor.core.publisher.Flux]

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/EventResult.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/EventResult.kt
@@ -247,15 +247,14 @@ public abstract class ReactivelyCollectableEventResult : SpecialEventResult() {
     
     /**
      *
-     * 当 [content] 的返回值为 reactive api相关的内容，且当前 [EventResult] 实例为 **[ReactivelyCollectableEventResult]** 类型的时候，
-     * 处理器应当对 reactive 的相关api对其进行转化收集。这通常使用在Java使用者或者与其他reactive API配合使用的时候。
+     * 当 [content] 的返回值为 _reactive api_ 相关或异步结果相关的内容，且当前 [EventResult] 实例为 **[ReactivelyCollectableEventResult]** 类型的时候，
+     * 处理器应当对这类相关的api进行收集。这通常使用在Java使用者或者与其他reactive API配合使用的时候。
      *
      * 比如当你的函数返回了 [flux](https://projectreactor.io/docs/core/3.4.1/api/reactor/core/publisher/Flux.html),
-     * 那么它将会被收集为 [List] 后重新作为 [content] 构建为 EventResult.
-     *
+     * 那么它将会被收集为 [List] 后重新作为 [content] 并通过 [collected] 构建为一个新的 [EventResult].
      * 同样的，如果你返回的是 [kotlinx.coroutines.flow.Flow], 也会在函数返回后进行收集。
      *
-     * 值得注意的是, 收集行为会在返回值返回后立即执行, 而不是等待所有监听函数执行结束后。
+     * 收集行为会在返回值返回后(某个监听函数处理结束后, 下一个监听函数开始执行前)立即执行, 而不是等待所有监听函数执行结束后。
      *
      * 支持的收集类型有：
      * - [java.util.concurrent.CompletionStage] ([java.util.concurrent.CompletableFuture])

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/EventResult.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/event/EventResult.kt
@@ -16,13 +16,17 @@
 
 package love.forte.simbot.event
 
-import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.*
 import kotlinx.coroutines.future.asCompletableFuture
+import kotlinx.coroutines.future.await
+import love.forte.plugin.suspendtrans.annotation.JvmBlocking
 import love.forte.simbot.Api4J
+import love.forte.simbot.InternalSimbotApi
 import love.forte.simbot.event.EventResult.Default.NormalEmpty
 import love.forte.simbot.event.EventResult.Default.Truncated
 import love.forte.simbot.event.EventResult.Invalid
-import java.util.concurrent.Future
+import love.forte.simbot.utils.DefaultBlockingContext
+import java.util.concurrent.*
 
 
 /**
@@ -31,20 +35,219 @@ import java.util.concurrent.Future
  *
  * [EventResult] 的特殊伴生对象 [Invalid] 可用于拦截器、过滤器中。事件处理器如果遇到了 [Invalid], 则应该直接忽略此值。
  *
- * 事件管理器 [EventListenerContainer]
+ * 有关其他具有特殊含义的事件结果, 参考 [SpecialEventResult].
  *
- * @see Invalid
+ * @see SpecialEventResult
  *
  * @author ForteScarlet
  */
 public interface EventResult {
-
+    
     /**
      * 此为监听函数所返回的真正内容。
      *
-     * ### Reactive API
+     *  当 [content] 的返回值为 reactive api相关的内容，且当前 [EventResult] 实例为 **[ReactivelyCollectableEventResult]** 类型的时候，
+     * 处理器应当对 reactive 的相关api对其进行转化收集。这通常使用在Java使用者或者与其他reactive API配合使用的时候。
      *
-     * 当 [content] 的返回值为 reactive api相关的内容，且当前 [EventResult] 实例为 [SimpleEventResult] 类型的时候，
+     * 有关响应式结果的更多描述参考 [ReactivelyCollectableEventResult.content].
+     *
+     * @see ReactivelyCollectableEventResult.content
+     */
+    public val content: Any?
+    
+    
+    /**
+     * 是否阻止下一个监听函数的执行。
+     *
+     * 这只会截断顺序执行的函数，而不会影响异步函数，异步函数也无法通过 [isTruncated] 对后续函数进行截断。
+     */
+    public val isTruncated: Boolean
+    
+    
+    public companion object {
+        
+        /**
+         * 得到一个无效的特殊默认值。
+         *
+         * [invalid] 与 [defaults] 得到结果的区别在于，[Invalid] 代表的是“无效的”，
+         * 因此此结果不会被记录到 [EventProcessingResult.results] 中。
+         *
+         * 当一个监听事件的结果为 [Invalid], 则代表它“没有真正地执行成功”。
+         *
+         * @see Invalid
+         */
+        @JvmStatic
+        public fun invalid(): Invalid = Invalid
+        
+        /**
+         * 提供一个 [content] 得到一个 [EventResult] 的简易实例。
+         * 当 [content] 不为null时，得到的实例类型为 [SimpleEventResult].
+         *
+         * @param content 结果内容。
+         * @param
+         */
+        @JvmOverloads
+        @JvmStatic
+        public fun of(content: Any? = null, isTruncated: Boolean = false): EventResult = if (content == null) {
+            if (isTruncated) Truncated else NormalEmpty
+        } else {
+            SimpleEventResult(content, isTruncated)
+        }
+        
+        
+        /**
+         * 得到一个异步执行函数的 [AsyncEventResult],
+         * 其 [AsyncEventResult.content] 为一个预期返回 [EventResult] 的 [Deferred].
+         *
+         * @see AsyncEventResult
+         */
+        @JvmSynthetic
+        public fun async(content: Deferred<EventResult>): AsyncEventResult = DeferredAsyncEventResult(content)
+        
+        /**
+         * 得到一个异步执行函数的 [AsyncEventResult],
+         * 其 [AsyncEventResult.content] 为一个预期返回 [EventResult] 的 [Deferred].
+         *
+         * @see AsyncEventResult
+         */
+        public fun async(content: Future<EventResult>): AsyncEventResult = FutureAsyncEventResult(content)
+        
+        /**
+         * 根据是否需要阻断后续监听 [isTruncated] 来得到一个默认的 [EventResult] 实例。
+         */
+        @JvmOverloads
+        @JvmStatic
+        public fun defaults(isTruncated: Boolean = false): EventResult = of(null, isTruncated)
+        
+        
+        /**
+         * 返回一个阻断后续监听函数执行的响应体(`EventResult(isTruncated=true)`)。
+         */
+        @JvmStatic
+        public fun truncate(): EventResult = defaults(true)
+    }
+    
+    /**
+     * 代表着 **无效** 的 [EventResult] 实例，是一个具有[特殊意义][SpecialEventResult]的类型: [事件处理器][EventProcessor] 不应对此结果进行保留或处理。
+     *
+     * [Invalid] 与其他的 [EventResult] 得到结果的区别在于，[Invalid] 代表的是“无效的”，
+     * 因此此结果不会被记录到 [EventProcessingResult.results] 中。
+     *
+     * 当一个监听事件的结果为 [Invalid], 则代表它“没有真正地执行成功”。
+     */
+    public object Invalid : SpecialEventResult() {
+        override val content: Any?
+            get() = null
+        
+        override val isTruncated: Boolean
+            get() = false
+    }
+    
+    /**
+     * 默认的 [EventResult] 实现，也是部分常见策略下的结果内容。
+     *
+     * @see Truncated
+     */
+    private sealed class Default : EventResult {
+        object Truncated : Default() {
+            override val content: Any? get() = null
+            override val isTruncated: Boolean get() = true
+        }
+        
+        object NormalEmpty : Default() {
+            override val content: Any? get() = null
+            override val isTruncated: Boolean get() = false
+        }
+        
+    }
+}
+
+/**
+ * 标记性接口, 代表一些在内部具有特殊意义的 [EventResult] 类型.
+ *
+ * @see EventResult.Invalid
+ * @see AsyncEventResult
+ *
+ */
+public sealed class SpecialEventResult : EventResult
+
+
+/**
+ * 代表一个异步任务的返回值。
+ *
+ * [AsyncEventResult] 是具有[特殊意义][SpecialEventResult]的 [EventResult]: [content] 中的 [Deferred] 不会被作为非阻塞内容而被收集.
+ * 更多说明参考 [EventResult.content].
+ *
+ * @see DeferredAsyncEventResult
+ * @see FutureAsyncEventResult
+ *
+ * @property content 异步事件的结果内容。
+ */
+public abstract class AsyncEventResult : SpecialEventResult() {
+    /**
+     * 用来表示一个异步任务的 [content], 例如 [Deferred] 或 [Future].
+     */
+    abstract override val content: Any?
+    
+    /**
+     * 正常情况下，异步任务将不会阻断后续事件的执行。
+     */
+    override val isTruncated: Boolean get() = false
+    
+    /**
+     * 将结果转化为 [Future].
+     */
+    @Api4J
+    public abstract fun contentAsFuture(): Future<EventResult>
+    
+    /**
+     * 等待 [content] 的异步任务响应。
+     */
+    @JvmBlocking
+    public abstract suspend fun awaitContent(): EventResult
+}
+
+/**
+ * 将一个 [Deferred] 类型的异步任务作为 [AsyncEventResult.content] 的实现。
+ */
+private class DeferredAsyncEventResult(override val content: Deferred<EventResult>) : AsyncEventResult() {
+    @Api4J
+    override fun contentAsFuture(): CompletableFuture<EventResult> = content.asCompletableFuture()
+    override suspend fun awaitContent(): EventResult = content.await()
+}
+
+/**
+ * 将一个 [Future] 类型的异步任务作为 [AsyncEventResult.content] 的实现。
+ */
+private class FutureAsyncEventResult(override val content: Future<EventResult>) : AsyncEventResult() {
+    @Api4J
+    override fun contentAsFuture(): Future<EventResult> = content
+    
+    override suspend fun awaitContent(): EventResult =
+        if (content is CompletionStage<*>) {
+            content.await() as EventResult
+        } else {
+            @OptIn(InternalSimbotApi::class)
+            withContext(DefaultBlockingContext) {
+                try {
+                    @Suppress("BlockingMethodInNonBlockingContext")
+                    content.get()
+                } catch (e: ExecutionException) {
+                    throw e.cause ?: e
+                }
+            }
+        }
+}
+
+
+/**
+ * 代表 [content] 可能为一个反应式的结果，并且允许其在一个函数结束时进行收集。
+ */
+public abstract class ReactivelyCollectableEventResult : SpecialEventResult() {
+    
+    /**
+     *
+     * 当 [content] 的返回值为 reactive api相关的内容，且当前 [EventResult] 实例为 **[ReactivelyCollectableEventResult]** 类型的时候，
      * 处理器应当对 reactive 的相关api对其进行转化收集。这通常使用在Java使用者或者与其他reactive API配合使用的时候。
      *
      * 比如当你的函数返回了 [flux](https://projectreactor.io/docs/core/3.4.1/api/reactor/core/publisher/Flux.html),
@@ -55,6 +258,7 @@ public interface EventResult {
      * 值得注意的是, 收集行为会在返回值返回后立即执行, 而不是等待所有监听函数执行结束后。
      *
      * 支持的收集类型有：
+     * - [java.util.concurrent.CompletionStage] ([java.util.concurrent.CompletableFuture])
      * - [kotlinx.coroutines.flow.Flow]
      * - [org.reactivestreams.Publisher]
      * - [reactor.core.publisher.Flux]
@@ -72,136 +276,21 @@ public interface EventResult {
      *
      * _是否将[Future]也作为需要收集的类型仍待定。目前尚不支持_
      *
-     * 详情请见 [kotlinx-coroutines-reactive](https://github.com/Kotlin/kotlinx.coroutines/blob/master/reactive/README.md) .
+     * 其他详情请见 [kotlinx-coroutines-reactive](https://github.com/Kotlin/kotlinx.coroutines/blob/master/reactive/README.md) .
      */
-    public val content: Any?
-
-
-    /**
-     * 是否阻止下一个监听函数的执行。
-     *
-     * 这只会截断顺序执行的函数，而不会影响异步函数，异步函数也无法通过 [isTruncated] 对后续函数进行截断。
-     */
-    public val isTruncated: Boolean
-
-
-    public companion object {
-
-        /**
-         * 得到一个无效的特殊默认值。
-         *
-         * [invalid] 与 [defaults] 得到结果的区别在于，[Invalid] 代表的是“无效的”，
-         * 因此此结果不会被记录到 [EventProcessingResult.results] 中。
-         *
-         * 当一个监听事件的结果为 [Invalid], 则代表它“没有真正的执行成功”。
-         *
-         * @see Invalid
-         */
-        @JvmStatic
-        public fun invalid(): Invalid = Invalid
-
-        /**
-         * 提供一个 [content] 得到一个 [EventResult] 的简易实例。
-         * 当 [content] 不为null时，得到的实例类型为 [SimpleEventResult].
-         *
-         * @param content 结果内容。
-         * @param
-         */
-        @JvmOverloads
-        @JvmStatic
-        public fun of(content: Any? = null, isTruncated: Boolean = false): EventResult = if (content == null) {
-            if (isTruncated) Truncated else NormalEmpty
-        } else {
-            SimpleEventResult(content, isTruncated)
-        }
-
-
-        /**
-         * 得到一个异步执行函数的 [AsyncEventResult],
-         * 其 [AsyncEventResult.content] 为一个预期返回 [EventResult] 的 [Deferred].
-         *
-         * @see AsyncEventResult
-         */
-        @JvmSynthetic
-        public fun async(content: Deferred<EventResult>): AsyncEventResult = AsyncEventResult(content)
-
-        /**
-         * 根据是否需要阻断后续监听 [isTruncated] 来得到一个默认的 [EventResult] 实例。
-         */
-        @JvmOverloads
-        @JvmStatic
-        public fun defaults(isTruncated: Boolean = false): EventResult = of(null, isTruncated)
-
-
-        /**
-         * 返回一个阻断后续监听函数执行的响应体(`EventResult(isTruncated=true)`)。
-         */
-        @JvmStatic
-        public fun truncate(): EventResult = defaults(true)
-    }
-
-    /**
-     * 代表着 **无效** 的 [EventResult] 实例，是一个具有特殊意义的类型。[事件处理器][EventProcessor] 不应对此结果进行保留或处理。
-     *
-     * [Invalid] 与其他的 [EventResult] 得到结果的区别在于，[Invalid] 代表的是“无效的”，
-     * 因此此结果不会被记录到 [EventProcessingResult.results] 中。
-     *
-     * 当一个监听事件的结果为 [Invalid], 则代表它“没有真正的执行成功”。
-     */
-    public object Invalid : EventResult {
-        override val content: Any?
-            get() = null
-
-        override val isTruncated: Boolean
-            get() = false
-    }
-
-    /**
-     * 默认的 [EventResult] 实现，也是部分常见策略下的结果内容。
-     *
-     * @see Truncated
-     */
-    private sealed class Default : EventResult {
-        object Truncated : Default() {
-            override val content: Any? get() = null
-            override val isTruncated: Boolean get() = true
-        }
+    abstract override val content: Any?
     
-        object NormalEmpty : Default() {
-            override val content: Any? get() = null
-            override val isTruncated: Boolean get() = false
-        }
-
-    }
-
+    /**
+     * 当响应式结果 [content] 被收集完毕后通过 [collected] 提供其收集的结果 [collectedContent],
+     * 并作为一个新的 [EventResult] 结果提供给 [EventProcessingResult.results].
+     *
+     * [collected] 的结果不会再被二次收集, 因此假若 [collectedContent] 仍然为响应式类型, 则它们将会被忽略并直接作为结果返回.
+     *
+     */
+    public abstract fun collected(collectedContent: Any?): EventResult
+    
 }
 
-/**
- * [content] 作为 [Deferred] 的异步函数返回值。
- *
- * [AsyncEventResult] 是特殊的 [EventResult] 之一, [content] 中的 [Deferred] 不会被作为非阻塞内容而被收集.
- * 更多说明参考 [EventResult.content].
- *
- * @property content 异步事件的结果内容。
- */
-public open class AsyncEventResult(override val content: Deferred<EventResult>) : EventResult {
-    /**
-     * 正常情况下，异步任务将不会阻断后续事件的执行。
-     */
-    override val isTruncated: Boolean get() = false
-
-    /**
-     * 将 [content] 转化为 [Future].
-     */
-    @Api4J
-    public fun contentAsFuture(): Future<EventResult> = content.asCompletableFuture()
-
-    /**
-     * 等待 [content] 的异步任务响应。
-     */
-    @JvmSynthetic
-    public suspend fun awaitContent(): EventResult = content.await()
-}
 
 /**
  * [EventResult] 的基础实现类型，是通过 [EventResult.of] 可能得到的基本结果类型。
@@ -214,9 +303,9 @@ public open class AsyncEventResult(override val content: Deferred<EventResult>) 
  */
 public open class SimpleEventResult
 @JvmOverloads constructor(
-    override val content: Any? = null, override val isTruncated: Boolean = false
-) : EventResult {
-
+    override val content: Any? = null, override val isTruncated: Boolean = false,
+) : ReactivelyCollectableEventResult() {
+    
     /**
      * 根据当前的 [content] 和 [isTruncated] 拷贝得到一个新的实例，并且允许提供额外的参数覆盖当前内容。
      */
@@ -224,25 +313,31 @@ public open class SimpleEventResult
     public open fun copy(newContent: Any? = content, newTruncated: Boolean = isTruncated): SimpleEventResult {
         return SimpleEventResult(newContent, newTruncated)
     }
-
+    
+    /**
+     * 根据新的内容拷贝一个结果
+     * @see copy
+     */
+    override fun collected(collectedContent: Any?): SimpleEventResult = copy(newContent = collectedContent)
+    
     override fun toString(): String = "SimpleEventResult(content=$content, isTruncated=$isTruncated)"
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is SimpleEventResult) return false
-
+        
         if (content != other.content) return false
         if (isTruncated != other.isTruncated) return false
-
+        
         return true
     }
-
+    
     override fun hashCode(): Int {
         var result = content?.hashCode() ?: 0
         result = 31 * result + isTruncated.hashCode()
         return result
     }
-
-
+    
+    
 }
 
 

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/utils/BlockingRunner.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/utils/BlockingRunner.kt
@@ -150,6 +150,13 @@ private fun initDefaultBlockingDispatcher(): CoroutineDispatcher {
 @InternalSimbotApi
 public val DefaultBlockingContext: CoroutineContext = DefaultBlockingDispatcher + CoroutineName("runInBlocking")
 
+
+
+@Suppress("unused", "ObjectPropertyName")
+@InternalSimbotApi
+private val `$$DefaultScope`: CoroutineScope = CoroutineScope(DefaultBlockingContext)
+
+
 /**
  *
  * 在simbot中提供的 [runBlocking] 包装。
@@ -193,10 +200,6 @@ public fun <T> runInAsync(block: suspend () -> T): CompletableFuture<T> =
 @InternalSimbotApi
 @Deprecated("Just used by auto-generate", level = DeprecationLevel.HIDDEN)
 public fun <T> `$$runInBlocking`(block: suspend () -> T): T = runInBlocking { block() }
-
-@Suppress("unused", "ObjectPropertyName")
-@InternalSimbotApi
-private val `$$DefaultScope` by lazy { CoroutineScope(DefaultBlockingContext) }
 
 @InternalSimbotApi
 @Deprecated("Just used by auto-generate", level = DeprecationLevel.HIDDEN)

--- a/simbot-cores/simbot-core/build.gradle.kts
+++ b/simbot-cores/simbot-core/build.gradle.kts
@@ -39,5 +39,6 @@ dependencies {
     testImplementation(libs.kotlinx.serialization.json)
     testImplementation(libs.kotlinx.serialization.properties)
     testImplementation(libs.kotlinx.serialization.protobuf)
-
+    testImplementation(libs.kotlinx.coroutines.reactor)
+    
 }

--- a/simbot-cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleEventProcessingContextResolver.kt
+++ b/simbot-cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleEventProcessingContextResolver.kt
@@ -17,7 +17,9 @@
 package love.forte.simbot.core.event
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.future.await
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactor.awaitSingleOrNull
 import kotlinx.coroutines.rx2.asFlow
@@ -32,6 +34,7 @@ import love.forte.simbot.ExperimentalSimbotApi
 import love.forte.simbot.MutableAttributeMap
 import love.forte.simbot.event.*
 import org.slf4j.LoggerFactory
+import java.util.concurrent.CompletionStage
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -85,10 +88,17 @@ internal class SimpleEventProcessingContextResolver(
     override suspend fun appendResultIntoContext(
         context: SimpleEventProcessingContext, result: EventResult,
     ): ListenerInvokeType {
-        if (result != EventResult.Invalid) {
-            val newResult = tryCollect(result)
-            context.addResult(newResult)
+        when (result) {
+            EventResult.Invalid -> {}
+            is AsyncEventResult -> {
+                context.addResult(result)
+            }
+            
+            else -> {
+                context.addResult(tryCollect(result))
+            }
         }
+        
         return if (result.isTruncated) ListenerInvokeType.TRUNCATED
         else ListenerInvokeType.CONTINUE
     }
@@ -195,65 +205,84 @@ internal class SimpleEventProcessingContextResolver(
         }
         
         private suspend fun tryCollect(result: EventResult): EventResult {
-            if (result !is SimpleEventResult) return result
+            if (result !is ReactivelyCollectableEventResult) return result
             val content = result.content ?: return result
             
-            if (content is kotlinx.coroutines.flow.Flow<*>) {
-                return result.copy(newContent = content.toList())
-            }
-            
-            if (reactorSupport) {
-                when (content) {
-                    is reactor.core.publisher.Flux<*> -> return if (reactiveKotlinSupport) result.copy(
-                        newContent = content.asFlow().toList()
-                    ) else result // else return itself
-                    
-                    is reactor.core.publisher.Mono<*> -> return if (reactorKotlinSupport) result.copy(newContent = content.awaitSingleOrNull()) else result
+            when {
+                content is kotlinx.coroutines.flow.Flow<*> -> {
+                    return result.collected(content.toList())
                 }
-            }
-            
-            if (rx2Support) {
-                when (content) {
-                    is io.reactivex.CompletableSource -> {
-                        content.await() // Just await
-                        return result.copy(newContent = null)
+                
+                content is CompletionStage<*> -> {
+                    return result.collected(content.await())
+                }
+                
+                content is Deferred<*> -> {
+                    return result.collected(content.await())
+                }
+                
+                reactorSupport -> {
+                    when (content) {
+                        is reactor.core.publisher.Flux<*> -> return if (reactiveKotlinSupport) result.collected(
+                            content.asFlow().toList()
+                        ) else result // else return itself
+                        
+                        is reactor.core.publisher.Mono<*> -> return if (reactorKotlinSupport) result.collected(content.awaitSingleOrNull()) else result
                     }
-                    is io.reactivex.SingleSource<*> -> return if (rx2KotlinSupport) result.copy(newContent = content.await()) else result
-                    is io.reactivex.MaybeSource<*> -> return if (rx2KotlinSupport) result.copy(newContent = content.awaitSingleOrNull()) else result
-                    is io.reactivex.ObservableSource<*> -> return if (reactiveKotlinSupport) result.copy(
-                        newContent = content.asFlow().toList()
-                    ) else result
-                    is io.reactivex.Flowable<*> -> return if (reactiveKotlinSupport) result.copy(
-                        newContent = content.asFlow().toList()
-                    ) else result
                 }
-            }
-            
-            if (rx3Support) {
-                when (content) {
-                    is io.reactivex.rxjava3.core.Completable -> {
-                        content.await()
-                        return result.copy(newContent = null)
+                
+                rx2Support -> {
+                    when (content) {
+                        is io.reactivex.CompletableSource -> {
+                            content.await() // Just await
+                            return result.collected(null)
+                        }
+                        
+                        is io.reactivex.SingleSource<*> -> return if (rx2KotlinSupport) result.collected(content.await()) else result
+                        is io.reactivex.MaybeSource<*> -> return if (rx2KotlinSupport) result.collected(content.awaitSingleOrNull()) else result
+                        is io.reactivex.ObservableSource<*> -> return if (reactiveKotlinSupport) result.collected(
+                            content.asFlow().toList()
+                        ) else result
+                        
+                        is io.reactivex.Flowable<*> -> return if (reactiveKotlinSupport) result.collected(
+                            content.asFlow().toList()
+                        ) else result
                     }
-                    is io.reactivex.rxjava3.core.SingleSource<*> -> return if (rx3KotlinSupport) result.copy(newContent = content.await()) else result
-                    is io.reactivex.rxjava3.core.MaybeSource<*> -> return if (rx3KotlinSupport) result.copy(newContent = content.awaitSingleOrNull()) else result
-                    is io.reactivex.rxjava3.core.ObservableSource<*> -> return result.copy(
-                        newContent = content.asFlow().toList()
-                    )
-                    is io.reactivex.rxjava3.core.Flowable<*> -> return result.copy(
-                        newContent = content.asFlow().toList()
-                    )
+                }
+                
+                rx3Support -> {
+                    when (content) {
+                        is io.reactivex.rxjava3.core.Completable -> {
+                            content.await()
+                            return result.collected(null)
+                        }
+                        
+                        is io.reactivex.rxjava3.core.SingleSource<*> -> return if (rx3KotlinSupport) result.collected(
+                            content.await()
+                        ) else result
+                        
+                        is io.reactivex.rxjava3.core.MaybeSource<*> -> return if (rx3KotlinSupport) result.collected(
+                            content.awaitSingleOrNull()
+                        ) else result
+                        
+                        is io.reactivex.rxjava3.core.ObservableSource<*> -> return result.collected(
+                            content.asFlow().toList()
+                        )
+                        
+                        is io.reactivex.rxjava3.core.Flowable<*> -> return result.collected(
+                            content.asFlow().toList()
+                        )
+                    }
+                }
+                
+                reactiveSupport -> {
+                    when (content) {
+                        is org.reactivestreams.Publisher<*> -> return if (reactiveKotlinSupport) result.collected(
+                            content.asFlow().toList()
+                        ) else result
+                    }
                 }
             }
-            
-            if (reactiveSupport) {
-                when (content) {
-                    is org.reactivestreams.Publisher<*> -> return if (reactiveKotlinSupport) result.copy(
-                        newContent = content.asFlow().toList()
-                    ) else result
-                }
-            }
-            
             
             return result
         }

--- a/simbot-cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleListenerBuilder.kt
+++ b/simbot-cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleListenerBuilder.kt
@@ -321,7 +321,7 @@ public class SimpleListenerRegistrationDescriptionBuilder<E : Event>(target: Eve
     }
     
     override fun buildDescription(): EventListenerRegistrationDescription {
-        return build().toRegistrationDescription()
+        return build().toRegistrationDescription(priority = priority, isAsync = isAsync)
     }
     
 }

--- a/simbot-cores/simbot-core/src/test/kotlin/EventAsyncProcessingTest.kt
+++ b/simbot-cores/simbot-core/src/test/kotlin/EventAsyncProcessingTest.kt
@@ -1,0 +1,186 @@
+import kotlinx.coroutines.*
+import kotlinx.coroutines.future.asCompletableFuture
+import kotlinx.serialization.modules.EmptySerializersModule
+import kotlinx.serialization.modules.SerializersModule
+import love.forte.simbot.*
+import love.forte.simbot.bot.Bot
+import love.forte.simbot.bot.BotManager
+import love.forte.simbot.bot.BotVerifyInfo
+import love.forte.simbot.core.event.buildSimpleListenerRegistrationDescription
+import love.forte.simbot.core.event.simpleListenerManager
+import love.forte.simbot.definition.Contact
+import love.forte.simbot.definition.Group
+import love.forte.simbot.definition.Guild
+import love.forte.simbot.event.*
+import love.forte.simbot.message.Image
+import love.forte.simbot.message.Image.Key.toImage
+import love.forte.simbot.message.doSafeCast
+import love.forte.simbot.resources.Resource.Companion.toResource
+import love.forte.simbot.utils.item.Items
+import love.forte.simbot.utils.item.Items.Companion.emptyItems
+import org.slf4j.Logger
+import java.io.File
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ *
+ * @author ForteScarlet
+ */
+class EventAsyncProcessingTest {
+    private val manager = simpleListenerManager { }
+    private val botManager = TestBotManager(manager)
+    private val bot = botManager.createBot()
+    
+    @OptIn(ExperimentalSimbotApi::class)
+    @Test
+    fun reactivelyResultTest() {
+        manager.register(buildSimpleListenerRegistrationDescription(TestEvent) {
+            priority = PriorityConstant.PRIORITIZED_1
+            handle {
+                EventResult.of(bot.async {
+                    delay(50)
+                    "Hello"
+                })
+            }
+        })
+        manager.register(buildSimpleListenerRegistrationDescription(TestEvent) {
+            priority = PriorityConstant.PRIORITIZED_2
+            handle {
+                EventResult.of(bot.async {
+                    delay(50)
+                    "World"
+                }.asCompletableFuture())
+            }
+        })
+    
+        val resultContent = runBlocking {
+            val results = manager.push(TestEvent(bot)).results
+            assertEquals(2, results.size, "result size")
+            results.joinToString(" ") { it.content.toString() }
+        }
+        
+        assertEquals("Hello World", resultContent, "result content")
+    }
+    
+    @OptIn(ExperimentalSimbotApi::class)
+    @Test
+    fun asyncResultTest() {
+        manager.register(buildSimpleListenerRegistrationDescription(TestEvent) {
+            priority = PriorityConstant.PRIORITIZED_1
+            isAsync = true
+            handle {
+                delay(50)
+                EventResult.of("Hello")
+            }
+        })
+        manager.register(buildSimpleListenerRegistrationDescription(TestEvent) {
+            priority = PriorityConstant.PRIORITIZED_2
+            isAsync = true
+            handle {
+                delay(50)
+                EventResult.of("World")
+            }
+        })
+    
+        val resultContent = runBlocking {
+            val results = manager.push(TestEvent(bot)).results
+            assertEquals(2, results.size, "result size")
+            results.joinToString(" ") {
+                it as AsyncEventResult
+                runBlocking { it.awaitContent() }.content.toString()
+            }
+        }
+        
+        assertEquals("Hello World", resultContent, "result content")
+    }
+    
+    
+}
+
+
+private class TestEvent(override val bot: Bot) : Event {
+    override val id: ID = randomID()
+    override val timestamp: Timestamp = Timestamp.now()
+    override val key: Event.Key<out Event>
+        get() = Key
+    
+    companion object Key : BaseEventKey<TestEvent>("test.test") {
+        override fun safeCast(value: Any): TestEvent? = doSafeCast(value)
+    }
+}
+
+
+private class TestBot(override val manager: TestBotManager, override val eventProcessor: EventProcessor, pj: Job) :
+    Bot {
+    private val job = Job(pj)
+    override val coroutineContext: CoroutineContext = EmptyCoroutineContext
+    override val id: ID = "forte".ID
+    override val username: String = "forte"
+    override val avatar: String = ""
+    override val logger: Logger = LoggerFactory.getLogger<TestBot>()
+    override val component: Component = TestComponent
+    override fun isMe(id: ID): Boolean = id == this.id
+    override suspend fun resolveImage(id: ID): Image<*> {
+        return File("").toResource().toImage()
+    }
+    
+    override suspend fun start(): Boolean = true
+    override suspend fun join() = job.join()
+    override suspend fun cancel(reason: Throwable?): Boolean {
+        job.cancel(reason?.let { CancellationException(it.localizedMessage, it) })
+        return true
+    }
+    
+    override val isStarted: Boolean = true
+    override val isActive: Boolean get() = job.isActive
+    override val isCancelled: Boolean get() = job.isCancelled
+    override val contacts: Items<Contact> = emptyItems()
+    override suspend fun contact(id: ID): Contact? = null
+    override val groups: Items<Group> = emptyItems()
+    override suspend fun group(id: ID): Group? = null
+    override val guilds: Items<Guild> = emptyItems()
+    override suspend fun guild(id: ID): Guild? = null
+}
+
+private object TestComponent : Component {
+    override val id: String = "test"
+    override val componentSerializersModule: SerializersModule
+        get() = EmptySerializersModule()
+}
+
+private class TestBotManager(private val eventProcessor: EventProcessor) : BotManager<TestBot>() {
+    override val coroutineContext: CoroutineContext = EmptyCoroutineContext
+    override val component: Component = TestComponent
+    private val job = Job()
+    
+    override suspend fun join() = job.join()
+    
+    override fun invokeOnCompletion(handler: CompletionHandler) {
+        job.invokeOnCompletion(handler)
+    }
+    
+    override suspend fun start(): Boolean = true
+    
+    override val isStarted: Boolean = true
+    override val isActive: Boolean
+        get() = job.isActive
+    override val isCancelled: Boolean
+        get() = job.isCancelled
+    
+    override fun register(verifyInfo: BotVerifyInfo): Bot = createBot()
+    fun createBot(): Bot = TestBot(this, eventProcessor, job)
+    
+    override suspend fun doCancel(reason: Throwable?): Boolean {
+        job.cancel(reason?.let { CancellationException(it.localizedMessage, it) })
+        return true
+    }
+    
+    override fun get(id: ID): TestBot? {
+        return null
+    }
+    
+    override fun all(): List<TestBot> = emptyList()
+}


### PR DESCRIPTION
调整EventResult下整体实现结构. 
- 增加类型 `SpecialEventResult` 描述特殊含义的实现
- 增加类型 `AsyncEventResult` 描述标准异步结果的类型
- 增加类型 `ReactivelyCollectableEventResult` 描述可以收集响应式/异步结果的类型

例如:

```kotlin
manager.register(buildSimpleListener(TestEvent) {
    handle {
        // 此处返回的是 Deferred<String>
        EventResult.of(bot.async {
            delay(50)
            "Hello World"
        })
    }
})

// ...

val results = manager.push(TestEvent(bot)).results
results.first().content == "Hello World" // true
```

除了 `Deferred` 和 `Flow` 的支持以外, 这更多的会降低Java在simbot中进行全异步开发的难度(配合#460), 可以仅通过 `CompletableFuture` 就能完成更高效的异步开发.

例如:

```java
@Listener
public CompletableFuture<String> onEvent(FriendMessageEvent event, EventProcessingContext context) {
    // 此处为消息发送后的回执(在future中)
    final CompletableFuture<? extends MessageReceipt> receiptFuture = event.getFriendAsync()
            // 获取好友信息, 并向这个好友发送一句"Hello"
            .thenCompose(friend -> friend.sendAsync("Hello"));

    return event.getBot()
            // 等待30s之后
            .delay(Duration.ofSeconds(30), () -> {})
            // 删除(撤回)上面发的"Hello"
            .thenCombine(receiptFuture, (v, receipt) -> receipt.deleteAsync())
            // 得到删除后的结果
            .thenCompose(Function.identity())
            .thenApply(deleted -> deleted ? "删除成功" : "删除失败")
    ;
}
```
