### PR TITLE
修复使用 JSON 自动加载 SerializableBotConfiguration 时多态信息被全盘替换为 `"component`" 的问题

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -55,3 +55,8 @@ include(":simbot-quantcat:simbot-quantcat-common")
 include(":simbot-cores:simbot-core-spring-boot-starter-common")
 include(":simbot-cores:simbot-core-spring-boot-starter") // v3
 //include(":simbot-cores:simbot-core-spring-boot-v2-starter")
+
+// local
+// if (!(System.getProperty("IS_CI") ?: System.getenv("IS_CI")).toBoolean()) {
+//     include(":tests:native-impl-test")
+// }

--- a/simbot-api/build.gradle.kts
+++ b/simbot-api/build.gradle.kts
@@ -75,6 +75,7 @@ kotlin {
                 // jvm compile only
                 compileOnly(libs.jetbrains.annotations)
                 compileOnly(project(":simbot-commons:simbot-common-annotations"))
+                compileOnly(libs.kotlinx.serialization.json)
                 api(project(":simbot-commons:simbot-common-suspend-runner"))
                 api(project(":simbot-commons:simbot-common-core"))
                 api(project(":simbot-commons:simbot-common-collection"))
@@ -118,12 +119,14 @@ kotlin {
         }
 
         nativeMain.dependencies {
+            api(libs.kotlinx.serialization.json)
             api(libs.jetbrains.annotations)
             api(project(":simbot-commons:simbot-common-annotations"))
             api(libs.suspend.reversal.annotations)
         }
 
         jsMain.dependencies {
+            api(libs.kotlinx.serialization.json)
             api(project(":simbot-commons:simbot-common-annotations"))
             api(libs.jetbrains.annotations)
             api(libs.suspend.reversal.annotations)

--- a/simbot-api/src/commonMain/kotlin/love/forte/simbot/bot/SerializableBotConfiguration.kt
+++ b/simbot-api/src/commonMain/kotlin/love/forte/simbot/bot/SerializableBotConfiguration.kt
@@ -23,11 +23,14 @@
 
 package love.forte.simbot.bot
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonClassDiscriminator
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
 import kotlinx.serialization.modules.SerializersModuleBuilder
 import kotlinx.serialization.modules.polymorphic
 import love.forte.simbot.bot.NotSerializedBotConfiguration.Companion.resolveType
+import love.forte.simbot.component.Component
 import love.forte.simbot.resource.StringResource
 import kotlin.jvm.JvmStatic
 
@@ -58,9 +61,29 @@ import kotlin.jvm.JvmStatic
  * [NotSerializedBotConfiguration] 是 [SerializableBotConfiguration] 的一个特殊实现，
  * 可在某些无法反序列化的情况下作为默认实现提供。
  *
+ * ## 序列化器
+ *
+ * 目前仅建议使用下述的序列化器，因为它们支持将外层 [SerializableBotConfiguration] 的
+ * `classDiscriminator` 重置为指定的 [`"component"`][Component.CLASS_DISCRIMINATOR]，
+ * 而不影响实现内的其他多态类型。
+ * 如果使用其他序列化器，需要使用 `type` 作为 `classDiscriminator`。
+ *
+ * ### JSON
+ *
+ * 当使用 `JSON` 序列化器时，`class` 为 [`"component"`][Component.CLASS_DISCRIMINATOR] 而不是 `type`。
+ *
+ * ```json
+ * {
+ *   "component": "aaa.bbb",
+ *   ...
+ * }
+ * ```
+ *
  * @author ForteScarlet
  */
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
+@JsonClassDiscriminator(Component.CLASS_DISCRIMINATOR)
 public abstract class SerializableBotConfiguration
 
 /**

--- a/simbot-cores/simbot-core-spring-boot-starter/src/main/kotlin/love/forte/simbot/spring/configuration/application/DefaultSimbotApplicationProcessor.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter/src/main/kotlin/love/forte/simbot/spring/configuration/application/DefaultSimbotApplicationProcessor.kt
@@ -30,7 +30,6 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import love.forte.simbot.bot.*
-import love.forte.simbot.component.Component
 import love.forte.simbot.logger.Logger
 import love.forte.simbot.logger.LoggerFactory
 import love.forte.simbot.logger.logger
@@ -140,7 +139,6 @@ private class BotAutoLoader(
     @OptIn(ExperimentalSerializationApi::class)
     val json = Json {
         isLenient = true
-        classDiscriminator = Component.CLASS_DISCRIMINATOR
         ignoreUnknownKeys = true
         allowTrailingComma = true
         decodeEnumsCaseInsensitive = true


### PR DESCRIPTION
fix #751