### PR TITLE
simbot-logger-slf4j-impl支持配置文件和更细致的日志等级配置

### DIFF
--- a/simbot-logger-slf4j-impl/README.md
+++ b/simbot-logger-slf4j-impl/README.md
@@ -4,3 +4,16 @@
 包括 [simbot-logger](../simbot-logger)。
 
 
+## 配置文件
+
+支持读取配置文件。在项目根路径或资源根路径创建文件 `simbot-logger-slf4j.properties`
+
+```properties
+# level 为默认全局等级
+level=DEBUG
+# 代表前缀为 love.forte.foo1 的日志等级为 TRACE
+level.love.forte.foo1=TRACE
+# 代表 **控制台输出的日志** 前缀为 love.forte.foo2 时等级为 INFO。
+# 某个特定的处理器（例如此处的 console 日志处理器）优先级高于全局配置。
+console.level.love.forte.foo2=INFO
+```

--- a/simbot-logger-slf4j-impl/src/main/kotlin/love/forte/simbot/logger/slf4j/ConsoleSimbotLoggerProcessor.kt
+++ b/simbot-logger-slf4j-impl/src/main/kotlin/love/forte/simbot/logger/slf4j/ConsoleSimbotLoggerProcessor.kt
@@ -1,17 +1,14 @@
 /*
- *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ * Copyright (c) 2022 ForteScarlet <ForteScarlet@163.com>
  *
- *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
+ * 本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x 、simbot3 等) 的一部分。
+ * simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ * 发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
  *
- *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
- *
- *  发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
- *
- *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
- *  https://www.gnu.org/licenses
- *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
- *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
- *
+ * 你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ * https://www.gnu.org/licenses
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  */
 
 package love.forte.simbot.logger.slf4j
@@ -27,7 +24,7 @@ import java.time.Instant
 
 /**
  * 将日志直接打印到控制台上的处理器。
- * 当参数 [level] 未指定日志等级的时候，会尝试加载系统参数 [`simbot.logger.level`][SIMBOT_LEVEL_PROPERTY_KEY], 如果系统参数也找不到，则默认为 [LogLevel.INFO][love.forte.simbot.logger.LogLevel.INFO] 级别。
+ * 当参数 [defaultLevel] 未指定日志等级的时候，会尝试加载系统参数 [`simbot.logger.level`][SIMBOT_LEVEL_PROPERTY_KEY], 如果系统参数也找不到，则默认为 [LogLevel.INFO][love.forte.simbot.logger.LogLevel.INFO] 级别。
  *
  * 你可以通过JVM参数 [`simbot.logger.level`][SIMBOT_LEVEL_PROPERTY_KEY]
  * 来指定一个控制台的日志等级而不需要直接提供一个新的 [SimbotLoggerProcessorsFactory] 实现,
@@ -38,12 +35,21 @@ import java.time.Instant
  *
  *
  */
