### PR TITLE
调整BlockingRunner内部实现，移除同步代码块和 wait/notify 的使用；为部分配置类增加直接配置 Executor 的API

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -54,6 +54,7 @@ if (!System.getenv("IS_CI").toBoolean()) {
     include(":simbot-component-http-server-api")
 }
 
+//include(":simbot-project-tests:simbot-project-test-j21")
 
 
 @Suppress("NOTHING_TO_INLINE")

--- a/simbot-core/src/main/kotlin/love/forte/simbot/core/application/BaseStandardApplicationBuilder.kt
+++ b/simbot-core/src/main/kotlin/love/forte/simbot/core/application/BaseStandardApplicationBuilder.kt
@@ -12,6 +12,7 @@
 
 package love.forte.simbot.core.application
 
+import kotlinx.coroutines.Job
 import love.forte.simbot.application.Application
 import love.forte.simbot.application.ApplicationBuilder
 import love.forte.simbot.application.ApplicationBuilderDsl
@@ -71,7 +72,7 @@ public abstract class BaseStandardApplicationBuilder<A : Application> : BaseAppl
         environment: Application.Environment,
     ): SimpleEventListenerManager {
         val initial = SimpleListenerManagerConfiguration {
-            coroutineContext = appConfig.coroutineContext
+            coroutineContext = appConfig.coroutineContext.minusKey(Job)
         }
         
         return simpleListenerManager(initial = initial) {

--- a/simbot-project-tests/simbot-project-test-j21/build.gradle.kts
+++ b/simbot-project-tests/simbot-project-test-j21/build.gradle.kts
@@ -1,0 +1,51 @@
+
+/*
+ * Copyright (c) 2023 ForteScarlet.
+ *
+ * This file is part of Simple Robot.
+ *
+ * Simple Robot is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * Simple Robot is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with Simple Robot. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+plugins {
+    kotlin("jvm") // version "1.9.20-Beta2"
+
+}
+
+
+tasks.getByName<Test>("test") {
+    useJUnitPlatform()
+}
+
+dependencies {
+    implementation(project(":simbot-util-suspend-transformer"))
+    testImplementation(kotlin("test-junit5"))
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    kotlinOptions {
+        javaParameters = true
+        jvmTarget = "21"
+        freeCompilerArgs = freeCompilerArgs + listOf("-Xjvm-default=all")
+    }
+}
+
+kotlin {
+    explicitApi()
+    this.sourceSets.configureEach {
+        languageSettings {
+            optIn("kotlin.RequiresOptIn")
+        }
+    }
+}
+
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.encoding = "UTF-8"
+}

--- a/simbot-project-tests/simbot-project-test-j21/src/test/kotlin/VisDisp.kt
+++ b/simbot-project-tests/simbot-project-test-j21/src/test/kotlin/VisDisp.kt
@@ -1,0 +1,15 @@
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.asCoroutineDispatcher
+import love.forte.simbot.utils.CustomBlockingDispatcherProvider
+import java.util.concurrent.Executors
+
+/**
+ *
+ * @author ForteScarlet
+ */
+class VisDisp : CustomBlockingDispatcherProvider() {
+    override fun blockingDispatcher(): CoroutineDispatcher {
+        return Executors.newVirtualThreadPerTaskExecutor().asCoroutineDispatcher()
+    }
+
+}

--- a/simbot-project-tests/simbot-project-test-j21/src/test/kotlin/t/BlockingRunnerTests.kt
+++ b/simbot-project-tests/simbot-project-test-j21/src/test/kotlin/t/BlockingRunnerTests.kt
@@ -1,0 +1,55 @@
+package t
+
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import love.forte.simbot.utils.runInBlocking
+import love.forte.simbot.utils.runInNoScopeBlocking
+import kotlin.coroutines.resume
+
+
+fun main() {
+    System.setProperty("simbot.blockingRunner.waitTimeoutMilliseconds", "2000")
+//    System.setProperty("simbot.runInBlocking.dispatcher", "custom")
+    System.setProperty("simbot.runInBlocking.dispatcher", "forkJoinPool")
+//    runInNoScopeBlocking {
+//        delay(5000)
+//        println("你好")
+//    }
+//
+//
+//    val value = runInNoScopeBlocking {
+//        delay(5000)
+//        kotlin.random.Random.nextLong()
+//    }
+//
+//    println("value = $value")
+
+    val value2 = runInBlocking {
+        println("T[1]" + Thread.currentThread())
+        coroutineScope {
+            println("T[2]" + Thread.currentThread())
+            suspendCancellableCoroutine { c ->
+                println("T[3]" + Thread.currentThread())
+                launch {
+                    println("T[4]" + Thread.currentThread())
+                    delay(20)
+                    c.resume(kotlin.random.Random.nextLong())
+                    println("T[5]" + Thread.currentThread())
+                }
+            }
+            println("T[6]" + Thread.currentThread())
+        }
+        println("T[7]" + Thread.currentThread())
+    }
+
+    println("value2 = $value2")
+
+//    runInNoScopeBlocking {
+//        delay(5000)
+//        throw RuntimeException()
+//    }
+
+    println("Done.")
+}

--- a/simbot-project-tests/simbot-project-test-j21/src/test/resources/META-INF/services/love.forte.simbot.utils.CustomBlockingDispatcherProvider
+++ b/simbot-project-tests/simbot-project-test-j21/src/test/resources/META-INF/services/love.forte.simbot.utils.CustomBlockingDispatcherProvider
@@ -1,0 +1,1 @@
+VisDisp

--- a/simbot-util-api-requestor-ktor/build.gradle.kts
+++ b/simbot-util-api-requestor-ktor/build.gradle.kts
@@ -50,9 +50,9 @@ kotlin {
     // https://ktor.io/docs/client-supported-platforms.html
     val supportedPlatforms = setOf(
         // iOS
-        "iosArm32", "iosArm64", "iosX64", "iosSimulatorArm64",
+        "iosArm64", "iosX64", "iosSimulatorArm64",
         // watchOS
-        "watchosArm32", "watchosArm64", "watchosX86", "watchosX64", "watchosSimulatorArm64",
+        "watchosArm32", "watchosArm64", "watchosX64", "watchosSimulatorArm64",
         // tvOS
         "tvosArm64", "tvosX64", "tvosSimulatorArm64",
         // macOS

--- a/simbot-util-suspend-transformer/build.gradle.kts
+++ b/simbot-util-suspend-transformer/build.gradle.kts
@@ -76,6 +76,13 @@ kotlin {
                 api(libs.kotlinx.coroutines.jdk8)
             }
         }
+
+        getByName("jvmTest") {
+            dependencies {
+                api(project(":simbot-logger-slf4j-impl"))
+            }
+        }
+
         getByName("jsMain") {
             dependencies {
                 api(libs.kotlinx.coroutines.core)

--- a/simbot-util-suspend-transformer/src/jvmMain/kotlin/love/forte/simbot/utils/BlockingRunner.kt
+++ b/simbot-util-suspend-transformer/src/jvmMain/kotlin/love/forte/simbot/utils/BlockingRunner.kt
@@ -50,7 +50,7 @@ private fun createDefaultDispatcher(
     if (coreSize == null && maxSize == null && keepAliveTime == null) {
         return null
     }
-    // cpu / 2 or 1
+    // cpu / 2 or 8
     val availableProcessors = Runtime.getRuntime().availableProcessors()
     val coreSize = (coreSize ?: (availableProcessors / 2)).coerceAtLeast(8)
     val maxSize =
@@ -129,7 +129,7 @@ private const val ASYNC_DISPATCHER_KEEP_ALIVE_TIME_PROPERTY = "$ASYNC_DISPATCHER
  * 可以选择使用 [CustomBlockingExecutorProvider] 类型。
  *
  * @see CustomBlockingDispatcherProvider
- *
+ * @since 3.3.0
  */
 public abstract class CustomBlockingDispatcherProvider {
     /**
@@ -142,6 +142,7 @@ public abstract class CustomBlockingDispatcherProvider {
  * 提供一个用于阻塞调用的调度器的供应商。
  *
  * @see CustomBlockingDispatcherProvider
+ * @since 3.3.0
  */
 public abstract class CustomBlockingExecutorProvider : CustomBlockingDispatcherProvider() {
     final override fun blockingDispatcher(): CoroutineDispatcher = blockingExecutor().asCoroutineDispatcher()
@@ -211,7 +212,7 @@ private fun loadCustomBlockingDispatcher(loader: ClassLoader?): CoroutineDispatc
  * | `simbot.runInBlocking.dispatcher=main` | [Dispatchers.Main] | 使用 [Dispatchers.Main] 作为默认调度器. |
  * | `simbot.runInBlocking.dispatcher=unconfined` | [Dispatchers.Unconfined] | 使用 [Dispatchers.Unconfined] 作为默认调度器. |
  * | `simbot.runInBlocking.dispatcher=forkJoinPool` | [ForkJoinPool] | 使用 [ForkJoinPool] 作为默认调度器. |
- * | `simbot.runInBlocking.dispatcher=custom` | 通过 SPI 加载 [CustomBlockingDispatcherProvider] 并通过其构建 [CoroutineDispatcher] |
+ * | `simbot.runInBlocking.dispatcher=custom` | (since 3.3.0) 通过 SPI 加载 [CustomBlockingDispatcherProvider] 并通过其构建 [CoroutineDispatcher] |
  *
  * 如果选择了使用某个具体的调度器，那么你可以额外指定属性 `simbot.runInBlocking.dispatcher.limitedParallelism` 来通过 [CoroutineDispatcher.limitedParallelism]
  * 来限制使用的最大并发数。更多说明（和警告）参考 [CoroutineDispatcher.limitedParallelism]。
@@ -357,7 +358,7 @@ public val DefaultBlockingContext: CoroutineContext by lazy {
  * | `simbot.runInAsync.dispatcher=main` | [Dispatchers.Main] | 使用 [Dispatchers.Main] 作为默认调度器. |
  * | `simbot.runInAsync.dispatcher=unconfined` | [Dispatchers.Unconfined] | 使用 [Dispatchers.Unconfined] 作为默认调度器. |
  * | `simbot.runInAsync.dispatcher=forkJoinPool` | [ForkJoinPool] | 使用 [ForkJoinPool] 作为默认调度器. |
- *
+ * | `simbot.runInAsync.dispatcher=custom` | (since 3.3.0) 通过 SPI 加载 [CustomBlockingDispatcherProvider] 并通过其构建 [CoroutineDispatcher] |
  */
 @InternalSimbotApi
 public val DefaultAsyncDispatcherOrNull: CoroutineDispatcher? by lazy {

--- a/simbot-util-suspend-transformer/src/jvmMain/kotlin/love/forte/simbot/utils/BlockingRunner.kt
+++ b/simbot-util-suspend-transformer/src/jvmMain/kotlin/love/forte/simbot/utils/BlockingRunner.kt
@@ -676,6 +676,7 @@ public fun <T> `$$runInAsyncNullable`(block: suspend () -> T, scope: CoroutineSc
 
 // Yes. I am the BlockingRunner.
 private class SuspendRunner<T>(override val context: CoroutineContext = EmptyCoroutineContext) : Continuation<T> {
+    @Suppress("unused")
     @Volatile
     var s: Int = 0
     // 1 = resume - success

--- a/simbot-util-suspend-transformer/src/jvmTest/kotlin/BlockingRunnerTests.kt
+++ b/simbot-util-suspend-transformer/src/jvmTest/kotlin/BlockingRunnerTests.kt
@@ -1,0 +1,53 @@
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import love.forte.simbot.utils.runInNoScopeBlocking
+import kotlin.coroutines.resume
+
+
+fun main() {
+    System.setProperty("simbot.blockingRunner.waitTimeoutMilliseconds", "2000")
+    System.setProperty("simbot.runInBlocking.dispatcher", "forkjoinpool")
+//    MethodHandles.publicLookup().findVirtual(Thread::class.java, "isVirtual", MethodType.methodType(java.lang.Boolean.TYPE))
+
+//    runInNoScopeBlocking {
+//        delay(5000)
+//        println("你好")
+//    }
+//
+//
+//    val value = runInNoScopeBlocking {
+//        delay(5000)
+//        kotlin.random.Random.nextLong()
+//    }
+//
+//    println("value = $value")
+
+    val value2 = runInNoScopeBlocking {
+        println("T[1]" + Thread.currentThread())
+        coroutineScope {
+            println("T[2]" + Thread.currentThread())
+            suspendCancellableCoroutine { c ->
+                println("T[3]" + Thread.currentThread())
+                launch {
+                    println("T[4]" + Thread.currentThread())
+                    delay(4000)
+                    c.resume(kotlin.random.Random.nextLong())
+                    println("T[5]" + Thread.currentThread())
+                }
+            }
+            println("T[6]" + Thread.currentThread())
+        }
+        println("T[7]" + Thread.currentThread())
+    }
+
+    println("value2 = $value2")
+
+//    runInNoScopeBlocking {
+//        delay(5000)
+//        throw RuntimeException()
+//    }
+
+    println("Done.")
+}


### PR DESCRIPTION
1. 调整BlockingRunner内部实现并移除同步代码块和 wait/notify，
主要用于提供对JDK21虚拟线程的支持。

   现在可以通过增加JVM参数 `-Dsimbot.runInBlocking.dispatcher=custom` 并提供一个 `CustomBlockingDispatcherProvider` 的SPI实现，即可在 BlockingRunner 产生的阻塞API（xxxBlocking）中使用此自定义调度器。


2. 为部分配置类增加直接配置 Executor 的API
主要是 `ApplicationConfiguration` 和 `SimpleListenerManagerConfiguration` 中，增加 `appendExecutorToCoroutineContext` 来快捷的提供一个调度器。
