### PR TITLE
BlockingRunner 增加对虚拟线程的配置支持

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -22,7 +22,7 @@ repositories {
 }
 
 val kotlinVersion = "1.9.10"
-val dokkaPluginVersion = "1.8.20"
+val dokkaPluginVersion = "1.9.0"
 val suspendTransformVersion = "0.5.0"
 val gradleCommon = "0.1.1"
 val ktor = "2.3.1"

--- a/buildSrc/src/main/kotlin/changelog/GenerateChangelog.kt
+++ b/buildSrc/src/main/kotlin/changelog/GenerateChangelog.kt
@@ -135,7 +135,7 @@ fun Project.generateChangelog(tag: String) {
                 }
             }
 
-        val tmpDir = rootProject.buildDir.resolve("tmp/changelog").apply { mkdirs() }
+        val tmpDir = rootProject.layout.buildDirectory.dir("tmp/changelog").get().asFile.apply { mkdirs() }
 
         val tmpFile =
             Files.createTempFile(tmpDir.toPath(), "changelog", "tmp").toFile()

--- a/buildSrc/src/main/kotlin/simbot.dokka-module-configuration.gradle.kts
+++ b/buildSrc/src/main/kotlin/simbot.dokka-module-configuration.gradle.kts
@@ -24,6 +24,11 @@ tasks.named("dokkaHtml").configure {
         dependsOn(kaptKotlinTask)
     }
 }
