### PR TITLE
使生成的 xxxAsync 函数会正确的使用当前类作为 CoroutineScope (如果可以的话)

### DIFF
--- a/buildSrc/src/main/kotlin/SuspendTransforms.kt
+++ b/buildSrc/src/main/kotlin/SuspendTransforms.kt
@@ -45,7 +45,7 @@ object SuspendTransforms {
      */
     val jvmAsyncTransformer = SuspendTransformConfiguration.jvmAsyncTransformer.copy(
         syntheticFunctionIncludeAnnotations = includeAnnotations,
-        transformFunctionInfo = FunctionInfo("love.forte.simbot.utils", null, "$\$runInAsync"),
+        transformFunctionInfo = FunctionInfo("love.forte.simbot.utils", null, "$\$runInAsync1"),
         copyAnnotationExcludes = SuspendTransformConfiguration.jvmAsyncTransformer.copyAnnotationExcludes + SuspendTransformConfiguration.jvmAsyncTransformer.markAnnotation.classInfo
     )
     

--- a/simbot-util-suspend-transformer/src/jvmMain/kotlin/love/forte/simbot/utils/BlockingRunner.kt
+++ b/simbot-util-suspend-transformer/src/jvmMain/kotlin/love/forte/simbot/utils/BlockingRunner.kt
@@ -498,9 +498,22 @@ public fun <T> runInAsync(block: suspend CoroutineScope.() -> T): CompletableFut
 @Deprecated("Just used by compiler", level = DeprecationLevel.HIDDEN)
 public fun <T> `$$runInBlocking`(block: suspend () -> T): T = runInNoScopeBlocking(block = block)
 
+/**
+ * [#670](https://github.com/simple-robot/simpler-robot/pull/670) 后仅保留做兼容，
+ * 更新后使用 `$$runInAsync1`
+ */
+@InternalSimbotApi
+@Deprecated("Compatible with 3.0.0 and earlier", level = DeprecationLevel.HIDDEN)
+public fun <T> `$$runInAsync`(block: suspend () -> T): CompletableFuture<T> {
+    return runInAsync { block() }
+}
+
+/**
+ * @since 3.1.0
+ */
 @InternalSimbotApi
 @Deprecated("Just used by compiler", level = DeprecationLevel.HIDDEN)
-public fun <T> `$$runInAsync`(block: suspend () -> T, scope: CoroutineScope = `$$DefaultScope`): CompletableFuture<T> {
+public fun <T> `$$runInAsync1`(block: suspend () -> T, scope: CoroutineScope = `$$DefaultScope`): CompletableFuture<T> {
     return runInAsync(scope) { block() }
 }
 
@@ -591,4 +604,6 @@ private class SuspendRunner<T>(override val context: CoroutineContext = EmptyCor
 
 private fun systemLong(key: String): Long? = System.getProperty(key)?.toLongOrNull()
 private fun systemInt(key: String): Int? = System.getProperty(key)?.toIntOrNull()
+
+@Suppress("SameParameterValue")
 private fun systemBool(key: String): Boolean = System.getProperty(key)?.toBoolean() ?: false


### PR DESCRIPTION
在 `BlockingRunner` 中追加新的供编译器插件使用的 `$$runInAsync1` 函数，并恢复 `$$runInAsync` 函数的参数来修正 #670 可能造成的不兼容问题。