### PR TITLE
为 `ContactsContainer`、`GroupsContainer`、`GuildsContainer` 提供可用性属性

### DIFF
--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/SocialRelationsContainers.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/SocialRelationsContainers.kt
@@ -97,7 +97,7 @@ public interface ContactsContainer : SocialRelationsContainer {
     
     /**
      * 是否支持contacts相关的获取操作。当 [contacts] 和 [contact] 都不被支持时得到 `false`。
-     * 默认情况下视其为 `true`，即支持，由实现者重写此属性来决定其可用性。
+     * 默认情况下视其为 `true`，由实现者重写此属性来决定其可用性。
      *
      * 当不支持的情况下（[isContactsSupported] == false）, [contacts] 和 [contact] 不可用。
      * 不可用可能会表现为得到默认的[空序列][Items.emptyItems]（[contacts]）和 `null`（[contact]），
@@ -147,7 +147,18 @@ public interface ContactsContainer : SocialRelationsContainer {
 public interface GroupsContainer : SocialRelationsContainer {
     
     /**
-     * 获取当前bot所处的群序列。
+     * 是否支持groups相关的获取操作。当 [groups] 和 [group] 都不被支持时得到 `false`。
+     * 默认情况下视其为 `true`，由实现者重写此属性来决定其可用性。
+     *
+     * 当不支持的情况下（[isGroupsSupported] == false）, [groups] 和 [group] 不可用。
+     * 不可用可能会表现为得到默认的[空序列][Items.emptyItems]（[groups]）和 `null`（[group]），
+     * 也有可能会表现为抛出异常。
+     *
+     */
+    public val isGroupsSupported: Boolean get() = true
+    
+    /**
+     * 获取当前bot所处的群聊序列。
      *
      */
     public val groups: Items<Group>

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/SocialRelationsContainers.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/SocialRelationsContainers.kt
@@ -28,6 +28,10 @@ import love.forte.simbot.utils.item.Items
  * 通常与 [Bot] 的社交关系相关，大部分子类型也都通过 [Bot] 默认实现。
  *
  * @see Bot
+ * @see FriendsContainer
+ * @see ContactsContainer
+ * @see GroupsContainer
+ * @see GuildsContainer
  */
 public sealed interface SocialRelationsContainer : SuspendablePropertyContainer
 
@@ -37,20 +41,20 @@ public sealed interface SocialRelationsContainer : SuspendablePropertyContainer
  *
  * 通常应用于 [Bot] 中为其提供获取 [Friend] 相关的属性api。
  *
- * [Bot] 或许会存在一些 "好友" 对象，但是默认情况下 [Bot] 不会默认实现 [FriendsContainer]，
+ * [Bot] 或许会存在一些 "好友" 对象，但是 [Bot] 不会默认实现 [FriendsContainer]，
  * 取而代之的是 [ContactsContainer]。当组件存在支持 [Friend] 相关操作的时候可以进行额外实现。
  *
- * "好友"并 _**不一定**_ 代表那些需要 "添加申请"、"同意" 后出现在好友列表中的好友 ——
- * 并非所有的组件都支持这种“好友”的概念。
+ * "好友"并 _**不一定**_ 代表那些需要 "添加申请"、"同意" 后出现在好友列表中的好友，
+ * 也并非所有的组件都支持“好友”的概念。
  *
- * 对于一个以"频道"概念为主的组件就是最常见的例子 —— 它们通常没有真正的"好友"概念，
+ * 对于一个以"频道"概念为主的组件就是最常见的例子（例如Kook） —— 它们通常没有真正的"好友"概念，
  * 至少对于bot来讲没有。取而代之的则通常是"频道成员"或者一个"会话"。
  *
  * 实际上，对于一个bot来讲"好友"的概念确实可有可无，它更需要"[联系人][Contact]"。
  *
  * 在一个容器同时支持 [FriendsContainer] 和 [ContactsContainer]
  * 的情况下，[FriendsContainer] 中能够得到的目标常常为 [ContactsContainer]
- * 的子集。
+ * 的**子集**。_但是这并不绝对。_
  *
  * @see ContactsContainer
  *
@@ -62,7 +66,6 @@ public interface FriendsContainer : SocialRelationsContainer {
      *
      */
     public val friends: Items<Friend>
-    
     
     /**
      * 通过唯一标识获取这个容器对应的某个好友，获取不到则为null。
@@ -81,13 +84,13 @@ public interface FriendsContainer : SocialRelationsContainer {
  *
  * 通常应用于 [Bot] 中为其提供获取 [Contact] 相关的属性api。
  *
- * [联系人][Contact] 通常代表为与当前容器存在"会话"的联系人，
+ * [联系人][Contact] 通常代表为与当前容器存在"会话"或可以建立会话的目标，
  * 它们之间必须存在一种硬性关系（例如它们之间是 [好友][Friend] 关系）
  * 或者存在一个被创建过的"会话"（例如某联系人主动与bot进行过交流或者
- * 与当前容器创建过与某个目标的会话）。
+ * 与当前容器（[Bot]）创建过与某个目标的会话）。
  *
  * 因上述约束，[ContactsContainer.contacts] 通常不具备检索 组织成员 [Member]
- * 这类间接联系人的能力, 尽管 [Member] 也属于 [Contact] 类型 ———— 除非它们与当前容器存在可查会话。
+ * 这类**间接**联系人的能力, 尽管 [Member] 也属于 [Contact] 类型 ———— 除非它们与当前容器存在**直接**会话。
  *
  * 当一个bot中，所有可能的联系人都是与bot存在硬性关系（例如它们之间是 [好友][Friend] 关系）的时候，
  * [ContactsContainer] 的表现将会与 [FriendsContainer] 类似。
@@ -105,6 +108,7 @@ public interface ContactsContainer : SocialRelationsContainer {
      *
      */
     public val isContactsSupported: Boolean get() = true
+    
     /**
      * 得到当前容器中能够获取到的联系人序列。
      *
@@ -121,7 +125,6 @@ public interface ContactsContainer : SocialRelationsContainer {
      *
      */
     public val contacts: Items<Contact>
-    
     
     /**
      * 通过唯一标识获取对应的 [Contact] 实例。当且仅当因标识对应联系人不存在而导致无法获取时得到null。

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/SocialRelationsContainers.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/SocialRelationsContainers.kt
@@ -97,10 +97,14 @@ public interface ContactsContainer : SocialRelationsContainer {
     
     /**
      * 是否支持contacts相关的获取操作。当 [contacts] 和 [contact] 都不被支持时得到 `false`。
-     * 默认情况下视其为 `true`，即支持，是否真的支持需要由实现者决定。
+     * 默认情况下视其为 `true`，即支持，由实现者重写此属性来决定其可用性。
+     *
+     * 当不支持的情况下（[isContactsSupported] == false）, [contacts] 和 [contact] 不可用。
+     * 不可用可能会表现为得到默认的[空序列][Items.emptyItems]（[contacts]）和 `null`（[contact]），
+     * 也有可能会表现为抛出异常。
+     *
      */
     public val isContactsSupported: Boolean get() = true
-    
     /**
      * 得到当前容器中能够获取到的联系人序列。
      *

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/SocialRelationsContainers.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/SocialRelationsContainers.kt
@@ -183,6 +183,17 @@ public interface GroupsContainer : SocialRelationsContainer {
 public interface GuildsContainer : SocialRelationsContainer {
     
     /**
+     * 是否支持guilds相关的获取操作。当 [guilds] 和 [guild] 都不被支持时得到 `false`。
+     * 默认情况下视其为 `true`，由实现者重写此属性来决定其可用性。
+     *
+     * 当不支持的情况下（[isGuildsSupported] == false）, [guilds] 和 [guild] 不可用。
+     * 不可用可能会表现为得到默认的[空序列][Items.emptyItems]（[guilds]）和 `null`（[guild]），
+     * 也有可能会表现为抛出异常。
+     *
+     */
+    public val isGuildsSupported: Boolean get() = true
+    
+    /**
      * 获取当前的所有频道服务器序列。
      */
     public val guilds: Items<Guild>

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/SocialRelationsContainers.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/definition/SocialRelationsContainers.kt
@@ -96,6 +96,12 @@ public interface FriendsContainer : SocialRelationsContainer {
 public interface ContactsContainer : SocialRelationsContainer {
     
     /**
+     * 是否支持contacts相关的获取操作。当 [contacts] 和 [contact] 都不被支持时得到 `false`。
+     * 默认情况下视其为 `true`，即支持，是否真的支持需要由实现者决定。
+     */
+    public val isContactsSupported: Boolean get() = true
+    
+    /**
      * 得到当前容器中能够获取到的联系人序列。
      *
      * 联系人序列不能保证结果为 **_预期内的_ 全量** 序列，尤其是对于一个 [Bot] 而言。


### PR DESCRIPTION
为它们提供各自的 `isXxxSupported` （例如 `GroupsContainer.isGroupsSupported`），提供判断相关api的可用性属性。