+tasks.named("dokkaHtmlPartial").configure {
+    tasks.findByName("kaptKotlin")?.also { kaptKotlinTask ->
+        dependsOn(kaptKotlinTask)
+    }
+}
 
 tasks.withType<org.jetbrains.dokka.gradle.DokkaTaskPartial>().configureEach {
     dokkaSourceSets.configureEach {

--- a/buildSrc/src/main/kotlin/simbot.dokka-module-configuration.gradle.kts
+++ b/buildSrc/src/main/kotlin/simbot.dokka-module-configuration.gradle.kts
@@ -13,24 +13,16 @@
 import org.jetbrains.dokka.DokkaConfiguration
 import java.net.URL
 
-/*
- *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
- *
- *  本文件是 simply-robot (或称 simple-robot 3.x 、simbot 3.x ) 的一部分。
- *
- *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
- *
- *  发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
- *
- *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
- *  https://www.gnu.org/licenses
- *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
- *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
- *
- */
+
 
 plugins {
     id("org.jetbrains.dokka")
+}
+
+tasks.named("dokkaHtml").configure {
+    tasks.findByName("kaptKotlin")?.also { kaptKotlinTask ->
+        dependsOn(kaptKotlinTask)
+    }
 }
 
 tasks.withType<org.jetbrains.dokka.gradle.DokkaTaskPartial>().configureEach {

--- a/buildSrc/src/main/kotlin/simbot.dokka-multi-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/simbot.dokka-multi-module.gradle.kts
@@ -14,22 +14,6 @@ import org.jetbrains.dokka.base.DokkaBase
 import org.jetbrains.dokka.base.DokkaBaseConfiguration
 import java.time.Year
 
-/*
- *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
- *
- *  本文件是 simply-robot (即 simple robot的v3版本，因此亦可称为 simple-robot v3 、simbot v3 等) 的一部分。
- *
- *  simply-robot 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
- *
- *  发布 simply-robot 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
- *
- *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
- *  https://www.gnu.org/licenses
- *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
- *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
- *
- *
- */
 
 /*
  使用在根配置，配置dokka多模块

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,10 @@ kotlin.native.ignoreDisabledTargets=true
 #kotlin.daemon.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 
 # see https://github.com/Kotlin/dokka/issues/3153
-org.jetbrains.dokka.classpath.useNativeDistributionAccessor=true
+#org.jetbrains.dokka.classpath.useNativeDistributionAccessor=true
+#org.jetbrains.dokka.classpath.useKonanDistribution=true
+#org.jetbrains.dokka.classpath.excludePlatformDependencyFiles=true
+
 
 #org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 org.gradle.jvmargs=-Xmx8G -Xms2G -XX:MaxMetaspaceSize=1G -Dfile.encoding=UTF-8

--- a/simbot-api/src/main/kotlin/love/forte/simbot/ID.kt
+++ b/simbot-api/src/main/kotlin/love/forte/simbot/ID.kt
@@ -487,7 +487,7 @@ public sealed class NumericalID<N : Number> : ID(), NumberSimilarly {
      * 将当前数字转为 [Char]. 同 [Number.toChar].
      * @see Number.toChar
      */
-    override fun toChar(): Char = value.toChar()
+    override fun toChar(): Char = value.toInt().toChar()
 
     /**
      * 将当前数字转为 [Short]. 同 [Number.toShort].
@@ -1084,7 +1084,6 @@ private class NumericalIdNumber(private val id: NumericalID<*>) : Number() {
     override fun toShort(): Short = id.toShort()
     override fun toInt(): Int = id.toInt()
     override fun toLong(): Long = id.toLong()
-    override fun toChar(): Char = id.toChar()
     override fun toDouble(): Double = id.toDouble()
     override fun toFloat(): Float = id.toFloat()
 }

--- a/simbot-util-suspend-transformer/src/jvmMain/kotlin/love/forte/simbot/utils/BlockingRunner.kt
+++ b/simbot-util-suspend-transformer/src/jvmMain/kotlin/love/forte/simbot/utils/BlockingRunner.kt
@@ -38,7 +38,7 @@ import kotlin.time.Duration.Companion.milliseconds
  * 如果不支持虚拟线程则会抛出 [UnsupportedOperationException]。
  *
  * @since 3.3.0
- *
+ * @see DefaultBlockingDispatcherOrNull
  * @throws UnsupportedOperationException 不支持虚拟线程时
  */
 @ExperimentalSimbotApi
@@ -355,6 +355,7 @@ private inline fun initDefaultBlockingDispatcher(
  * - 名称为 `"runInBlocking"` 的 [CoroutineName].
  * - 默认调度器 [DefaultBlockingDispatcher].
  *
+ * @see DefaultBlockingDispatcherOrNull
  */
 @InternalSimbotApi
 public val DefaultBlockingContext: CoroutineContext by lazy {

--- a/simbot-util-suspend-transformer/src/jvmTest/kotlin/BlockingRunnerTests.kt
+++ b/simbot-util-suspend-transformer/src/jvmTest/kotlin/BlockingRunnerTests.kt
@@ -8,7 +8,7 @@ import kotlin.coroutines.resume
 
 fun main() {
     System.setProperty("simbot.blockingRunner.waitTimeoutMilliseconds", "2000")
-    System.setProperty("simbot.runInBlocking.dispatcher", "forkjoinpool")
+    System.setProperty("simbot.runInBlocking.dispatcher", "virtualOrIO")
 //    MethodHandles.publicLookup().findVirtual(Thread::class.java, "isVirtual", MethodType.methodType(java.lang.Boolean.TYPE))
 
 //    runInNoScopeBlocking {


### PR DESCRIPTION
现在添加JVM参数 `-Dsimbot.runInBlocking.dispatcher=virtual` 即可将所有通过 BlockingRunner 执行的阻塞函数（`xxxBlocking`）的调度器切换至虚拟线程。

（你也可以在 #743 中通过 `-Dsimbot.runInBlocking.dispatcher=custom` 切换到其他自定义调度器 ）

> **Note**
> 更多描述参考 [API文档](https://docs.simbot.forte.love/main/simbot-util-suspend-transformer/love.forte.simbot.utils/-default-blocking-dispatcher-or-null.html)

不过需要注意的是，这里切换到的是 `xxxBlocking` **内**的逻辑阻塞，而此函数**本身**则**可能**会被某个异步的虚拟线程 "join"。因此当开启BlockingRunner的虚拟线程调度器时，我们建议你将**事件调度**时使用的调度器也切换为虚拟线程。否则，在事件调度过程中仍会因物理线程被虚拟线程阻塞而导致影响效率。

在普通的core模块应用中，你可以通过 `ApplicationConfiguration` 或 `SimpleListenerManagerConfiguration` 的中的 `coroutineContext` 来定制事件调度器。

在 `Spring Starter` 中，向程序中注入一个 `CoroutineDispatcherContainer` 的实例并使其携带一个虚拟线程的线程池。

例如Java中：

```java
@Bean
public CoroutineDispatcherContainer virtualCoroutineDispatcherContainer() {
 return new CoroutineDispatcherContainer(ExecutorsKt.from(Executors.newVirtualThreadPerTaskExecutor()));
}
```


