### PR TITLE
SimpleEventListenerManager 实现中增加默认调度器

### DIFF
--- a/simbot-cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleEventListenerManager.kt
+++ b/simbot-cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleEventListenerManager.kt
@@ -50,7 +50,6 @@ public interface CoreListenerManager : SimpleEventListenerManager
  * 立即返回一个 [AsyncEventResult].
  *
  *
- *
  * ## 监听函数的解析、缓存与获取
  * 在 [SimpleEventListenerManager] 中，真正被执行的监听函数是经过缓存与转化的，它们只会在遇到一个目前缓存中未知的事件类型的时候进行同步转化缓存。
  *
@@ -73,6 +72,8 @@ public interface CoreListenerManager : SimpleEventListenerManager
  *
  * 但是这存在例外：当存在任何通过 [ContinuousSessionContext] 而注册的持续会话监听函数的时候，[isProcessable] 将会始终得到 `true`。
  *
+ * 需要注意的是, [isProcessable] 的结果并不保证是 **"强可靠"** 的。由于对监听函数动态增删的支持，其内部持有的监听函数集应当保证线程安全，
+ * 但是不会保证**强一致性**。这可能会导致当一个监听函数被追加的这一**瞬间**，[isProcessable] 仍无法感知到它的存在。
  *
  *
  */

--- a/simbot-cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleEventListenerManagerImpl.kt
+++ b/simbot-cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleEventListenerManagerImpl.kt
@@ -45,6 +45,11 @@ internal class SimpleEventListenerManagerImpl internal constructor(
             LoggerFactory.getLogger("love.forte.simbot.core.event.SimpleEventListenerManagerImpl")
         
         private const val EVENT_KEY_PROCESSABLE_COUNTER_CLEAR_THRESHOLD = 83
+    
+        /**
+         * 是否禁用产生内部使用的默认调度器。
+         */
+        private const val DISABLE_DEFAULT_DISPATCHER = "love.forte.simbot.core.SimpleListenerManager.disableDefaultDispatcher"
         
     }
     
@@ -213,8 +218,12 @@ internal class SimpleEventListenerManagerImpl internal constructor(
     
         @OptIn(ExperimentalStdlibApi::class, ExperimentalCoroutinesApi::class)
         if (context[CoroutineDispatcher] == null) {
-            // todo configurable
-            context += Dispatchers.Default.limitedParallelism(Runtime.getRuntime().availableProcessors().coerceAtLeast(16))
+            if (System.getProperty(DISABLE_DEFAULT_DISPATCHER).toBoolean()) {
+                // todo configurable
+                context += Dispatchers.Default.limitedParallelism(Runtime.getRuntime().availableProcessors().coerceAtLeast(16))
+            } else {
+                logger.debug("No dispatcher for current simple listener manager, and default dispatcher is disabled.")
+            }
         }
         
         managerCoroutineContext = context

--- a/simbot-cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleEventListenerManagerImpl.kt
+++ b/simbot-cores/simbot-core/src/main/kotlin/love/forte/simbot/core/event/SimpleEventListenerManagerImpl.kt
@@ -214,7 +214,7 @@ internal class SimpleEventListenerManagerImpl internal constructor(
         @OptIn(ExperimentalStdlibApi::class, ExperimentalCoroutinesApi::class)
         if (context[CoroutineDispatcher] == null) {
             // todo configurable
-            context += Dispatchers.Default.limitedParallelism(16)
+            context += Dispatchers.Default.limitedParallelism(Runtime.getRuntime().availableProcessors().coerceAtLeast(16))
         }
         
         managerCoroutineContext = context


### PR DESCRIPTION
当 `SimpleEventListenerManager` 配置实例中的 `context` 中没有 `CoroutineDispatcher` 时，提供一个默认的最低允许16并发的调度器。

此行为可以通过JVM参数 `love.forte.simbot.core.SimpleListenerManager.disableDefaultDispatcher=true` 来关闭。