### PR TITLE
修复Spring Boot中无法读取可重复注解的问题；移除注解上的多余标记、调整spring-boot-starter项目配置等

### DIFF
--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlinx-coroutines = "1.6.4"
 kotlinx-serialization = "1.4.0"
-spring-boot = "2.7.2"
+spring-boot = "2.7.6"
 openjdk-jmh = "1.35"
 forte-di = "0.0.3"
 forte-annotationTool = "0.6.3"

--- a/simbot-boots/simboot-core-annotation/src/main/kotlin/love/forte/simboot/annotation/Filter.kt
+++ b/simbot-boots/simboot-core-annotation/src/main/kotlin/love/forte/simboot/annotation/Filter.kt
@@ -1,17 +1,14 @@
 /*
- *  Copyright (c) 2021-2022 ForteScarlet <ForteScarlet@163.com>
+ * Copyright (c) 2021-2022 ForteScarlet <ForteScarlet@163.com>
  *
- *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
+ * 本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x 、simbot3 等) 的一部分。
+ * simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ * 发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
  *
- *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
- *
- *  发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
- *
- *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
- *  https://www.gnu.org/licenses
- *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
- *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
- *
+ * 你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ * https://www.gnu.org/licenses
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  */
 
 package love.forte.simboot.annotation
@@ -78,7 +75,6 @@ import kotlin.reflect.KClass
  *
  */
 @Retention(AnnotationRetention.RUNTIME)
-@Repeatable
 @JvmRepeatable(Filters::class)
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
 @MustBeDocumented
