### PR TITLE
调整 MessageReceipt 结构与实现

### DIFF
--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/action/SendSupport.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/action/SendSupport.kt
@@ -18,7 +18,6 @@ package love.forte.simbot.action
 
 import love.forte.plugin.suspendtrans.annotation.JvmAsync
 import love.forte.plugin.suspendtrans.annotation.JvmBlocking
-import love.forte.simbot.ID
 import love.forte.simbot.SimbotIllegalArgumentException
 import love.forte.simbot.SimbotIllegalStateException
 import love.forte.simbot.definition.Objective
@@ -137,28 +136,6 @@ public interface ReplySupport {
     public suspend fun reply(text: String): MessageReceipt = reply(Text.of(text))
 }
 
-
-/**
- * “回复”回执。
- */
-@Deprecated("No longer use", level = DeprecationLevel.ERROR)
-public interface MessageReplyReceipt : MessageReceipt {
-    override val id: ID
-    override val isSuccess: Boolean
-
-    /**
-     * 是否作为 **回复** 发送成功。
-     * 很多时候对于可回复事件来说，其只能 **回复一次**，因而在次数已经消耗的前提下，
-     * 假若平台允许，**或许** 会继续尝试使用普通消息进行发送（需要当前目标实现 [SendSupport]）。
-     *
-     * 并不代表所有平台都会这么做，或者说大多数情况下，在回复次数耗尽后会抛出异常。
-     *
-     * @throws UnsupportedActionException 当此行为不被支持时
-     */
-    public val isReplySuccess: Boolean
-}
-
-
 /**
  * 消息回应支持。
  *
@@ -179,18 +156,6 @@ public interface MessageReplyReceipt : MessageReceipt {
 public interface MessageReactSupport {
 
     public suspend fun react(message: Message): MessageReceipt
-}
-
-/**
- * 标记回执。
- *
- * 对于标记回执的 [id][ReactReceipt.id]，有可能是这个回执所属ID，也有可能是被标记消息的ID。
- *
- */
-@Deprecated("No longer use", level = DeprecationLevel.ERROR)
-public interface ReactReceipt : MessageReceipt {
-    override val id: ID
-    override val isSuccess: Boolean
 }
 
 

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/action/SendSupport.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/action/SendSupport.kt
@@ -42,7 +42,7 @@ import love.forte.simbot.message.*
 @JvmBlocking
 @JvmAsync
 public interface SendSupport {
-
+    
     /**
      * 发送消息，并得到一个回执单。
      *
@@ -53,7 +53,7 @@ public interface SendSupport {
      *
      */
     public suspend fun send(message: Message): MessageReceipt
-
+    
     /**
      * 发送消息，并得到一个回执单。
      *
@@ -80,8 +80,6 @@ public interface SendSupport {
  * [ReplySupport] 期望中是由一些 [事件][love.forte.simbot.event.Event] 进行实现，尤其是 [消息事件][love.forte.simbot.event.MessageEvent]，代表此事件可以 *回复消息* 。
  * 默认情况下 [ReplySupport] 不会实现于任何默认定义的事件类型（因为无法保证有哪些消息事件存在*可回复消息*这一行为），
  * 但是这不代表你所监听到的实际事件没有实现此类型（例如`tencent-guild`组件中的消息事件或`mirai`组件中的消息事件，便实际上的实现了 [ReplySupport] ）。
- *
- * *Note: 未来可能会默认实现于 [love.forte.simbot.event.MessageEvent]*
  *
  * 相比较于 [SendSupport], [ReplySupport] 更倾向于针对一次事件或者这次事件的发送者为目标的**回复**行为，而不是单纯的发送消息，例如 `tencent-guild` 组件中，
  * 公域机器人如果想要根据一个@消息回复一段消息，则**必须**引用这个消息的ID，因此在 `tencent-guild` 组件中，如果使用的是公域BOT，那么想要回复消息的最好的办法是使用 [ReplySupport.reply] 而不是 [SendSupport.send],
@@ -119,12 +117,12 @@ public interface SendSupport {
 @JvmBlocking
 @JvmAsync
 public interface ReplySupport {
-
+    
     /**
      * 回复当前目标，并得到一个 [回复回执][MessageReceipt]
      */
     public suspend fun reply(message: Message): MessageReceipt
-
+    
     /**
      * 回复当前目标，并得到一个 [回复回执][MessageReceipt]
      */
@@ -154,71 +152,159 @@ public interface ReplySupport {
 @JvmBlocking
 @JvmAsync
 public interface MessageReactSupport {
-
+    
     public suspend fun react(message: Message): MessageReceipt
 }
 
 
-//region send
+// region send
 /**
- * 如果此目标允许发送消息，发送，否则得到null。
+ * **Deprecated**。
+ * @suppress 你应当明确知道你所需要发送的目标是 [love.forte.simbot.definition.Contact]
+ * 还是 [love.forte.simbot.definition.ChatRoom]。
+ * [SendSupport] 默认实现于它们。
+ *
+ * ```kotlin
+ * if (objective is Contact) {
+ *    objective.send(message)
+ * }
+ * // or
+ * if (objective is ChatRoom) {
+ *    objective.send(message)
+ * }
+ * ```
+ *
  */
 @JvmSynthetic
+@Deprecated(
+    "Use Contact.send(message) or ChatRoom.send(message)",
+    ReplaceWith("if (this is SendSupport) send(message) else null")
+)
 public suspend fun Objective.sendIfSupport(message: Message): MessageReceipt? =
     if (this is SendSupport) send(message) else null
 
 /**
- * 如果此目标允许发送消息，发送，否则得到null。
+ * **Deprecated**。
+ * @suppress 你应当明确知道你所需要发送的目标是 [love.forte.simbot.definition.Contact]
+ * 还是 [love.forte.simbot.definition.ChatRoom]。
+ * [SendSupport] 默认实现于它们。
+ *
+ * ```kotlin
+ * if (objective is Contact) {
+ *    objective.send(message)
+ * }
+ * // or
+ * if (objective is ChatRoom) {
+ *    objective.send(message)
+ * }
+ * ```
+ *
  */
 @JvmSynthetic
+@Deprecated(
+    "Use Contact.send(message) or ChatRoom.send(message)",
+    ReplaceWith("if (this is SendSupport) send(message()) else null")
+)
 public suspend inline fun Objective.sendIfSupport(message: () -> Message): MessageReceipt? =
     if (this is SendSupport) send(message()) else null
 
 /**
- * 如果此事件允许发送消息，发送，否则得到null。
+ * @suppress 通常消息载体不应具备 '消息发送' 的能力。而对于消息事件，则应参考 [love.forte.simbot.event.MessageEvent.reply]。
  */
 @JvmSynthetic
+@Deprecated(
+    "Use MessageEvent.reply(message)",
+    ReplaceWith("if (this is SendSupport) send(message) else null")
+)
 public suspend fun MessageContainer.sendIfSupport(message: Message): MessageReceipt? =
     if (this is SendSupport) send(message) else null
 
 /**
- * 如果此事件允许发送消息，发送，否则得到null。
+ * @suppress 通常消息载体不应具备 '消息发送' 的能力。而对于消息事件，则应参考 [love.forte.simbot.event.MessageEvent.reply]。
  */
 @JvmSynthetic
+@Deprecated(
+    "Use MessageEvent.reply(message)",
+    ReplaceWith("if (this is SendSupport) send(message) else null")
+)
 public suspend inline fun MessageContainer.sendIfSupport(message: () -> Message): MessageReceipt? =
     if (this is SendSupport) send(message()) else null
 
 /**
- * 如果此目标允许发送消息，发送，否则得到null。
+ * **Deprecated**。
+ * @suppress 你应当明确知道你所需要发送的目标是 [love.forte.simbot.definition.Contact]
+ * 还是 [love.forte.simbot.definition.ChatRoom]。
+ * [SendSupport] 默认实现于它们。
+ *
+ * ```kotlin
+ * if (objective is Contact) {
+ *    objective.send(message)
+ * }
+ * // or
+ * if (objective is ChatRoom) {
+ *    objective.send(message)
+ * }
+ * ```
+ *
  */
 @JvmSynthetic
+@Deprecated(
+    "Use Contact.send(message) or ChatRoom.send(message)",
+    ReplaceWith("if (this is SendSupport) send(message()) else null")
+)
 public suspend fun Objective.sendIfSupport(message: MessageContent): MessageReceipt? =
     if (this is SendSupport) send(message) else null
 
 /**
- * 如果此事件允许发送消息，发送，否则得到null。
+ * @suppress 通常消息载体不应具备 '消息发送' 的能力。而对于消息事件，则应参考 [love.forte.simbot.event.MessageEvent.reply]。
  */
 @JvmSynthetic
+@Deprecated(
+    "Use MessageEvent.reply(message)",
+    ReplaceWith("if (this is SendSupport) send(message) else null")
+)
 public suspend fun MessageContainer.sendIfSupport(message: MessageContent): MessageReceipt? =
     if (this is SendSupport) send(message) else null
 
 /**
- * 如果此目标允许发送消息，发送，否则得到null。
+ * **Deprecated**。
+ * @suppress 你应当明确知道你所需要发送的目标是 [love.forte.simbot.definition.Contact]
+ * 还是 [love.forte.simbot.definition.ChatRoom]。
+ * [SendSupport] 默认实现于它们。
+ *
+ * ```kotlin
+ * if (objective is Contact) {
+ *    objective.send(message)
+ * }
+ * // or
+ * if (objective is ChatRoom) {
+ *    objective.send(message)
+ * }
+ * ```
+ *
  */
 @JvmSynthetic
+@Deprecated(
+    "Use Contact.send(message) or ChatRoom.send(message)",
+    ReplaceWith("if (this is SendSupport) send(message()) else null")
+)
 public suspend fun Objective.sendIfSupport(message: String): MessageReceipt? =
     if (this is SendSupport) send(message) else null
 
 /**
- * 如果此事件允许发送消息，发送，否则得到null。
+ * @suppress 通常消息载体不应具备 '消息发送' 的能力。而对于消息事件，则应参考 [love.forte.simbot.event.MessageEvent.reply]。
  */
 @JvmSynthetic
+@Deprecated(
+    "Use MessageEvent.reply(message)",
+    ReplaceWith("if (this is SendSupport) send(message) else null")
+)
 public suspend fun MessageContainer.sendIfSupport(message: String): MessageReceipt? =
     if (this is SendSupport) send(message) else null
-//endregion
+// endregion
 
 
-//region reply
+// region reply
 /**
  * 如果此事件允许回复消息，发送，否则得到null。
  */
@@ -248,114 +334,137 @@ public suspend fun Event.replyIfSupport(message: String): MessageReceipt? =
     if (this is ReplySupport) reply(message) else null
 
 /**
- * 如果此目标允许回复消息，发送，否则得到null。
+ * @suppress 消息回复由 [love.forte.simbot.event.MessageEvent] 实现，对于 [Objective] 来说通常不具备此能力。
  */
 @JvmSynthetic
-@Suppress("DeprecatedCallableAddReplaceWith")
-@Deprecated("ReplySupport通常由Event类型实现", level = DeprecationLevel.ERROR)
+@Deprecated(
+    "Use MessageEvent.reply(message)", level = DeprecationLevel.ERROR,
+    replaceWith = ReplaceWith("if (this is ReplySupport) reply(message) else null")
+)
 public suspend fun Objective.replyIfSupport(message: Message): MessageReceipt? =
     if (this is ReplySupport) reply(message) else null
 
 
 /**
- * 如果此组织允许回复消息，发送，否则得到null。
+ * @suppress 消息回复由 [love.forte.simbot.event.MessageEvent] 实现，对于 [Objective] 来说通常不具备此能力。
  */
 @JvmSynthetic
-@Suppress("DeprecatedCallableAddReplaceWith")
-@Deprecated("ReplySupport通常由Event类型实现", level = DeprecationLevel.ERROR)
+@Deprecated(
+    "Use MessageEvent.reply(message)", level = DeprecationLevel.ERROR,
+    replaceWith = ReplaceWith("if (this is ReplySupport) reply(message) else null")
+)
 public suspend fun MessageContainer.replyIfSupport(message: Message): MessageReceipt? =
     if (this is ReplySupport) reply(message) else null
 
 /**
- * 如果此目标允许回复消息，发送，否则得到null。
+ * @suppress 消息回复由 [love.forte.simbot.event.MessageEvent] 实现，对于 [Objective] 来说通常不具备此能力。
  */
 @JvmSynthetic
-@Suppress("DeprecatedCallableAddReplaceWith")
-@Deprecated("ReplySupport通常由Event类型实现", level = DeprecationLevel.ERROR)
+@Deprecated(
+    "Use MessageEvent.reply(message)", level = DeprecationLevel.ERROR,
+    replaceWith = ReplaceWith("if (this is ReplySupport) reply(message()) else null")
+)
 public suspend inline fun Objective.replyIfSupport(message: () -> Message): MessageReceipt? =
     if (this is ReplySupport) reply(message()) else null
 
 
 /**
- * 如果此组织允许回复消息，发送，否则得到null。
+ * @suppress 消息回复由 [love.forte.simbot.event.MessageEvent] 实现。
  */
 @JvmSynthetic
-@Suppress("DeprecatedCallableAddReplaceWith")
-@Deprecated("ReplySupport通常由Event类型实现", level = DeprecationLevel.ERROR)
+@Deprecated("Use MessageEvent.reply(message)", level = DeprecationLevel.ERROR,
+    replaceWith = ReplaceWith("if (this is ReplySupport) reply(message()) else null")
+)
 public suspend inline fun MessageContainer.replyIfSupport(message: () -> Message): MessageReceipt? =
     if (this is ReplySupport) reply(message()) else null
 
 
 /**
- * 如果此目标允许回复消息，发送，否则得到null。
+ * @suppress 消息回复由 [love.forte.simbot.event.MessageEvent] 实现，对于 [Objective] 来说通常不具备此能力。
  */
 @JvmSynthetic
-@Suppress("DeprecatedCallableAddReplaceWith")
-@Deprecated("ReplySupport通常由Event类型实现", level = DeprecationLevel.ERROR)
+@Deprecated("Use MessageEvent.reply(message)", level = DeprecationLevel.ERROR,
+    replaceWith = ReplaceWith("if (this is ReplySupport) reply(message) else null")
+)
 public suspend fun Objective.replyIfSupport(message: MessageContent): MessageReceipt? =
     if (this is ReplySupport) reply(message) else null
 
 
 /**
- * 如果此组织允许回复消息，发送，否则得到null。
+ * @suppress 消息回复由 [love.forte.simbot.event.MessageEvent] 实现。
  */
 @JvmSynthetic
-@Suppress("DeprecatedCallableAddReplaceWith")
-@Deprecated("ReplySupport通常由Event类型实现", level = DeprecationLevel.ERROR)
+@Deprecated("Use MessageEvent.reply(message)", level = DeprecationLevel.ERROR,
+    replaceWith = ReplaceWith("if (this is ReplySupport) reply(message) else null")
+)
 public suspend fun MessageContainer.replyIfSupport(message: MessageContent): MessageReceipt? =
     if (this is ReplySupport) reply(message) else null
 
 
 /**
- * 如果此目标允许回复消息，发送，否则得到null。
+ * @suppress 消息回复由 [love.forte.simbot.event.MessageEvent] 实现，对于 [Objective] 来说通常不具备此能力。
  */
 @JvmSynthetic
-@Suppress("DeprecatedCallableAddReplaceWith")
-@Deprecated("ReplySupport通常由Event类型实现", level = DeprecationLevel.ERROR)
+@Deprecated("Use MessageEvent.reply(message)", level = DeprecationLevel.ERROR,
+    replaceWith = ReplaceWith("if (this is ReplySupport) reply(message) else null")
+)
 public suspend fun Objective.replyIfSupport(message: String): MessageReceipt? =
     if (this is ReplySupport) reply(message) else null
 
 
 /**
- * 如果此组织允许回复消息，发送，否则得到null。
+ * @suppress 消息回复由 [love.forte.simbot.event.MessageEvent] 实现。
  */
 @JvmSynthetic
-@Suppress("DeprecatedCallableAddReplaceWith")
-@Deprecated("ReplySupport通常由Event类型实现", level = DeprecationLevel.ERROR)
+@Deprecated("Use MessageEvent.reply(message)", level = DeprecationLevel.ERROR,
+    replaceWith = ReplaceWith("if (this is ReplySupport) reply(message) else null")
+)
 public suspend fun MessageContainer.replyIfSupport(message: String): MessageReceipt? =
     if (this is ReplySupport) reply(message) else null
-//endregion
+// endregion
 
 
-//region react
+// region react
 /**
- * 如果此目标允许回复标记消息，发送，否则得到null。
+ * @suppress react api使用场景较少，且大概率应用于 [MessageContent] 或 [MessageReceipt] 中，需要时可直接自行判断。
  */
 @JvmSynthetic
+@Deprecated("The react api is used in fewer scenarios and can be judged directly by itself when needed",
+    ReplaceWith("if (this is MessageReactSupport) react(message) else null")
+)
 public suspend fun Objective.reactIfSupport(message: Message): MessageReceipt? =
     if (this is MessageReactSupport) react(message) else null
 
 /**
- * 如果此事件允许回复标记消息，发送，否则得到null。
+ * @suppress react api使用场景较少，且大概率应用于 [MessageContent] 或 [MessageReceipt] 中，需要时可直接自行判断。
  */
 @JvmSynthetic
+@Deprecated("The react api is used in fewer scenarios and can be judged directly by itself when needed",
+    ReplaceWith("if (this is MessageReactSupport) react(message) else null")
+)
 public suspend fun MessageContainer.reactIfSupport(message: Message): MessageReceipt? =
     if (this is MessageReactSupport) react(message) else null
 
 /**
- * 如果此目标允许回复标记消息，发送，否则得到null。
+ * @suppress react api使用场景较少，且大概率应用于 [MessageContent] 或 [MessageReceipt] 中，需要时可直接自行判断。
  */
 @JvmSynthetic
+@Deprecated("The react api is used in fewer scenarios and can be judged directly by itself when needed",
+    ReplaceWith("if (this is MessageReactSupport) react(message) else null")
+)
 public suspend inline fun Objective.reactIfSupport(message: () -> Message): MessageReceipt? =
     if (this is MessageReactSupport) react(message()) else null
 
 /**
- * 如果此事件允许回复标记消息，发送，否则得到null。
+ * @suppress react api使用场景较少，且大概率应用于 [MessageContent] 或 [MessageReceipt] 中，需要时可直接自行判断。
  */
 @JvmSynthetic
+@Deprecated("The react api is used in fewer scenarios and can be judged directly by itself when needed",
+    ReplaceWith("if (this is MessageReactSupport) react(message) else null")
+)
 public suspend inline fun MessageContainer.reactIfSupport(message: () -> Message): MessageReceipt? =
     if (this is MessageReactSupport) react(message()) else null
-//endregion
+// endregion
 
 
 /**

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/message/MessageReceipt.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/message/MessageReceipt.kt
@@ -16,11 +16,9 @@
 
 package love.forte.simbot.message
 
-import love.forte.simbot.Api4J
 import love.forte.simbot.ID
 import love.forte.simbot.action.DeleteSupport
 import love.forte.simbot.definition.IDContainer
-import love.forte.simbot.utils.runInNoScopeBlocking
 
 
 /**
@@ -41,28 +39,15 @@ public interface MessageReceipt : IDContainer, DeleteSupport {
      * 假若 [isSuccess] 为 `false`, 那么 [id] 可能会是一个空值。
      */
     public val isSuccess: Boolean
-
-
+    
     /**
-     * 如果此回执单是可删除的, 执行删除。
+     * 删除此回执所代表的消息。这通常代表为'撤回'相关消息。
+     * 如果此回执不支持撤回则可能会恒定的得到 `false`。
      *
-     * Deprecated: [MessageReceipt] 已实现 [DeleteSupport], 可以直接使用 [MessageReceipt.delete].
+     * 进行删除的过程中通常不会捕获任何异常，因此可能抛出任何可能涉及的
+     * 业务或状态异常。
      *
-     * @return 删除成功为true，失败或不可删除均为null。
+     * @return 是否删除成功
      */
-    @Api4J
-    @Deprecated("Just use deleteBlocking()", ReplaceWith("deleteBlocking()"), level = DeprecationLevel.ERROR)
-    public fun deleteIfSupportBlocking(): Boolean = runInNoScopeBlocking { delete() }
+    override suspend fun delete(): Boolean
 }
-
-
-/**
- * 如果此回执单是可删除的, 执行删除。
- *
- * Deprecated: [MessageReceipt] 已实现 [DeleteSupport], 可以直接使用 [MessageReceipt.delete].
- *
- * @return 删除成功为true，失败或不可删除均为null。
- */
-@JvmSynthetic
-@Deprecated("Just use delete()", ReplaceWith("delete()"), level = DeprecationLevel.ERROR)
-public suspend fun MessageReceipt.deleteIfSupport(): Boolean = delete()

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/message/MessageReceipt.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/message/MessageReceipt.kt
@@ -49,5 +49,6 @@ public interface MessageReceipt : IDContainer, DeleteSupport {
      *
      * @return 是否删除成功
      */
+    @JvmSynthetic
     override suspend fun delete(): Boolean
 }

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/message/MessageReceipt.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/message/MessageReceipt.kt
@@ -16,29 +16,28 @@
 
 package love.forte.simbot.message
 
+import love.forte.simbot.CharSequenceID
 import love.forte.simbot.ID
 import love.forte.simbot.action.DeleteSupport
 import love.forte.simbot.definition.IDContainer
+import love.forte.simbot.randomID
 
 
 /**
  * 消息回执，当消息发出去后所得到的回执信息。
+ *
+ * @see SingleMessageReceipt
+ * @see AggregatedMessageReceipt
+ *
  * @author ForteScarlet
  */
-public interface MessageReceipt : IDContainer, DeleteSupport {
-
-    /**
-     * 一个消息回执中存在一个ID.
-     */
-    override val id: ID
-
+public sealed class MessageReceipt : DeleteSupport {
+    
     /**
      * 消息是否发送成功。此属性的 `false` 一般代表在排除其他所有的 **异常情况** 下，在正常流程中依然发送失败（例如发送的消息是空的）。
      * 不代表发送中出现了异常，仅代表在过程完全正常的情况下的发送结果。
-     *
-     * 假若 [isSuccess] 为 `false`, 那么 [id] 可能会是一个空值。
      */
-    public val isSuccess: Boolean
+    public abstract val isSuccess: Boolean
     
     /**
      * 删除此回执所代表的消息。这通常代表为'撤回'相关消息。
@@ -50,5 +49,73 @@ public interface MessageReceipt : IDContainer, DeleteSupport {
      * @return 是否删除成功
      */
     @JvmSynthetic
-    override suspend fun delete(): Boolean
+    abstract override suspend fun delete(): Boolean
+}
+
+/**
+ * 明确代表为一个或零个（发送失败时）具体消息的消息回执，可以作为 [AggregatedMessageReceipt] 的元素进行聚合。
+ *
+ * @see MessageReceipt
+ * @see AggregatedMessageReceipt
+ */
+public abstract class SingleMessageReceipt : IDContainer, MessageReceipt() {
+    /**
+     * 一个消息回执中存在一个ID.
+     *
+     * [id] 不一定具有实际含义，也有可能是仅仅只是一个 [随机值][randomID] 或 [空值][CharSequenceID.EMPTY]。
+     * 当不具有实际意义时，[随机值][randomID] 通常出现在成功的回执中，
+     * 而 [空值][CharSequenceID.EMPTY] 通常出现在失败的回执中。
+     *
+     */
+    abstract override val id: ID
+}
+
+
+/**
+ * 聚合消息回执，代表多个 [SingleMessageReceipt] 的聚合体。
+ *
+ * @see MessageReceipt
+ * @see SingleMessageReceipt
+ */
+public abstract class AggregatedMessageReceipt : MessageReceipt(), Iterable<SingleMessageReceipt> {
+    
+    /**
+     * 聚合消息中的 [isSuccess] 代表是否存在**任意**回执的 [MessageReceipt.isSuccess] 为 `true`。
+     */
+    abstract override val isSuccess: Boolean
+    
+    /**
+     * 当前聚合消息中包含的所有 [MessageReceipt] 的数量。
+     */
+    public abstract val size: Int
+    
+    /**
+     * 根据索引值获取到指定位置的 [SingleMessageReceipt]。
+     *
+     * @throws IndexOutOfBoundsException 索引越界时
+     */
+    public abstract fun get(index: Int): SingleMessageReceipt
+    
+    /**
+     * 删除其所代表的所有消息回执。
+     *
+     * @see deleteAll
+     * @return 是否存在**任意**内容删除成功
+     */
+    override suspend fun delete(): Boolean {
+        return deleteAll() > 0
+    }
+    
+    /**
+     * 删除其所代表的所有消息回执。
+     */
+    public suspend fun deleteAll(): Int {
+        var count = 0
+        for (receipt in this) {
+            if (receipt.delete()) {
+                count++
+            }
+        }
+        return count
+    }
 }

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/message/MessageReceipts.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/message/MessageReceipts.kt
@@ -1,0 +1,207 @@
+/*
+ *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ *
+ *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
+ *
+ *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ *
+ *  发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
+ *
+ *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ *  https://www.gnu.org/licenses
+ *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ *
+ */
+
+@file:JvmName("MessageReceipts")
+
+package love.forte.simbot.message
+
+
+/**
+ * 将多个 [SingleMessageReceipt] 聚合为 [AggregatedMessageReceipt].
+ *
+ * @see SingleMessageReceipt
+ * @see AggregatedMessageReceipt
+ */
+public fun List<SingleMessageReceipt>.aggregation(): AggregatedMessageReceipt {
+    return when (size) {
+        0 -> EmptyAggregatedMessageReceipt
+        1 -> SingleElementAggregatedMessageReceipt(first())
+        else -> ListAggregatedMessageReceipt(this)
+    }
+}
+
+/**
+ * 将多个 [SingleMessageReceipt] 聚合为 [AggregatedMessageReceipt].
+ *
+ * @see SingleMessageReceipt
+ * @see AggregatedMessageReceipt
+ */
+public fun Collection<SingleMessageReceipt>.aggregation(): AggregatedMessageReceipt {
+    if (this is List) {
+        return aggregation()
+    }
+    
+    return when (size) {
+        0 -> EmptyAggregatedMessageReceipt
+        1 -> SingleElementAggregatedMessageReceipt(first())
+        else -> CollectionAggregatedMessageReceipt(this)
+    }
+}
+
+/**
+ * 将多个 [SingleMessageReceipt] 聚合为 [AggregatedMessageReceipt].
+ *
+ * @see SingleMessageReceipt
+ * @see AggregatedMessageReceipt
+ */
+public fun Iterable<SingleMessageReceipt>.aggregation(): AggregatedMessageReceipt {
+    if (this is List) {
+        return aggregation()
+    }
+    
+    if (this is Collection) {
+        return aggregation()
+    }
+    
+    return IterableAggregatedMessageReceipt(this)
+}
+
+/**
+ * 没有元素的 [AggregatedMessageReceipt] 实现。
+ */
+private object EmptyAggregatedMessageReceipt : AggregatedMessageReceipt() {
+    override fun iterator(): Iterator<SingleMessageReceipt> = EmptyIterator
+    
+    override val isSuccess: Boolean
+        get() = false
+    
+    override val size: Int
+        get() = 0
+    
+    override fun get(index: Int): SingleMessageReceipt {
+        throw IndexOutOfBoundsException("Empty aggregated message receipt has no elements.")
+    }
+    
+    private object EmptyIterator : Iterator<Nothing> {
+        override fun hasNext(): Boolean = false
+        override fun next(): Nothing = throw NoSuchElementException("Empty aggregated message receipt has no elements.")
+    }
+}
+
+/**
+ * 只有一个元素的 [AggregatedMessageReceipt] 实现。
+ */
+private class SingleElementAggregatedMessageReceipt(
+    private val value: SingleMessageReceipt,
+) : AggregatedMessageReceipt() {
+    override fun iterator(): Iterator<SingleMessageReceipt> = SingleElementIterator(value)
+    
+    override val isSuccess: Boolean
+        get() = value.isSuccess
+    
+    override val size: Int
+        get() = 1
+    
+    override fun get(index: Int): SingleMessageReceipt {
+        if (index != 0) {
+            throw IndexOutOfBoundsException("Index $index of size 1")
+        }
+        
+        return value
+    }
+    
+    
+    private class SingleElementIterator(value: SingleMessageReceipt) : Iterator<SingleMessageReceipt> {
+        private var value: SingleMessageReceipt? = value
+        
+        override fun hasNext(): Boolean = value != null
+        override fun next(): SingleMessageReceipt {
+            return value?.also {
+                value = null
+            } ?: throw NoSuchElementException()
+        }
+    }
+}
+
+/**
+ * 使用 [List] 作为 [SingleMessageReceipt] 集的载体。
+ */
+private class ListAggregatedMessageReceipt(
+    private val list: List<SingleMessageReceipt>,
+) : AggregatedMessageReceipt() {
+    override fun iterator(): Iterator<SingleMessageReceipt> = list.iterator()
+    
+    override val isSuccess: Boolean
+        get() = list.any { it.isSuccess }
+    
+    override val size: Int
+        get() = list.size
+    
+    override fun get(index: Int): SingleMessageReceipt = list[index]
+}
+
+
+/**
+ * 使用 [Collection] 作为 [SingleMessageReceipt] 集的载体。
+ *
+ * 与 [ListAggregatedMessageReceipt] 不同的是
+ * [CollectionAggregatedMessageReceipt] 无法通过索引直接访问元素。
+ */
+private class CollectionAggregatedMessageReceipt(
+    private val collection: Collection<SingleMessageReceipt>,
+) : AggregatedMessageReceipt() {
+    override fun iterator(): Iterator<SingleMessageReceipt> = collection.iterator()
+    
+    override val isSuccess: Boolean
+        get() = collection.any { it.isSuccess }
+    
+    override val size: Int
+        get() = collection.size
+    
+    override fun get(index: Int): SingleMessageReceipt {
+        val size = collection.size
+        if (index !in 0 until size) {
+            throw IndexOutOfBoundsException("Index $index of size $size")
+        }
+        for ((currentIndex, receipt) in collection.withIndex()) {
+            if (currentIndex == index) {
+                return receipt
+            }
+        }
+        
+        throw IndexOutOfBoundsException("Index $index of size $size")
+    }
+}
+
+
+/**
+ * 使用 [Iterable] 作为 [SingleMessageReceipt] 集的载体。
+ */
+private class IterableAggregatedMessageReceipt(
+    private val iterable: Iterable<SingleMessageReceipt>,
+) : AggregatedMessageReceipt() {
+    override fun iterator(): Iterator<SingleMessageReceipt> = iterable.iterator()
+    
+    override val isSuccess: Boolean
+        get() = iterable.any { it.isSuccess }
+    
+    override val size: Int
+        get() = iterable.count()
+    
+    override fun get(index: Int): SingleMessageReceipt {
+        if (index < 0) {
+            throw IndexOutOfBoundsException("Index $index of size $size")
+        }
+        for ((currentIndex, receipt) in iterable.withIndex()) {
+            if (currentIndex == index) {
+                return receipt
+            }
+        }
+        
+        throw IndexOutOfBoundsException("Index $index of size $size")
+    }
+}
+

--- a/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/utils/view/Views.kt
+++ b/simbot-apis/simbot-api/src/main/kotlin/love/forte/simbot/utils/view/Views.kt
@@ -31,7 +31,7 @@ public fun <T> List<T>.asView(): IndexAccessView<T> {
 }
 
 
-private class ListView<out T>(private val list: List<T>) : IndexAccessView<T>, RandomAccess {
+private class ListView<out T>(val list: List<T>) : IndexAccessView<T>, RandomAccess {
     override fun iterator(): Iterator<T> = list.iterator()
     
     override val size: Int
@@ -53,7 +53,7 @@ public fun <T> Collection<T>.asView(): View<T> {
 }
 
 
-private class CollectionView<out T>(private val collection: Collection<T>) : View<T> {
+private class CollectionView<out T>(val collection: Collection<T>) : View<T> {
     override fun iterator(): Iterator<T> = collection.iterator()
     
     override val size: Int
@@ -78,6 +78,17 @@ public fun <T> Iterable<T>.asView(): View<T> {
         is List -> this.asView()
         is Collection -> this.asView()
         else -> IterableView(this)
+    }
+}
+
+/**
+ * 将 [View] 转化为 [List].
+ */
+public fun <T> View<T>.toList(): List<T> {
+    return when (this) {
+        is ListView -> list.toList()
+        is CollectionView -> collection.toList()
+        else -> (this as Iterable<T>).toList()
     }
 }
 
@@ -116,5 +127,6 @@ private object EmptyView : IndexAccessView<Nothing>, RandomAccess {
     
     override fun contains(element: Nothing): Boolean = false
     
-    override fun get(index: Int): Nothing = throw IndexOutOfBoundsException("Empty view doesn't contain element at index $index.")
+    override fun get(index: Int): Nothing =
+        throw IndexOutOfBoundsException("Empty view doesn't contain element at index $index.")
 }


### PR DESCRIPTION
`MessageReceipt` 不再作为接口而可直接实现，而是拆分为了两个类型: 
- `SingleMessageReceipt`
- `AggregatedMessageReceipt`

并用于区分是否为聚合类型的回执。

对于相关API其返回值依旧保持为 `MessageReceipt`
