### PR TITLE
尝试优化 Spring Boot Starter 中监听函数与bot的注册流程

### DIFF
--- a/simbot-boots/simboot-core-spring-boot-starter/build.gradle.kts
+++ b/simbot-boots/simboot-core-spring-boot-starter/build.gradle.kts
@@ -18,14 +18,13 @@ plugins {
     id("simbot.boot-module-conventions")
     `simbot-jvm-maven-publish`
     kotlin("plugin.serialization")
-    // kotlin("kapt")
+    kotlin("kapt")
 }
 
 
 dependencies {
-    api(project(":simbot-boots:simboot-core")) {
-        exclude("love.forte.simbot","simbot-logger")
-    }
+    api(project(":simbot-boots:simboot-core"))
+    
 
     api(libs.javax.inject)
     api(libs.forte.di.spring)
@@ -33,8 +32,8 @@ dependencies {
 
     implementation(libs.spring.boot.autoconfigure)
     implementation(libs.spring.boot.configuration.processor)
-    // annotationProcessor(libs.spring.boot.configuration.processor)
-    // kapt(libs.spring.boot.configuration.processor)
+    annotationProcessor(libs.spring.boot.configuration.processor)
+    kapt(libs.spring.boot.configuration.processor)
 
     compileOnly(libs.javax.annotation.api)
     compileOnly(libs.forte.annotationTool.api)

--- a/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/DependAutowiredConfig.kt
+++ b/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/DependAutowiredConfig.kt
@@ -21,7 +21,7 @@ import org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostP
 import org.springframework.beans.factory.config.SmartInstantiationAwareBeanPostProcessor
 
 
-private fun getMyAutowiredAnnotationBeanPostProcessor(): AutowiredAnnotationBeanPostProcessor =
+private fun getDependAnnotationBeanPostProcessor(): AutowiredAnnotationBeanPostProcessor =
     AutowiredAnnotationBeanPostProcessor().also {
         it.setAutowiredAnnotationType(Depend::class.java)
     }
@@ -32,4 +32,4 @@ private fun getMyAutowiredAnnotationBeanPostProcessor(): AutowiredAnnotationBean
  */
 public open class AutowiredConfig :
     SmartInstantiationAwareBeanPostProcessor
-    by getMyAutowiredAnnotationBeanPostProcessor()
+    by getDependAnnotationBeanPostProcessor()

--- a/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/EnableSimbot.kt
+++ b/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/EnableSimbot.kt
@@ -16,7 +16,6 @@
 
 package love.forte.simboot.spring.autoconfigure
 
-import love.forte.simboot.listener.ParameterBinderFactory
 import org.springframework.context.annotation.Import
 
 /**
@@ -58,5 +57,11 @@ import org.springframework.context.annotation.Import
     SimbotSpringBootDefaultConfigures::class,
     // app
     SimbotSpringBootApplicationConfiguration::class,
+    // after application
+    
+    // listener register
+    SimbotSpringBootListenerAutoRegisterBuildConfigure::class,
+    // bot register
+    SimbotSpringBootBotAutoRegisterBuildConfigure::class,
 )
 public annotation class EnableSimbot

--- a/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/SimbotListenerMethodProcessor.kt
+++ b/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/SimbotListenerMethodProcessor.kt
@@ -103,7 +103,6 @@ public class SimbotListenerMethodProcessor : ApplicationContextAware, BeanDefini
         instanceBinders(beanFactory, globalBinderFactories, idBinderFactories)
         functionalBinders(beanFactory, globalBinderFactories, idBinderFactories)
         
-        
         return CoreBinderManager(globalBinderFactories, idBinderFactories)
     }
     

--- a/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/SimbotSpringBootApplicationConfiguration.kt
+++ b/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/SimbotSpringBootApplicationConfiguration.kt
@@ -20,9 +20,10 @@ import love.forte.simboot.spring.autoconfigure.application.SpringBootApplication
 import love.forte.simboot.spring.autoconfigure.application.SpringBootApplicationConfiguration
 import love.forte.simboot.spring.autoconfigure.application.SpringBootApplicationConfigurationProperties
 import love.forte.simboot.spring.autoconfigure.application.springBootApplication
-import love.forte.simbot.Api4J
 import love.forte.simbot.application.Application
 import love.forte.simbot.event.EventListenerManager
+import love.forte.simbot.logger.LoggerFactory
+import love.forte.simbot.logger.logger
 import love.forte.simbot.utils.runInNoScopeBlocking
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.ApplicationArguments
@@ -77,7 +78,6 @@ public open class SimbotSpringBootApplicationConfiguration : ResourceLoaderAware
     /**
      * 构建 [simbot application][Application].
      */
-    @OptIn(Api4J::class)
     @Bean(destroyMethod = "shutdownBlocking")
     @ConditionalOnMissingBean(Application::class)
     public fun simbotSpringBootApplication(
@@ -86,9 +86,9 @@ public open class SimbotSpringBootApplicationConfiguration : ResourceLoaderAware
         @Autowired(required = false) applicationConfigures: List<SimbotSpringBootApplicationBuildConfigure>? = null,
         coroutineDispatcherContainer: CoroutineDispatcherContainer,
     ): SpringBootApplication {
-        initialConfiguration.applicationContext
-        
         return runInNoScopeBlocking {
+            logger.debug("Launching application...")
+    
             springBootApplication(initialConfiguration,
                 {
                     // initial
@@ -105,6 +105,8 @@ public open class SimbotSpringBootApplicationConfiguration : ResourceLoaderAware
                 }
                 // TODO..?
             }.launch()
+        }.also {
+            logger.debug("Application launched. {}", it)
         }
     }
     
@@ -126,4 +128,7 @@ public open class SimbotSpringBootApplicationConfiguration : ResourceLoaderAware
     // endregion
     
     
+    public companion object {
+        private val logger = LoggerFactory.logger<SimbotSpringBootApplicationConfiguration>()
+    }
 }

--- a/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/SimbotSpringBootComponentAutoInstallBuildConfigure.kt
+++ b/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/SimbotSpringBootComponentAutoInstallBuildConfigure.kt
@@ -21,6 +21,7 @@ import love.forte.simboot.spring.autoconfigure.application.SpringBootApplication
 import love.forte.simbot.Component
 import love.forte.simbot.ComponentFactory
 import love.forte.simbot.installAllComponents
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 
 
@@ -78,12 +79,20 @@ public open class SimbotSpringBootComponentAutoInstallBuildConfigure(
     private val factories: List<ComponentFactory<*, *>> = factories ?: emptyList()
     
     override fun SpringBootApplicationBuilder.config(configuration: SpringBootApplicationConfiguration) {
+        logger.info("The number of Installable Event Provider Factories is {}", factories.size)
         if (factories.isEmpty()) {
-            installAllComponents(configuration.classLoader)
+            val classLoader = configuration.classLoader
+            logger.info("Install components by [installAllComponents] via classLoader {}", classLoader)
+            installAllComponents(classLoader)
         } else {
+            logger.debug("Install components by: {}", factories)
             factories.forEach {
                 install(it)
             }
         }
+    }
+    
+    public companion object {
+        private val logger = LoggerFactory.getLogger(SimbotSpringBootComponentAutoInstallBuildConfigure::class.java)
     }
 }

--- a/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/SimbotSpringBootDefaultConfigures.kt
+++ b/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/SimbotSpringBootDefaultConfigures.kt
@@ -30,11 +30,8 @@ import org.springframework.context.annotation.Import
     DefaultBinderFactoryConfigure::class,
     // listeners
     SimbotListenerMethodProcessor::class,
-    SimbotSpringBootListenerAutoRegisterBuildConfigure::class,
-    //
-    SimbotSpringBootBotAutoRegisterBuildConfigure::class,
     SimbotSpringBootComponentAutoInstallBuildConfigure::class,
     SimbotSpringBootEventProviderAutoInstallBuildConfigure::class,
     SimbotSpringBootInterceptorsAutoConfigure::class,
-    )
+)
 public open class SimbotSpringBootDefaultConfigures