@@ -88,7 +84,7 @@ public annotation class Filter(
      * 如果此属性为空，则相当于不生效。
      */
     val value: String = "",
-    
+
     /**
      * 当 [value] 匹配的目标（[EventListenerProcessingContext.textContent][love.forte.simbot.event.EventListenerProcessingContext.textContent]）的值为 null 的时候，
      * 是否直接放行。如果为 `true`, 则代表匹配值为null的时候视为匹配通过，反之则为匹配失败。默认为 `false`。此参数只有当 [value] 不为空的时候有效。如果 [value] 为空，则不会进行匹配。
@@ -96,13 +92,13 @@ public annotation class Filter(
      *
      */
     val ifNullPass: Boolean = false,
-    
+
     /**
      * 针对匹配目标所使用的匹配规则。
      * 默认情况下使用 [正则完全匹配][MatchType.REGEX_MATCHES].
      */
     val matchType: MatchType = MatchType.REGEX_MATCHES,
-    
+
     /**
      * 目标过滤内容。
      *
@@ -115,12 +111,12 @@ public annotation class Filter(
     @Suppress("DEPRECATION_ERROR")
     @Deprecated("Use targets", ReplaceWith("targets"), level = DeprecationLevel.ERROR)
     val target: TargetFilter = TargetFilter(),
-    
+
     /*
         在 target 还存在的情况下，
         当使用了 targets, 则不会使用 target。
      */
-    
+
     /**
      * 目标过滤内容。
      *
@@ -129,8 +125,8 @@ public annotation class Filter(
      * @see [Targets]
      */
     val targets: Targets = Targets(),
-    
-    
+
+
     /**
      * 指定一个对当前 [Filter] 的处理过滤器。当 [by] 指定了任意一个不直接等同于 [AnnotationEventFilterFactory]
      * 的类型时，此注解的上述其他参数将不再继续被解析，而是直接交由指定目标进行处理。
@@ -143,9 +139,9 @@ public annotation class Filter(
      *
      */
     val by: KClass<out AnnotationEventFilterFactory> = AnnotationEventFilterFactory::class,
-    
+
     ) {
-    
+
     /**
      * 通用属性过滤规则。
      *
@@ -175,7 +171,7 @@ public annotation class Filter(
          * 除了通过此 [components] 作为组件的筛选条件，直接监听一个组件下特有的事件类型能够更好的起到组件过滤的作用。
          */
         val components: Array<String> = [],
-        
+
         /**
          * 对接收事件的botID匹配。
          *
@@ -185,7 +181,7 @@ public annotation class Filter(
          * ```
          */
         val bots: Array<String> = [],
-        
+
         /**
          * 对消息发送者的ID匹配。
          *
@@ -195,7 +191,7 @@ public annotation class Filter(
          * ```
          */
         val authors: Array<String> = [],
-        
+
         /**
          * 如果这是个[群相关事件][GroupEvent] ，则对群ID匹配。
          *
@@ -206,7 +202,7 @@ public annotation class Filter(
          *
          */
         val groups: Array<String> = [],
-        
+
         /**
          * 如果是个[子频道相关事件][ChannelEvent], 则对频道ID匹配。
          *
@@ -216,12 +212,12 @@ public annotation class Filter(
          * ```
          */
         val channels: Array<String> = [],
-        
+
         /**
          * 如果是个[频道服务器相关事件][GuildEvent], 则对频道服务器ID匹配。
          */
         val guilds: Array<String> = [],
-        
+
         /**
          * 只有当前消息中存在任意一个 [At.target][love.forte.simbot.message.At.target] == event.bot.id 的 [At][love.forte.simbot.message.At] 消息的时候才会通过匹配。
          *
@@ -273,7 +269,7 @@ public annotation class TargetFilter(
      * 除了通过此 [components] 作为组件的筛选条件，直接监听一个组件下特有的事件类型能够更好的起到组件过滤的作用。
      */
     val components: Array<String> = [],
-    
+
     /**
      * 对接收事件的botID匹配。
      *
@@ -283,7 +279,7 @@ public annotation class TargetFilter(
      * ```
      */
     val bots: Array<String> = [],
-    
+
     /**
      * 对消息发送者的ID匹配。
      *
@@ -293,7 +289,7 @@ public annotation class TargetFilter(
      * ```
      */
     val authors: Array<String> = [],
-    
+
     /**
      * 如果这是个[群相关事件][GroupEvent] ，则对群ID匹配。
      *
@@ -304,7 +300,7 @@ public annotation class TargetFilter(
      *
      */
     val groups: Array<String> = [],
-    
+
     /**
      * 如果是个[子频道相关事件][ChannelEvent], 则对频道ID匹配。
      *
@@ -314,12 +310,12 @@ public annotation class TargetFilter(
      * ```
      */
     val channels: Array<String> = [],
-    
+
     /**
      * 如果是个[频道服务器相关事件][GuildEvent], 则对频道服务器ID匹配。
      */
     val guilds: Array<String> = [],
-    
+
     /**
      * 只有当前消息中存在任意一个 [At.target][love.forte.simbot.message.At.target] == event.bot.id 的 [At][love.forte.simbot.message.At] 消息的时候才会通过匹配。
      *
@@ -357,7 +353,7 @@ public annotation class Filters(
      * 所有子过滤器。
      */
     vararg val value: Filter,
-    
+
     /**
      * 多个过滤器之间的匹配策略。默认情况下为 [any][MultiFilterMatchType.ANY] 匹配。
      */

--- a/simbot-boots/simboot-core-annotation/src/main/kotlin/love/forte/simboot/annotation/Interceptor.kt
+++ b/simbot-boots/simboot-core-annotation/src/main/kotlin/love/forte/simboot/annotation/Interceptor.kt
@@ -1,17 +1,14 @@
 /*
- *  Copyright (c) 2021-2022 ForteScarlet <ForteScarlet@163.com>
+ * Copyright (c) 2021-2022 ForteScarlet <ForteScarlet@163.com>
  *
- *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
+ * 本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x 、simbot3 等) 的一部分。
+ * simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ * 发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
  *
- *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
- *
- *  发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
- *
- *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
- *  https://www.gnu.org/licenses
- *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
- *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
- *
+ * 你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ * https://www.gnu.org/licenses
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  */
 
 package love.forte.simboot.annotation
@@ -67,7 +64,6 @@ import kotlin.reflect.KClass
  * @see AnnotatedEventListenerInterceptor
  */
 @Retention(AnnotationRetention.RUNTIME)
-@Repeatable
 @JvmRepeatable(Interceptors::class)
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
 public annotation class Interceptor(
@@ -77,7 +73,7 @@ public annotation class Interceptor(
      * 当使用 [value] 的时候（[value] 不为空字符串时），[type]的值将会被忽略。
      */
     val value: String = "",
-    
+
     /**
      * 通过 **类型** 获取所需拦截器。
      * 对于类型的获取，流程如下：
@@ -89,7 +85,7 @@ public annotation class Interceptor(
      *
      */
     val type: KClass<out AnnotatedEventListenerInterceptor> = AnnotatedEventListenerInterceptor::class,
-    
+
     /**
      * 此拦截器在所有标记的注解拦截器中的优先级。
      */

--- a/simbot-boots/simboot-core-annotation/src/main/kotlin/love/forte/simboot/annotation/Listen.kt
+++ b/simbot-boots/simboot-core-annotation/src/main/kotlin/love/forte/simboot/annotation/Listen.kt
@@ -1,17 +1,14 @@
 /*
- *  Copyright (c) 2021-2022 ForteScarlet <ForteScarlet@163.com>
+ * Copyright (c) 2021-2022 ForteScarlet <ForteScarlet@163.com>
  *
- *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
+ * 本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x 、simbot3 等) 的一部分。
+ * simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ * 发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
  *
- *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
- *
- *  发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
- *
- *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
- *  https://www.gnu.org/licenses
- *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
- *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
- *
+ * 你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ * https://www.gnu.org/licenses
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  */
 
 package love.forte.simboot.annotation
@@ -35,7 +32,6 @@ import kotlin.reflect.KClass
  * @see love.forte.simbot.event.Event
  */
 @Retention(AnnotationRetention.RUNTIME)
-@Repeatable
 @JvmRepeatable(Listens::class)
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
 @MustBeDocumented

--- a/simbot-boots/simboot-core-annotation/src/main/kotlin/love/forte/simboot/annotation/Preparer.kt
+++ b/simbot-boots/simboot-core-annotation/src/main/kotlin/love/forte/simboot/annotation/Preparer.kt
@@ -1,17 +1,14 @@
 /*
- *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ * Copyright (c) 2022 ForteScarlet <ForteScarlet@163.com>
  *
- *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
+ * 本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x 、simbot3 等) 的一部分。
+ * simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ * 发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
  *
- *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
- *
- *  发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
- *
- *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
- *  https://www.gnu.org/licenses
- *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
- *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
- *
+ * 你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ * https://www.gnu.org/licenses
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  */
 
 package love.forte.simboot.annotation
@@ -43,7 +40,6 @@ public annotation class Preparator(
  *
  * @see ListenerPreparer
  */
-@Repeatable
 @JvmRepeatable(Preparers::class)
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
@@ -59,7 +55,7 @@ public annotation class Preparer(
      *
      */
     val value: KClass<out ListenerPreparer>,
-    
+
     /**
      * 假如提供的 [value] 能够从 bean 容器中获取，
      * 可以通过 [name] 指定此 bean 在容器中的唯一标识。
@@ -68,7 +64,7 @@ public annotation class Preparer(
      *
      */
     val name: String = "",
-    
+
     /**
      * 相对于所有预处理器之间的优先级。
      */

--- a/simbot-boots/simboot-core-spring-boot-starter/build.gradle.kts
+++ b/simbot-boots/simboot-core-spring-boot-starter/build.gradle.kts
@@ -1,17 +1,14 @@
 /*
- *  Copyright (c) 2021-2022 ForteScarlet <ForteScarlet@163.com>
+ * Copyright (c) 2021-2022 ForteScarlet <ForteScarlet@163.com>
  *
- *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
+ * 本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x 、simbot3 等) 的一部分。
+ * simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ * 发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
  *
- *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
- *
- *  发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
- *
- *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
- *  https://www.gnu.org/licenses
- *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
- *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
- *
+ * 你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ * https://www.gnu.org/licenses
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  */
 
 plugins {
@@ -24,14 +21,14 @@ plugins {
 
 dependencies {
     api(project(":simbot-boots:simboot-core"))
-    
+
 
     api(libs.javax.inject)
     api(libs.forte.di.spring)
     api(libs.spring.boot.logging)
 
-    implementation(libs.spring.boot.autoconfigure)
-    implementation(libs.spring.boot.configuration.processor)
+    compileOnly(libs.spring.boot.autoconfigure)
+    compileOnly(libs.spring.boot.configuration.processor)
     annotationProcessor(libs.spring.boot.configuration.processor)
     kapt(libs.spring.boot.configuration.processor)
 
@@ -42,10 +39,12 @@ dependencies {
     testImplementation(libs.kotlinx.serialization.properties)
     testImplementation(libs.kotlinx.serialization.protobuf)
     testImplementation(libs.spring.boot.aop)
+    testImplementation(libs.spring.boot.autoconfigure)
+    testImplementation(libs.spring.boot.configuration.processor)
     // testImplementation(libs.spring.boot.webflux)
-    
+
     // @Suppress("VulnerableLibrariesLocal")
-    testImplementation("love.forte.simbot.component:simbot-component-mirai-boot:3.0.0.0-beta-M2-SNAPSHOT")
+    testImplementation("love.forte.simbot.component:simbot-component-mirai-boot:3.0.0.0-beta.6")
     // testImplementation(V.Kotlinx.Coroutines.Reactor.notation)
 }
 

--- a/simbot-boots/simboot-core-spring-boot-starter/src/test/kotlin/love/forli/test/AnnotationTest.kt
+++ b/simbot-boots/simboot-core-spring-boot-starter/src/test/kotlin/love/forli/test/AnnotationTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022 ForteScarlet <ForteScarlet@163.com>
+ *
+ * 本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x 、simbot3 等) 的一部分。
+ * simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ * 发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
+ *
+ * 你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ * https://www.gnu.org/licenses
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ */
+
+package love.forli.test
+
+import love.forte.simboot.annotation.Filter
+import love.forte.simboot.spring.autoconfigure.utils.SpringAnnotationTool
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+
+private const val VALUE_1 = "1"
+private const val VALUE_2 = "2"
+private const val VALUE_3 = "Hello"
+
+private class A {
+    @Filter(VALUE_1)
+    @Filter(VALUE_2)
+    @MyFilter
+    fun b() {
+    }
+}
+
+@Filter(VALUE_3)
+private annotation class MyFilter
+
+class AnnotationTest {
+
+    @Test
+    fun repeatableTest() {
+        val tool = SpringAnnotationTool()
+        val func = A::b
+        val annotations = tool.getAnnotations(func, Filter::class)
+        assertEquals(3, annotations.size)
+
+        val values = annotations.map { it.value }
+        assertContains(values, VALUE_1)
+        assertContains(values, VALUE_2)
+        assertContains(values, VALUE_3)
+    }
+}
+

--- a/simbot-project-tests/simbot-project-test-spring-boot-starter/build.gradle.kts
+++ b/simbot-project-tests/simbot-project-test-spring-boot-starter/build.gradle.kts
@@ -1,7 +1,20 @@
+/*
+ * Copyright (c) 2022 ForteScarlet <ForteScarlet@163.com>
+ *
+ * 本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x 、simbot3 等) 的一部分。
+ * simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ * 发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
+ *
+ * 你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ * https://www.gnu.org/licenses
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ */
+
 plugins {
     java
     kotlin("jvm") // version "1.7.21"
-    id("org.springframework.boot") version "2.7.5"
+    id("org.springframework.boot") version "2.7.6"
     id("io.spring.dependency-management") version "1.1.0"
 }
 
@@ -20,3 +33,4 @@ dependencies {
 tasks.withType<Test> {
     useJUnitPlatform()
 }
+


### PR DESCRIPTION
fix #540

现在 spring-boot-starter 模块中的spring相关依赖都调整为 `compileOnly`, 因此在使用时请确保项目环境中存在 `spring-boot-autoconfigure` 依赖。