-public class ConsoleSimbotLoggerProcessor(level: LogLevel?) : SimbotLoggerProcessor {
+public class ConsoleSimbotLoggerProcessor(configuration: SimbotLoggerConfiguration) : SimbotLoggerProcessor {
     // package prefix support?
-    private val level: LogLevel = level ?: loadLevel()
+    private val defaultLevel: LogLevel = loadLevel(configuration)
+    private val prefixLevel: List<Pair<String, LogLevel>>? = loadPrefixLevel(configuration).takeIf { it.isNotEmpty() }
 
-    override fun isLevelEnabled(level: LogLevel, marker: Marker?): Boolean {
-        return this.level.toInt() <= level.toInt()
+
+    override fun isLevelEnabled(name: String?, level: LogLevel, marker: Marker?): Boolean {
+        if (name == null) {
+            return defaultLevel.toInt() <= level.toInt()
+        }
+
+        val level0 = prefixLevel?.firstOrNull { (prefix, _) ->
+            name.startsWith(prefix)
+        }?.second ?: this.defaultLevel
+        return level0.toInt() <= level.toInt()
     }
 
     private fun printLog(info: LogInfo) {
@@ -80,14 +86,42 @@ public class ConsoleSimbotLoggerProcessor(level: LogLevel?) : SimbotLoggerProces
     }
 
 
-    private fun loadLevel(): LogLevel {
-        val levelName = System.getProperty(SIMBOT_LEVEL_PROPERTY_KEY) ?: return LogLevel.INFO
-        return LogLevel.values().find { it.name.equals(levelName, true) } ?: LogLevel.INFO
+    private fun loadPrefixLevel(configuration: SimbotLoggerConfiguration): List<Pair<String, LogLevel>> {
+        val prefixSet = mutableSetOf<String>()
+        val prefixLevelList = mutableListOf<Pair<String, LogLevel>>()
+        val properties = configuration.properties
+        properties.forEach { (k, v) ->
+            if (k.length > SIMBOT_LEVEL_CONSOLE_PROPERTY_KEY.length && k.startsWith(SIMBOT_LEVEL_CONSOLE_PROPERTY_KEY)) {
+                val prefix = k.substringAfter("${SIMBOT_LEVEL_CONSOLE_PROPERTY_KEY}.").takeIf { it.isNotBlank() }
+                    ?: return@forEach
+                if (prefixSet.add(prefix)) {
+                    val level = LogLevel.valueOf(v.stringValue.uppercase())
+                    prefixLevelList.add(prefix to level)
+                }
+            }
+        }
+
+        configuration.prefixLevelList.forEach { preLog ->
+            if (prefixSet.add(preLog.prefix)) {
+                prefixLevelList.add(preLog.prefix to preLog.level)
+            }
+        }
+
+        return prefixLevelList
+    }
+
+    private fun loadLevel(configuration: SimbotLoggerConfiguration): LogLevel {
+        val prop = configuration.properties
+        val levelName =
+            (prop[SIMBOT_LEVEL_CONSOLE_PROPERTY_KEY] ?: prop[SIMBOT_LEVEL_PROPERTY_KEY])?.stringValue?.uppercase()
+                ?: return (configuration.defaultLevel ?: LogLevel.INFO)
+        return LogLevel.valueOf(levelName)
     }
 
 
     public companion object {
-        private const val SIMBOT_LEVEL_PROPERTY_KEY = "simbot.logger.level"
+        private const val SIMBOT_LEVEL_PROPERTY_KEY = "level"
+        private const val SIMBOT_LEVEL_CONSOLE_PROPERTY_KEY = "console.level"
     }
 }
 

--- a/simbot-logger-slf4j-impl/src/main/kotlin/love/forte/simbot/logger/slf4j/DefaultSimbotLoggerProcessorsFactory.kt
+++ b/simbot-logger-slf4j-impl/src/main/kotlin/love/forte/simbot/logger/slf4j/DefaultSimbotLoggerProcessorsFactory.kt
@@ -1,17 +1,14 @@
 /*
- *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ * Copyright (c) 2022 ForteScarlet <ForteScarlet@163.com>
  *
- *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
+ * 本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x 、simbot3 等) 的一部分。
+ * simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ * 发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
  *
- *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
- *
- *  发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
- *
- *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
- *  https://www.gnu.org/licenses
- *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
- *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
- *
+ * 你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ * https://www.gnu.org/licenses
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  */
 
 package love.forte.simbot.logger.slf4j
@@ -23,14 +20,10 @@ package love.forte.simbot.logger.slf4j
  *
  */
 public object DefaultSimbotLoggerProcessorsFactory : SimbotLoggerProcessorsFactory {
-    private val processors = listOf(
-        ConsoleSimbotLoggerProcessor(null) // use default value.
-    )
-
     /**
      * 得到默认工厂中的处理器。
      */
-    override fun getProcessors(): List<SimbotLoggerProcessor> {
-        return processors
+    override fun getProcessors(configuration: SimbotLoggerConfiguration): List<SimbotLoggerProcessor> {
+        return listOf(ConsoleSimbotLoggerProcessor(configuration))
     }
 }

--- a/simbot-logger-slf4j-impl/src/main/kotlin/love/forte/simbot/logger/slf4j/SimbotLogger.kt
+++ b/simbot-logger-slf4j-impl/src/main/kotlin/love/forte/simbot/logger/slf4j/SimbotLogger.kt
@@ -1,17 +1,14 @@
 /*
- *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ * Copyright (c) 2022 ForteScarlet <ForteScarlet@163.com>
  *
- *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
+ * 本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x 、simbot3 等) 的一部分。
+ * simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ * 发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
  *
- *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
- *
- *  发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
- *
- *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
- *  https://www.gnu.org/licenses
- *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
- *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
- *
+ * 你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ * https://www.gnu.org/licenses
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  */
 
 package love.forte.simbot.logger.slf4j
@@ -80,7 +77,7 @@ public class SimbotLogger(
     override fun isErrorEnabled(marker: Marker?): Boolean = isLevelEnabled(LogLevel.ERROR, marker)
 
     private fun isLevelEnabled(level: LogLevel, marker: Marker? = null): Boolean {
-        return processors.any { it.isLevelEnabled(level, marker) }
+        return processors.any { it.isLevelEnabled(fullyQualifiedCallerName, level, marker) }
     }
 
     public fun getFullyQualifiedCallerName(): String = fullyQualifiedCallerName

--- a/simbot-logger-slf4j-impl/src/main/kotlin/love/forte/simbot/logger/slf4j/SimbotLoggerConfiguration.kt
+++ b/simbot-logger-slf4j-impl/src/main/kotlin/love/forte/simbot/logger/slf4j/SimbotLoggerConfiguration.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2022 ForteScarlet <ForteScarlet@163.com>
+ *
+ * 本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x 、simbot3 等) 的一部分。
+ * simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ * 发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
+ *
+ * 你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ * https://www.gnu.org/licenses
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ */
+
+package love.forte.simbot.logger.slf4j
+
+import love.forte.simbot.logger.LogLevel
+import love.forte.simbot.logger.slf4j.SimbotLoggerConfiguration.Companion.JVM_PROPERTY_PREFIX
+
+
+/**
+ * simbot-logger的实现中进行传递的配置文件。
+ * @author ForteScarlet
+ */
+public abstract class SimbotLoggerConfiguration {
+    /**
+     * 可读取到的所有配置文件属性。其中包括目标目录中的 `simbot-logger-slf4j.properties` 文件内容
+     * 和以 `simbot.logger` 开头的JVM属性。
+     *
+     * 其中，JVM属性优先级高于文件读取到的属性。
+     */
+    public abstract val properties: Map<String, Property>
+
+    /**
+     * 属性键为 [DEFAULT_LEVEL_PROPERTY] 时对应的结果。如果为找到此属性则得到null。
+     */
+    public abstract val defaultLevel: LogLevel?
+
+    /**
+     * 指定了前缀的等级配置，例如
+     * ```properties
+     * level.love.forte=DEBUG
+     * level.org.example=DEBUG
+     * ```
+     *
+     * 则当logger前缀为 `love.forte` 或 `org.example` 时，日志等级为 `DEBUG`。
+     *
+     */
+    public abstract val prefixLevelList: List<PrefixLogLevel>
+
+    public companion object {
+        /**
+         * 当JVM属性前缀为 `simbot.logger` 时，此值将会被解析至 [SimbotLoggerConfiguration.properties] 中。
+         * (此前缀将会被移除)
+         */
+        public const val JVM_PROPERTY_PREFIX: String = "simbot.logger"
+
+        /**
+         * 默认（全局）的日志等级配置属性键。此键对应的值必须为 [LogLevel] 中的元素名称。
+         *
+         * ```
+         * level=DEBUG
+         * ```
+         *
+         */
+        public const val DEFAULT_LEVEL_PROPERTY: String = "level"
+    }
+
+
+    public interface Property {
+        /**
+         * 此属性的键。
+         */
+        public val key: String
+
+        /**
+         * 此属性的字符串值。
+         */
+        public val stringValue: String
+    }
+
+    public interface PrefixLogLevel {
+        /**
+         * 匹配前缀
+         */
+        public val prefix: String
+
+        /**
+         * 对应等级
+         */
+        public val level: LogLevel
+    }
+}
+
+internal fun createSimbotLoggerConfiguration(
+    loadJvmArgs: Boolean = true,
+    initProperties: Map<String, String> = emptyMap()
+): SimbotLoggerConfiguration {
+    val properties = initProperties.toMutableMap()
+    if (loadJvmArgs) {
+        for (propertyName in System.getProperties().stringPropertyNames()) {
+            if (!propertyName.startsWith("$JVM_PROPERTY_PREFIX.")) {
+                continue
+            }
+
+            val value = System.getProperty(propertyName) ?: continue
+            val key = propertyName.substringAfter("$JVM_PROPERTY_PREFIX.")
+
+            properties[key] = value
+        }
+    }
+
+    return SimbotLoggerConfigurationImpl(properties.mapValues { (k, v) -> PropertyImpl(k, v) })
+}
+
+private data class PropertyImpl(override val key: String, private val value: String) :
+    SimbotLoggerConfiguration.Property {
+    override val stringValue: String
+        get() = value
+}
+
+private data class PrefixLogLevelImpl(override val prefix: String, override val level: LogLevel) :
+    SimbotLoggerConfiguration.PrefixLogLevel
+
+private data class SimbotLoggerConfigurationImpl(
+    override val properties: Map<String, Property>
+) : SimbotLoggerConfiguration() {
+    @Transient
+    override val defaultLevel: LogLevel? = properties[DEFAULT_LEVEL_PROPERTY]?.stringValue?.let { LogLevel.valueOf(it) }
+
+    @Transient
+    override val prefixLevelList: List<PrefixLogLevel>
+
+
+    init {
+        val prefixLevelList = mutableListOf<PrefixLogLevel>()
+        properties.forEach { (k, v) ->
+            if (k.length > DEFAULT_LEVEL_PROPERTY.length && k.startsWith(DEFAULT_LEVEL_PROPERTY)) {
+                val prefix = k.substringAfter("$DEFAULT_LEVEL_PROPERTY.").takeIf { it.isNotBlank() } ?: return@forEach
+                val level = LogLevel.valueOf(v.stringValue.uppercase())
+                prefixLevelList.add(PrefixLogLevelImpl(prefix, level))
+            }
+        }
+
+        this.prefixLevelList = prefixLevelList.toList()
+
+    }
+}

--- a/simbot-logger-slf4j-impl/src/main/kotlin/love/forte/simbot/logger/slf4j/SimbotLoggerFactory.kt
+++ b/simbot-logger-slf4j-impl/src/main/kotlin/love/forte/simbot/logger/slf4j/SimbotLoggerFactory.kt
@@ -1,17 +1,14 @@
 /*
- *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ * Copyright (c) 2022 ForteScarlet <ForteScarlet@163.com>
  *
- *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
+ * 本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x 、simbot3 等) 的一部分。
+ * simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ * 发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
  *
- *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
- *
- *  发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
- *
- *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
- *  https://www.gnu.org/licenses
- *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
- *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
- *
+ * 你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ * https://www.gnu.org/licenses
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  */
 
 package love.forte.simbot.logger.slf4j
@@ -99,7 +96,7 @@ private class LogInfoDataEventHandler(
     override fun onEvent(event: LogInfoEvent, sequence: Long, endOfBatch: Boolean) {
         processors.forEach { processor ->
             val info = event.info
-            if (processor.isLevelEnabled(info.level, info.marker)) {
+            if (processor.isLevelEnabled(event.info.fullName, info.level, info.marker)) {
                 processor.doHandle(info)
             }
         }
@@ -108,7 +105,7 @@ private class LogInfoDataEventHandler(
     override fun onEvent(event: LogInfoEvent) {
         processors.forEach { processor ->
             val info = event.info
-            if (processor.isLevelEnabled(info.level, info.marker)) {
+            if (processor.isLevelEnabled(event.info.fullName, info.level, info.marker)) {
                 processor.doHandle(info)
             }
         }

--- a/simbot-logger-slf4j-impl/src/main/kotlin/love/forte/simbot/logger/slf4j/SimbotLoggerProcessor.kt
+++ b/simbot-logger-slf4j-impl/src/main/kotlin/love/forte/simbot/logger/slf4j/SimbotLoggerProcessor.kt
@@ -1,17 +1,14 @@
 /*
- *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ * Copyright (c) 2022 ForteScarlet <ForteScarlet@163.com>
  *
- *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
+ * 本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x 、simbot3 等) 的一部分。
+ * simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ * 发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
  *
- *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
- *
- *  发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
- *
- *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
- *  https://www.gnu.org/licenses
- *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
- *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
- *
+ * 你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ * https://www.gnu.org/licenses
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  */
 
 package love.forte.simbot.logger.slf4j
@@ -30,7 +27,13 @@ public interface SimbotLoggerProcessor {
     /**
      * 检测日志等级是否可用。
      */
-    public fun isLevelEnabled(level: LogLevel, marker: Marker?): Boolean
+    @Deprecated("use isLevelEnabled(name, level, marker)", ReplaceWith("isLevelEnabled(null, level, marker)"))
+    public fun isLevelEnabled(level: LogLevel, marker: Marker?): Boolean = isLevelEnabled(null, level, marker)
+
+    /**
+     * 检测日志等级是否可用。
+     */
+    public fun isLevelEnabled(name: String?, level: LogLevel, marker: Marker?): Boolean
 
     /**
      * 处理日志。 [doHandle] 是当 [SimbotLoggerFactory] 中的异步处理通道尚未关闭的时候进行的处理函数。
@@ -42,7 +45,13 @@ public interface SimbotLoggerProcessor {
  * [SimbotLoggerProcessor] 的工厂接口， 通过 `Java Service Loader` ([java.util.ServiceLoader]) 进行加载。
  */
 public interface SimbotLoggerProcessorsFactory {
-    public fun getProcessors(): List<SimbotLoggerProcessor>
+    @Suppress("DeprecatedCallableAddReplaceWith")
+    @Deprecated("use getProcessors(SimbotLoggerConfiguration)")
+    public fun getProcessors(): List<SimbotLoggerProcessor> {
+        return getProcessors(createSimbotLoggerConfiguration(false))
+    }
+
+    public fun getProcessors(configuration: SimbotLoggerConfiguration): List<SimbotLoggerProcessor>
 }
 
 

--- a/simbot-logger-slf4j-impl/src/main/kotlin/org/slf4j/impl/StaticLoggerBinder.kt
+++ b/simbot-logger-slf4j-impl/src/main/kotlin/org/slf4j/impl/StaticLoggerBinder.kt
@@ -1,33 +1,45 @@
 /*
- *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ * Copyright (c) 2022 ForteScarlet <ForteScarlet@163.com>
  *
- *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
+ * 本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x 、simbot3 等) 的一部分。
+ * simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ * 发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
  *
- *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
- *
- *  发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
- *
- *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
- *  https://www.gnu.org/licenses
- *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
- *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
- *
+ * 你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ * https://www.gnu.org/licenses
+ * https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ * https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  */
 
 package org.slf4j.impl
 
-import love.forte.simbot.logger.slf4j.DefaultSimbotLoggerProcessorsFactory
-import love.forte.simbot.logger.slf4j.SimbotLoggerFactory
-import love.forte.simbot.logger.slf4j.SimbotLoggerProcessorsFactory
+import love.forte.simbot.logger.slf4j.*
 import org.slf4j.ILoggerFactory
 import org.slf4j.helpers.Util
 import org.slf4j.spi.LoggerFactoryBinder
+import java.io.IOException
 import java.util.*
+import kotlin.io.path.*
 
 /**
  * simbot-logger 下的日志工厂绑定器。
  *
  * `simbot-logger` 的所有日志处理均通过 [SimbotLoggerProcessorsFactory] 所得到的处理器列表进行链式处理。
+ *
+ * ## 配置文件
+ *
+ * 会读取配置文件 `simbot-logger-slf4j.properties` 文件，此文件优先寻找当前项目根目录，其次则会根据当前类加载器寻找资源目录，否则不读取。
+ *
+ * 可通过JVM属性 `simbot.logger.configFile.disable=true` 来直接关闭配置文件的读取。
+ *
+ * 可通过JVM属性 `simbot.logger.configFile.file` 来指定一个配置文件。此文件需要为 `properties` 格式。
+ *
+ * ## JVM属性
+ *
+ * 默认情况下，除了配置文件还会加载所有 [`'simbot.logger'`][SimbotLoggerConfiguration.JVM_PROPERTY_PREFIX] 为开头的JVM属性，
+ * 并（在去除前缀之后）以高优先级加载为配置属性。
+ *
+ * 例如 `-Dsimbot.logger.level=DEBUG` 会被加载为 `level=DEBUG`
  *
  * @see SimbotLoggerFactory
  * @see SimbotLoggerProcessorsFactory
@@ -35,6 +47,11 @@ import java.util.*
  * @author forte
  */
 public object StaticLoggerBinder : LoggerFactoryBinder {
+    private const val DISABLE_CONFIG_FILE_LOAD = "simbot.logger.configFile.disable"
+    private const val DISABLE_CONFIG_FROM_JVM = "simbot.logger.configJvm.disable"
+    private const val CONFIG_FILE_FILEPATH = "simbot.logger.configFile.file"
+    private const val DEFAULT_CONFIG_FILE_NAME = "simbot-logger-slf4j.properties"
+
     private val processFactory by lazy {
         val loader = ServiceLoader.load(SimbotLoggerProcessorsFactory::class.java, javaClass.classLoader)
         val processorList = loader.toList()
@@ -45,22 +62,81 @@ public object StaticLoggerBinder : LoggerFactoryBinder {
 
         val firstProcessor = processorList.first()
         if (processorList.size > 1) {
-            report("There are multiple SimbotLoggerProcessorsFactory loaded. The [$firstProcessor] will be selected.")
+            report("There are multiple SimbotLoggerProcessorsFactory loaded. The firstProcessor [$firstProcessor] will be selected.")
+            processorList.forEachIndexed { index, fac ->
+                report("\t${index + 1}. $fac")
+            }
         }
 
         firstProcessor
     }
 
+    private val configuration by lazy {
+        initConfiguration()
+    }
+
     private val loggerFactory by lazy {
-        SimbotLoggerFactory(processFactory.getProcessors())
+        SimbotLoggerFactory(processFactory.getProcessors(configuration))
     }
 
     private const val LOGGER_FACTORY_CLASS_STR = "love.forte.simbot.logger.SimbotLoggerFactory"
+
     @JvmStatic
     public fun getSingleton(): StaticLoggerBinder = this
 
     override fun getLoggerFactory(): ILoggerFactory = loggerFactory
     override fun getLoggerFactoryClassStr(): String = LOGGER_FACTORY_CLASS_STR
+
+
+    private fun initConfiguration(): SimbotLoggerConfiguration {
+        val initProperties = if (System.getProperty(DISABLE_CONFIG_FILE_LOAD).toBoolean()) {
+            emptyMap()
+        } else {
+            loadFileProperties()
+        }
+
+        val loadJvmArgs = !System.getProperty(DISABLE_CONFIG_FROM_JVM).toBoolean()
+
+        return createSimbotLoggerConfiguration(loadJvmArgs, initProperties)
+    }
+
+    private fun loadFileProperties(): Map<String, String> {
+        val fileName = configFileName()
+        val file = Path(fileName)
+        val properties = Properties()
+        if (file.exists() && !file.isDirectory() && file.isReadable()) {
+            try {
+                file.bufferedReader().use { reader ->
+                    properties.load(reader)
+                }
+            } catch (e: IOException) {
+                System.err.println("Logger config file $file load failure. Reason: $e")
+                e.printStackTrace() // print, but do not break
+            }
+        } else {
+            try {
+                val classLoader = javaClass.classLoader ?: ClassLoader.getSystemClassLoader()
+                classLoader.getResourceAsStream(fileName)?.use { inp ->
+                    properties.load(inp)
+                }
+            } catch (e: IOException) {
+                System.err.println("Logger config file $file load failure. Reason: $e")
+                e.printStackTrace() // print, but do not break
+            }
+        }
+
+        val map = mutableMapOf<String, String>()
+        for (name in properties.stringPropertyNames()) {
+            val value = properties.getProperty(name) ?: continue
+            map[name] = value
+        }
+
+        return map
+    }
+
+    private fun configFileName(): String {
+        return System.getProperty(CONFIG_FILE_FILEPATH, DEFAULT_CONFIG_FILE_NAME)
+    }
 }
 
 /**


### PR DESCRIPTION
可参考模块下README说明中的简单示例，支持配置文件（默认为 `simbot-logger-slf4j.properties` 的读取。