--- a/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/SimbotSpringBootEventProviderAutoInstallBuildConfigure.kt
+++ b/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/SimbotSpringBootEventProviderAutoInstallBuildConfigure.kt
@@ -79,11 +79,13 @@ public open class SimbotSpringBootEventProviderAutoInstallBuildConfigure(
 ) : SimbotSpringBootApplicationBuildConfigure {
     private val factories: List<EventProviderFactory<*, *>> = factories ?: emptyList()
     override fun SpringBootApplicationBuilder.config(configuration: SpringBootApplicationConfiguration) {
-        logger.info("The number of Installable Event Provider Factory is {}", factories.size)
+        logger.info("The number of Installable event provider Factories is {}", factories.size)
         if (factories.isEmpty()) {
-            logger.info("Install Event Providers by [installAllEventProviders]")
-            installAllEventProviders(configuration.classLoader)
+            val classLoader = configuration.classLoader
+            logger.info("Install event providers by [installAllEventProviders] via classLoader {}", classLoader)
+            installAllEventProviders(classLoader)
         } else {
+            logger.debug("Install event providers by: {}", factories)
             factories.forEach {
                 install(it)
             }

--- a/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/SimbotTopLevelScanProcessor.kt
+++ b/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/SimbotTopLevelScanProcessor.kt
@@ -191,7 +191,7 @@ public class SimbotTopLevelListenerScanProcessor : AbstractSimbotTopLevelScanPro
                         val beanName = DefaultBeanNameGenerator.INSTANCE.generateBeanName(
                             beanDefinition,
                             registry
-                        ) + "#GENERATED_TOP_LISTENER"
+                        ) + "#${methodMetadata.methodName}#GENERATED_TOP_LISTENER"
                         registry.registerBeanDefinition(beanName, beanDefinition)
                         logger.debug(
                             "Created new bean definition for top-level EventListener. beanName={}, definition={}",
@@ -222,7 +222,7 @@ public class SimbotTopLevelListenerScanProcessor : AbstractSimbotTopLevelScanPro
                         val beanName = beanNameGenerator.generateBeanName(
                             beanDefinition,
                             registry
-                        ) + "#GENERATED_TOP_LISTENER_FUNCTION"
+                        ) + "#${methodMetadata.methodName}#GENERATED_TOP_LISTENER_FUNCTION"
                         
                         registry.registerBeanDefinition(beanName, beanDefinition)
                         processedMethod.add(method)
@@ -256,7 +256,7 @@ public class SimbotTopLevelListenerScanProcessor : AbstractSimbotTopLevelScanPro
                             val beanName = DefaultBeanNameGenerator.INSTANCE.generateBeanName(
                                 beanDefinition,
                                 registry
-                            ) + "#GENERATED_TOP_LISTENER_FUNCTION"
+                            ) + "#${methodMetadata.methodName}#GENERATED_TOP_LISTENER_FUNCTION"
                             registry.registerBeanDefinition(beanName, beanDefinition)
                             processedMethod.add(method)
                             logger.debug(

--- a/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/application/SpringBootApplicationConfiguration.kt
+++ b/simbot-boots/simboot-core-spring-boot-starter/src/main/kotlin/love/forte/simboot/spring/autoconfigure/application/SpringBootApplicationConfiguration.kt
@@ -18,8 +18,6 @@ package love.forte.simboot.spring.autoconfigure.application
 
 import love.forte.simboot.core.application.BootApplicationConfiguration
 import love.forte.simboot.core.application.BootApplicationConfiguration.Companion.DEFAULT_BOT_VERIFY_GLOB
-import love.forte.simboot.listener.ParameterBinderFactory
-import love.forte.simboot.spring.autoconfigure.EnableSimbot
 import love.forte.simbot.bot.Bot
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory

--- a/simbot-boots/simboot-core-spring-boot-starter/src/test/kotlin/love/forli/test/SpringBootApp.kt
+++ b/simbot-boots/simboot-core-spring-boot-starter/src/test/kotlin/love/forli/test/SpringBootApp.kt
@@ -113,7 +113,8 @@ open class MyListener {
 open class MyListenerConfiguration2 {
     
     @Bean
-    open fun myListener2() = buildSimpleListener(FriendMessageEvent) {
+    open fun myListener2(application: SpringBootApplication) = buildSimpleListener(FriendMessageEvent) {
+        println("APP: $application")
         process {}
     }
     


### PR DESCRIPTION
理论上来说，现在可以在监听函数配置类中直接使用 `Application` 而不会导致循环依赖