### PR TITLE
增加扩展模块: 持续会话, 并实现持续会话的基本内容

### DIFF
--- a/buildSrc/src/main/kotlin/P.kt
+++ b/buildSrc/src/main/kotlin/P.kt
@@ -56,6 +56,7 @@ sealed class P(override val group: String) : ProjectDetail() {
         const val GROUP_LOGGER = "love.forte.simbot.logger"
         const val GROUP_GRADLE = "love.forte.simbot.gradle"
         const val GROUP_QUANTCAT = "love.forte.simbot.quantcat"
+        const val GROUP_EXTENSION = "love.forte.simbot.extension"
 
         // const val COMPONENT_GROUP = "love.forte.simbot.component"
         const val DESCRIPTION = "Simple Robot，一个通用的bot风格事件调度框架，以灵活的统一标准来编写bot应用。"
@@ -76,6 +77,7 @@ sealed class P(override val group: String) : ProjectDetail() {
     object SimbotLogger : P(GROUP_LOGGER)
     object SimbotGradle : P(GROUP_GRADLE)
     object SimbotQuantcat : P(GROUP_QUANTCAT)
+    object SimbotExtension : P(GROUP_QUANTCAT)
 
     final override val version: Version
     val versionWithoutSnapshot: Version

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,7 @@
  *     Project    https://github.com/simple-robot/simpler-robot
  *     Email      ForteScarlet@163.com
  *
- *     This file is part of the Simple Robot Library.
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Lesser General Public License as published by
@@ -59,6 +59,9 @@ include(":simbot-quantcat:simbot-quantcat-common")
 include(":simbot-cores:simbot-core-spring-boot-starter-common")
 include(":simbot-cores:simbot-core-spring-boot-starter") // v3
 //include(":simbot-cores:simbot-core-spring-boot-v2-starter")
+
+// extensions
+include(":simbot-extensions:simbot-extension-continuous-session")
 
 // local
 // if (!(System.getProperty("IS_CI") ?: System.getenv("IS_CI")).toBoolean()) {

--- a/simbot-api/src/commonMain/kotlin/love/forte/simbot/message/Messages.kt
+++ b/simbot-api/src/commonMain/kotlin/love/forte/simbot/message/Messages.kt
@@ -4,7 +4,7 @@
  *     Project    https://github.com/simple-robot/simpler-robot
  *     Email      ForteScarlet@163.com
  *
- *     This file is part of the Simple Robot Library.
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Lesser General Public License as published by
@@ -423,7 +423,8 @@ public fun StringFormat.decodeMessagesFromString(string: String): Messages =
 
 
 // TODO delete on stable version
-@Deprecated("仅供临时二进制兼容", level = DeprecationLevel.HIDDEN)
+@Suppress("FunctionName")
+@Deprecated("仅供临时针对v4.0.0-dev16及以下的版本的JVM二进制兼容", level = DeprecationLevel.HIDDEN)
 public object MessagesKt {
     @JvmStatic
     public fun StringFormat.encodeMessagesToString(messages: Messages): String =
@@ -432,6 +433,30 @@ public object MessagesKt {
     @JvmStatic
     public fun StringFormat.decodeMessagesFromString(string: String): Messages =
         decodeFromString(Messages.serializer, string)
+
+    @JvmStatic
+    @JvmName("emptyMessages")
+    public fun emptyMessages_compatible(): Messages = emptyMessages()
+
+    @JvmStatic
+    @JvmName("messagesOf")
+    public fun messagesOf_compatible(element: Message.Element): Messages = messagesOf(element)
+
+    @JvmStatic
+    @JvmName("messagesOf")
+    public fun messagesOf_compatible(vararg elements: Message.Element): Messages = messagesOf(*elements)
+
+    @JvmStatic
+    @JvmName("toMessages")
+    public fun Iterable<Message.Element>.toMessages_compatible(): Messages = toMessages()
+
+    @JvmStatic
+    @JvmName("plus")
+    public fun Message.plus_compatible(other: Message): Messages = plus(other)
+
+    @JvmStatic
+    @JvmName("isNotEmpty")
+    public fun Messages.isNotEmpty_compatible(): Boolean = isNotEmpty()
 }
 
 /**

--- a/simbot-commons/simbot-common-collection/src/commonMain/kotlin/love/forte/simbot/common/collection/maps.kt
+++ b/simbot-commons/simbot-common-collection/src/commonMain/kotlin/love/forte/simbot/common/collection/maps.kt
@@ -4,7 +4,7 @@
  *     Project    https://github.com/simple-robot/simpler-robot
  *     Email      ForteScarlet@163.com
  *
- *     This file is part of the Simple Robot Library.
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Lesser General Public License as published by
@@ -93,8 +93,9 @@ public expect inline fun <K, V> MutableMap<K, V>.removeValue(key: K, crossinline
  * （例如使用 [MutableMap.keys]、[MutableMap.values]、[MutableMap.entries]）
  * 对原 map 进行修改，而不会引发 [ConcurrentModificationException]，
  * 但正在迭代的迭代器不保证可以实时感知到已经发生的修改。换言之这种并发修改是弱一致性的。
+ * 并且大多数情况下，
+ * [MutableMap.keys]、[MutableMap.values]、[MutableMap.entries] 很可能是一个副本。
  *
- * [concurrentMutableMap] 得到的结果可能是弱一致性的。
  */
 public expect fun <K, V> concurrentMutableMap(): MutableMap<K, V>
 

--- a/simbot-commons/simbot-common-collection/src/nativeMain/kotlin/love/forte/simbot/common/collection/maps.native.kt
+++ b/simbot-commons/simbot-common-collection/src/nativeMain/kotlin/love/forte/simbot/common/collection/maps.native.kt
@@ -129,7 +129,7 @@ public actual inline fun <K, V> MutableMap<K, V>.removeValue(key: K, crossinline
  *
  */
 public actual fun <K, V> concurrentMutableMap(): MutableMap<K, V> =
-    SynchronizedMutableMap(mutableMapOf())
+    SynchronizedMutableMap(mutableMapOf<K, V>())
     // AtomicCopyOnWriteConcurrentMutableMap(emptyMap())
 
 @PublishedApi
@@ -208,7 +208,7 @@ private class SynchronizedMutableMap<K, V>(private val map: MutableMap<K, V>) : 
 }
 
 
-@Deprecated("似乎有Bug")
+@Deprecated("似乎有Bug?")
 private class AtomicCopyOnWriteConcurrentMutableMap<K, V>(initMap: Map<K, V>) : MutableMap<K, V>,
     MutableMapOperators<K, V> {
     private open class MapBox<K, out V>(val map: Map<K, V>)

--- a/simbot-commons/simbot-common-collection/src/nativeMain/kotlin/love/forte/simbot/common/collection/maps.native.kt
+++ b/simbot-commons/simbot-common-collection/src/nativeMain/kotlin/love/forte/simbot/common/collection/maps.native.kt
@@ -4,7 +4,7 @@
  *     Project    https://github.com/simple-robot/simpler-robot
  *     Email      ForteScarlet@163.com
  *
- *     This file is part of the Simple Robot Library.
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Lesser General Public License as published by
@@ -23,6 +23,8 @@
 
 package love.forte.simbot.common.collection
 
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
 import kotlin.concurrent.AtomicReference
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
@@ -132,7 +134,8 @@ public actual inline fun <K, V> MutableMap<K, V>.removeValue(key: K, crossinline
  *
  */
 public actual fun <K, V> concurrentMutableMap(): MutableMap<K, V> =
-    AtomicCopyOnWriteConcurrentMutableMap(emptyMap())
+    SynchronizedMutableMap(mutableMapOf())
+    // AtomicCopyOnWriteConcurrentMutableMap(emptyMap())
 
 @PublishedApi
 internal interface MutableMapOperators<K, V> : MutableMap<K, V> {
@@ -154,6 +157,62 @@ internal interface MutableMapOperators<K, V> : MutableMap<K, V> {
     fun removeValue(key: K, target: V): Boolean
 }
 
+// TODO
+private class SynchronizedMutableMap<K, V>(private val map: MutableMap<K, V>) : MutableMap<K, V>,
+    MutableMapOperators<K, V>, SynchronizedObject() {
+    private inline fun <T> inSync(block: () -> T): T = synchronized(this, block)
+
+    override val size: Int
+        get() = inSync { map.size }
+
+    override fun containsKey(key: K): Boolean = inSync { map.containsKey(key) }
+    override fun containsValue(value: V): Boolean = inSync { map.containsValue(value) }
+    override fun get(key: K): V? = inSync { map[key] }
+    override fun isEmpty(): Boolean = inSync { map.isEmpty() }
+
+    override val entries: MutableSet<MutableMap.MutableEntry<K, V>>
+        get() = inSync { map.toMutableMap() }.entries
+
+    override val keys: MutableSet<K>
+        get() = inSync { map.toMutableMap() }.keys
+
+    override val values: MutableCollection<V>
+        get() = inSync { map.toMutableMap() }.values
+
+    override fun clear() {
+        inSync { map.clear() }
+    }
+
+    override fun put(key: K, value: V): V? = inSync { map.put(key, value) }
+
+    override fun putAll(from: Map<out K, V>) {
+        inSync { map.putAll(from) }
+    }
+
+    override fun remove(key: K): V? = inSync { map.remove(key) }
+
+    override fun mergeOperator(key: K, value: V & Any, remapping: (V & Any, V & Any) -> V?): V? {
+        return inSync { map.internalMergeImpl(key, value, remapping) }
+    }
+
+    override fun computeOperator(key: K, remapping: (K, V?) -> V?): V? {
+        return inSync { map.internalComputeImpl(key, remapping) }
+    }
+
+    override fun computeIfAbsentOperator(key: K, remapping: (K) -> V): V {
+        return inSync { map.internalComputeIfAbsentImpl(key, remapping) }
+    }
+
+    override fun computeIfPresentOperator(key: K, mappingFunction: (K, V & Any) -> V?): V? {
+        return inSync { map.internalComputeIfPresentImpl(key, mappingFunction) }
+    }
+
+    override fun removeValue(key: K, target: V): Boolean {
+        return inSync { map.internalRemoveValueImpl(key) { target } }
+    }
+}
+
+
 private class AtomicCopyOnWriteConcurrentMutableMap<K, V>(initMap: Map<K, V>) : MutableMap<K, V>,
     MutableMapOperators<K, V> {
     private open class MapBox<K, out V>(val map: Map<K, V>)
@@ -164,60 +223,72 @@ private class AtomicCopyOnWriteConcurrentMutableMap<K, V>(initMap: Map<K, V>) : 
 
     private val mapRef = AtomicReference(initMap.toMap().box())
 
-    private inline val mapBox get() = mapRef.value
-    private inline val mapValue get() = mapBox.map
-
     @OptIn(ExperimentalContracts::class)
     private inline fun compareAndSetMap(block: (oldValue: Map<K, V>) -> Map<K, V>) {
         contract {
             callsInPlace(block, InvocationKind.AT_LEAST_ONCE)
         }
         do {
-            val oldValue = mapRef.value
-            val newValue = block(oldValue.map)
-        } while (!mapRef.compareAndSet(expected = oldValue, newValue = newValue.box()))
+            val oldValueBox = mapRef.value
+            val oldValueMap = oldValueBox.map
+            val newValueMap = block(oldValueMap)
+            val newValueBox = if (newValueMap === oldValueMap) oldValueBox else newValueMap.box()
+        } while (!mapRef.compareAndSet(expected = oldValueBox, newValue = newValueBox))
+        // } while (oldValueBox != mapRef.compareAndExchange(expected = oldValueBox, newValue = newValueBox))
+    }
+
+    private inline fun <T> useMap(block: (oldValue: Map<K, V>) -> T): T {
+        var result: T
+        compareAndSetMap { old ->
+            result = block(old)
+            old
+        }
+        return result
     }
 
     override val size: Int
-        get() = mapValue.size
+        get() = useMap { map -> map.size }
 
-    override fun containsKey(key: K): Boolean =
-        mapValue.containsKey(key)
+    override fun containsKey(key: K): Boolean = useMap { map -> map.containsKey(key) }
+    // mapValue.containsKey(key)
 
-    override fun containsValue(value: V): Boolean =
-        mapValue.containsValue(value)
+    override fun containsValue(value: V): Boolean = useMap { map -> map.containsValue(value) }
+    // mapValue.containsValue(value)
 
-    override fun get(key: K): V? = mapValue[key]
+    // override fun get(key: K): V? = mapValue[key]
+    override fun get(key: K): V? = useMap { map -> map[key] }
 
-    override fun isEmpty(): Boolean =
-        mapValue.isEmpty()
+    override fun isEmpty(): Boolean = useMap { map -> map.isEmpty() }
+    // mapValue.isEmpty()
 
     override val entries: MutableSet<MutableMap.MutableEntry<K, V>>
-        get() = mapValue.entries.mapTo(mutableSetOf()) { e ->
-            val value = AtomicReference(e.value)
-            val key = e.key
-            object : MutableMap.MutableEntry<K, V> {
-                override val key: K
-                    get() = key
-                override val value: V
-                    get() = value.value
+        get() = useMap { map ->
+            map.entries.mapTo(mutableSetOf()) { e ->
+                val value = AtomicReference(e.value)
+                val key = e.key
+                object : MutableMap.MutableEntry<K, V> {
+                    override val key: K
+                        get() = key
+                    override val value: V
+                        get() = value.value
 
-                override fun setValue(newValue: V): V {
-                    var oldValue: V
-                    do {
-                        oldValue = value.value
-                    } while (value.compareAndSet(oldValue, newValue))
+                    override fun setValue(newValue: V): V {
+                        var oldValue: V
+                        do {
+                            oldValue = value.value
+                        } while (value.compareAndSet(oldValue, newValue))
 
-                    return oldValue
+                        return oldValue
+                    }
                 }
             }
         }
 
     override val keys: MutableSet<K>
-        get() = mapValue.keys.toMutableSet()
+        get() = useMap { map -> map.keys.toMutableSet() }
 
     override val values: MutableCollection<V>
-        get() = mapValue.values.toMutableList()
+        get() = useMap { map -> map.values.toMutableList() }
 
     override fun clear() {
         compareAndSetMap { emptyMap() }

--- a/simbot-commons/simbot-common-collection/src/nativeMain/kotlin/love/forte/simbot/common/collection/maps.native.kt
+++ b/simbot-commons/simbot-common-collection/src/nativeMain/kotlin/love/forte/simbot/common/collection/maps.native.kt
@@ -122,15 +122,10 @@ public actual inline fun <K, V> MutableMap<K, V>.removeValue(key: K, crossinline
 }
 
 /**
- * 得到一个基于 [AtomicReference] 的 CopyOnWrite Map 实现。
- * 此 Map 中的修改操作是弱一致性的。
+ * 得到一个基于可重入同步锁的 concurrent map 实现。
  *
  * 此 Map 的 [entries][MutableMap.entries]、[keys][MutableMap.keys]、[values][MutableMap.values] 都是瞬时副本，
  * 对它们（以及它们的元素）进行修改不会对 Map 本体产生影响。
- *
- * 此 Map 在进行同时大量的修改且元素数量比较多时可能会有较高的损耗。
- *
- * 此 Map 支持 [mergeValue]、[computeValue]、[computeValueIfAbsent]、[computeValueIfPresent]
  *
  */
 public actual fun <K, V> concurrentMutableMap(): MutableMap<K, V> =
@@ -213,6 +208,7 @@ private class SynchronizedMutableMap<K, V>(private val map: MutableMap<K, V>) : 
 }
 
 
+@Deprecated("似乎有Bug")
 private class AtomicCopyOnWriteConcurrentMutableMap<K, V>(initMap: Map<K, V>) : MutableMap<K, V>,
     MutableMapOperators<K, V> {
     private open class MapBox<K, out V>(val map: Map<K, V>)

--- a/simbot-extensions/simbot-extension-continuous-session/README.md
+++ b/simbot-extensions/simbot-extension-continuous-session/README.md
@@ -1,0 +1,59 @@
+# 持续会话扩展
+
+仍在考虑中。
+
+**持续会话需要解决什么？**
+
+一个监听函数内、连贯的逻辑中，持续处理多次事件。
+例如：
+
+```kotlin
+val e1 = awaitEvent()
+val e2 = awaitEvent()
+    ...
+```
+
+**持续会话与普通事件处理器之间如何协调？**
+由于持续会话需要持续接收事件，因此在等待**下一个**事件时会处于挂起状态，
+这时对于后续的其他事件处理器会有较大影响。
+
+因此持续会话这个**会话**本身应当是处于**异步**的。
+
+因此会话开启 -> 异步中开始处理事件，此时又涉及到几个问题：
+
+- 事件唯一标识？
+  也许需要一个唯一标识来允许重新获取、分门别类，并允许超时、终止等行为。
+- 事件从哪儿来？
+  也许需要用户在事件处理器中主动向某个**会话**推送事件？
+  
+- 事件会话每次推送的响应？
+  需要想办法处理每次 `awaitEvent` 时的响应结果，并由此决定时候继续向后传递此事件。
+
+
+```kotlin
+suspend fun inSession(event: Event, sessionContext: ContinuousSessionContext): EventResult {
+    val key: ... // 字符串？还是 object？
+    
+    val sessionProvider = sessionContext.session(key) { // this: sessionReceiver
+        // 异步中、可挂起
+        val e = await() // event
+    }
+    
+    // 向会话推送，然后得到一个结果？
+    // 比如
+    //   不符合预期的结果 invalid
+    //   成功的空结果 empty
+    //   需要阻断后续事件处理的结果 truncate = true
+    val result: EventResult = sessionProvider.push(event)
+    
+    // 主要逻辑在 session 中，这里只需要返回结果
+    return result
+}
+
+```
+
+
+**持续会话的条件过滤？**
+持续会话大多有它的条件。例如，我想要连续接收同一个人的事件。
+
+****

--- a/simbot-extensions/simbot-extension-continuous-session/build.gradle.kts
+++ b/simbot-extensions/simbot-extension-continuous-session/build.gradle.kts
@@ -1,0 +1,146 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+import love.forte.gradle.common.core.project.setup
+import love.forte.gradle.common.kotlin.multiplatform.applyTier1
+import love.forte.gradle.common.kotlin.multiplatform.applyTier2
+import love.forte.gradle.common.kotlin.multiplatform.applyTier3
+
+plugins {
+    kotlin("multiplatform")
+    // kotlin("plugin.serialization")
+//    id("io.gitlab.arturbosch.detekt")
+    id("simbot.suspend-transform-configure")
+//     alias(libs.plugins.ksp)
+    id("simbot.dokka-module-configuration")
+}
+
+setup(P.SimbotExtension)
+
+configJavaCompileWithModule("simbot.extension.continuous.session")
+// apply(plugin = "simbot-multiplatform-maven-publish")
+
+kotlin {
+    explicitApi()
+    applyDefaultHierarchyTemplate()
+
+    configKotlinJvm(JVMConstants.KT_JVM_TARGET_VALUE)
+
+    js(IR) {
+        configJs()
+    }
+
+    applyTier1()
+    applyTier2()
+    applyTier3()
+
+    // wasm?
+//    @Suppress("OPT_IN_USAGE")
+//    wasmJs()
+//    @Suppress("OPT_IN_USAGE")
+//    wasmWasi()
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                // jvm compile only
+                // compileOnly(libs.jetbrains.annotations)
+                api(project(":simbot-api"))
+                // compileOnly(libs.kotlinx.serialization.json)
+            }
+        }
+        commonTest {
+            dependencies {
+                implementation(libs.kotlinx.coroutines.test)
+                // implementation(libs.kotlinx.coroutines.debug)
+                implementation(kotlin("test"))
+            }
+        }
+
+
+
+        jvmMain {
+            dependencies {
+                compileOnly(libs.kotlinx.coroutines.reactive)
+                compileOnly(libs.kotlinx.coroutines.reactor)
+                compileOnly(libs.kotlinx.coroutines.rx2)
+                compileOnly(libs.kotlinx.coroutines.rx3)
+            }
+        }
+
+        jvmTest {
+            dependencies {
+                implementation(libs.kotlinx.coroutines.reactive)
+                implementation(libs.kotlinx.coroutines.reactor)
+                implementation(libs.kotlinx.coroutines.rx2)
+                implementation(libs.kotlinx.coroutines.rx3)
+                implementation(libs.ktor.client.core)
+
+                implementation(kotlin("test-junit5"))
+                implementation(kotlin("reflect"))
+                implementation(libs.ktor.client.cio)
+            }
+        }
+
+        nativeMain.dependencies {
+            api(libs.kotlinx.serialization.json)
+            api(libs.jetbrains.annotations)
+            api(project(":simbot-commons:simbot-common-annotations"))
+            api(libs.suspend.reversal.annotations)
+        }
+
+        jsMain.dependencies {
+            api(libs.kotlinx.serialization.json)
+            api(project(":simbot-commons:simbot-common-annotations"))
+            api(libs.jetbrains.annotations)
+            api(libs.suspend.reversal.annotations)
+        }
+
+        jsTest.dependencies {
+            implementation(libs.ktor.client.js)
+            implementation(libs.ktor.client.core)
+        }
+
+        nativeTest.dependencies {
+            // implementation(libs.ktor.client.core)
+            // implementation(libs.ktor.client.cio)
+        }
+
+        linuxTest.dependencies {
+            // implementation(libs.ktor.client.core)
+            // implementation(libs.ktor.client.cio)
+        }
+
+        appleTest.dependencies {
+            // implementation(libs.ktor.client.core)
+            // implementation(libs.ktor.client.cio)
+        }
+
+        mingwTest.dependencies {
+            // implementation(libs.ktor.client.core)
+            // implementation(libs.ktor.client.winhttp)
+        }
+
+
+    }
+}

--- a/simbot-extensions/simbot-extension-continuous-session/src/commonMain/kotlin/love/forte/simbot/extension/continuous/session/AbstractContinuousSessionContext.kt
+++ b/simbot-extensions/simbot-extension-continuous-session/src/commonMain/kotlin/love/forte/simbot/extension/continuous/session/AbstractContinuousSessionContext.kt
@@ -1,0 +1,197 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.extension.continuous.session
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import kotlinx.coroutines.channels.ClosedSendChannelException
+import love.forte.simbot.ability.OnCompletion
+import love.forte.simbot.common.collection.computeValue
+import love.forte.simbot.common.collection.computeValueIfAbsent
+import love.forte.simbot.common.collection.concurrentMutableMap
+import love.forte.simbot.common.collection.removeValue
+import love.forte.simbot.extension.continuous.session.ContinuousSessionContext.ConflictStrategy.*
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+
+/**
+ *
+ * @author ForteScarlet
+ */
+public abstract class AbstractContinuousSessionContext<T, R>(coroutineContext: CoroutineContext) :
+    ContinuousSessionContext<T, R> {
+    protected val sessions: MutableMap<Any, ContinuousSessionProvider<T, R>> = concurrentMutableMap()
+    protected val launchScope: CoroutineScope = CoroutineScope(coroutineContext)
+
+    protected abstract fun computeSession(key: Any, inSession: InSession<T, R>): ContinuousSessionProvider<T, R>
+
+    override fun session(
+        key: Any,
+        strategy: ContinuousSessionContext.ConflictStrategy,
+        inSession: InSession<T, R>
+    ): ContinuousSessionProvider<T, R> {
+        return when (strategy) {
+            FAILURE -> {
+                sessions.computeValue(key) { _, old ->
+                    if (old != null) throw IllegalStateException("Session with key $key already exists")
+
+                    computeSession(key, inSession)
+                }!!
+            }
+
+            REPLACE -> {
+                sessions.computeValue(key) { _, old ->
+                    old?.cancel(/* TODO REPLACED EXCEPTION? */)
+                    computeSession(key, inSession)
+                }!!
+            }
+
+            OLD -> {
+                sessions.computeValueIfAbsent(key) { computeSession(key, inSession) }
+            }
+        }
+    }
+
+    override fun get(key: Any): ContinuousSessionProvider<T, R>? = sessions[key]
+    override fun remove(key: Any): ContinuousSessionProvider<T, R>? = sessions[key]
+}
+
+
+internal class SimpleContinuousSessionContext<T, R>(coroutineContext: CoroutineContext) :
+    AbstractContinuousSessionContext<T, R>(coroutineContext) {
+    private val parentJob = coroutineContext[Job]
+
+    // override fun toString(): String {
+    //     // TODO
+    //     return sessions.toString()
+    // }
+
+    override fun computeSession(key: Any, inSession: InSession<T, R>): SimpleSessionImpl<T, R> {
+        val job = Job(parentJob)
+        val channel = Channel<SessionData<T, R>>()
+        val session = SimpleSessionImpl(key, job, channel, launchScope)
+
+        job.invokeOnCompletion {
+            channel.close(it)
+            sessions.removeValue(key) { session }
+        }
+
+        launchScope.launch {
+            kotlin.runCatching {
+                inSession.run { session.invoke() }
+            }.onFailure { e ->
+                job.completeExceptionally(e)
+            }.onSuccess {
+                job.complete()
+            }
+        }
+
+        return session
+    }
+}
+
+internal data class SessionData<T, R>(val value: T, val continuation: CancellableContinuation<R>)
+
+
+internal class SimpleSessionImpl<T, R>(
+    private val key: Any,
+    private val job: CompletableJob,
+    private val channel: Channel<SessionData<T, R>>,
+    private val launchScope: CoroutineScope
+) : ContinuousSession<T, R> {
+
+    override val isActive: Boolean
+        get() = job.isActive
+
+    override val isCompleted: Boolean
+        get() = job.isCompleted
+
+    override val isCancelled: Boolean
+        get() = job.isCancelled
+
+    override fun onCompletion(handle: OnCompletion) {
+        job.invokeOnCompletion(handle::invoke)
+    }
+
+    override suspend fun join() {
+        job.join()
+    }
+
+    override suspend fun push(value: T): R = suspendCancellableCoroutine { continuation ->
+        val data = SessionData(value, continuation)
+        launchScope.launch {
+            kotlin.runCatching {
+                channel.send(data)
+            }.onFailure { e ->
+                when (e) {
+                    is ClosedSendChannelException -> {
+                        data.continuation.resumeWithException(
+                            SessionPushOnFailureException("Push to session channel (key=$key) failed: ${e.message}", e)
+                        )
+                    }
+
+                    is ClosedReceiveChannelException -> {
+                        data.continuation.resumeWithException(
+                            SessionPushOnFailureException("Push to session channel (key=$key) failed: ${e.message}", e)
+                        )
+                    }
+
+                    is CancellationException -> {
+                        data.continuation.cancel(
+                            CancellationException(
+                                "Push to session channel (key=$key) failed: ${e.message}",
+                                e.cause?.let { SessionPushOnFailureException(e.message, it) }
+                            )
+                        )
+                    }
+
+                    else -> {
+                        data.continuation.resumeWithException(
+                            SessionPushOnFailureException("Push to session channel (key=$key) failed: ${e.message}", e)
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    override fun cancel(cause: Throwable?) {
+        job.cancel(cause?.let { CancellationException("Cancelled: ${it.message}", it) })
+    }
+
+    override suspend fun await(result: (T) -> R): T {
+        val (value, continuation) = channel.receive()
+        try {
+            continuation.resume(result(value))
+        } catch (e: Throwable) {
+            continuation.resumeWithException(SessionAwaitOnFailureException(e.message, e))
+            throw e
+        }
+        return value
+    }
+}
+

--- a/simbot-extensions/simbot-extension-continuous-session/src/commonMain/kotlin/love/forte/simbot/extension/continuous/session/ContinuousSession.kt
+++ b/simbot-extensions/simbot-extension-continuous-session/src/commonMain/kotlin/love/forte/simbot/extension/continuous/session/ContinuousSession.kt
@@ -1,0 +1,80 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.extension.continuous.session
+
+import love.forte.simbot.ability.CompletionAware
+
+
+/**
+ *
+ * @author ForteScarlet
+ */
+public interface ContinuousSessionProvider<in T, out R> : CompletionAware {
+    /**
+     * @throws SessionPushOnFailureException 如果推送行为本身失败，
+     * 例如session已经结束或关闭。
+     * @throws SessionAwaitOnFailureException 如果推送行为成功、
+     * 但是在 [ContinuousSessionReceiver.await] 时出现了异常（例如构造响应结果时出现异常）
+     * @throws
+     */
+    public suspend fun push(value: T): R
+
+    public fun cancel(cause: Throwable?)
+
+    public fun cancel() {
+        cancel(null)
+    }
+
+    public val isActive: Boolean
+    public val isCompleted: Boolean
+    public val isCancelled: Boolean
+    public suspend fun join()
+}
+
+/**
+ *
+ * @author ForteScarlet
+ */
+public interface ContinuousSessionReceiver<out T, R> {
+
+    /**
+     * 等待 [ContinuousSessionProvider] 的下一次 [推送][ContinuousSessionProvider.push]。
+     *
+     * 在 [await] 的实现中，
+     * 如果在 [await] 过程中出现异常，会在抛出此异常前，
+     * 将此异常使用 [SessionAwaitOnFailureException]
+     * 包装并恢复(`resume`)给 [ContinuousSessionProvider.push]。
+     *
+     *
+     * @param result
+     *
+     */
+    public suspend fun await(result: (T) -> R): T
+
+    // TODO await 如何延迟响应？
+
+}
+
+
+public interface ContinuousSession<T, R> : ContinuousSessionProvider<T, R>, ContinuousSessionReceiver<T, R>

--- a/simbot-extensions/simbot-extension-continuous-session/src/commonMain/kotlin/love/forte/simbot/extension/continuous/session/ContinuousSession.kt
+++ b/simbot-extensions/simbot-extension-continuous-session/src/commonMain/kotlin/love/forte/simbot/extension/continuous/session/ContinuousSession.kt
@@ -23,58 +23,128 @@
 
 package love.forte.simbot.extension.continuous.session
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import love.forte.simbot.ability.CompletionAware
+import love.forte.simbot.ability.OnCompletion
+import kotlin.coroutines.CoroutineContext
 
 
 /**
+ * 一组 `Session` 的元素之一，
+ * 用来向 [ContinuousSessionReceiver] 推送事件 [T] 并获悉结果 [R]。
+ *
+ * ```kotlin
+ * val session = context.session(Key()) {
+ *     val next = await { v -> v.toResult() } // 假设 toResult() 将事件转化为结果
+ * }         ↑                      |
+ *       |-- | ---------------------|
+ *       |   |-----------|
+ *       ↓               |
+ * val result = session.push(value) // 此处得到 v.toResult() 的结果
+ * ```
  *
  * @author ForteScarlet
  */
 public interface ContinuousSessionProvider<in T, out R> : CompletionAware {
     /**
+     * 推送一个事件到对应的 [ContinuousSessionReceiver] 中并挂起直到将其
+     * [消费][ContinuousSessionReceiver.await] 或被关闭。
+     *
      * @throws SessionPushOnFailureException 如果推送行为本身失败，
      * 例如session已经结束或关闭。
      * @throws SessionAwaitOnFailureException 如果推送行为成功、
      * 但是在 [ContinuousSessionReceiver.await] 时出现了异常（例如构造响应结果时出现异常）
      * @throws
      */
+    // TODO @ST?
     public suspend fun push(value: T): R
 
+    /**
+     * 关闭对应的 `session`。
+     * 关闭后会同时将对应的 `session` 从对应的 [ContinuousSessionContext] 中移除。
+     */
     public fun cancel(cause: Throwable?)
 
+    /**
+     * 关闭对应的 `session`。
+     * 关闭后会同时将对应的 `session` 从对应的 [ContinuousSessionContext] 中移除。
+     */
     public fun cancel() {
         cancel(null)
     }
 
+    /**
+     * 是否处于活跃状态。
+     */
     public val isActive: Boolean
+
+    /**
+     * 是否已经完成。
+     */
     public val isCompleted: Boolean
+
+    /**
+     * 是否由于 cancel 而完成。
+     */
     public val isCancelled: Boolean
+
+    /**
+     * 挂起直到 `session` 完成任务或被关闭。
+     */
+    // TODO @ST?
     public suspend fun join()
+
+    /**
+     * 注册一个当 `session` 完成任务后执行的回调 [handle]。
+     * 也可以通过此回调得知被终止时的异常。
+     */
+    override fun onCompletion(handle: OnCompletion)
 }
 
 /**
+ * 一组 `Session` 的元素之一，
+ * 用来在异步中接收 [ContinuousSessionProvider] 推送的事件 [T]
+ * 并根据此事件为其返回结果 [R]。
+ *
+ * ```kotlin
+ * val session = context.session(Key()) {
+ *     val next = await { v -> v.toResult() } // 假设 toResult() 将事件转化为结果
+ * }         ↑                      |
+ *       |-- | ---------------------|
+ *       |   |-----------|
+ *       ↓               |
+ * val result = session.push(value) // 此处得到 v.toResult() 的结果
+ * ```
  *
  * @author ForteScarlet
  */
-public interface ContinuousSessionReceiver<out T, R> {
+public interface ContinuousSessionReceiver<out T, R> : CoroutineScope {
+    /**
+     * [ContinuousSessionReceiver] 作为 [CoroutineScope] 的协程上下文。
+     * 其中不会包含 [Job]。
+     */
+    override val coroutineContext: CoroutineContext
 
     /**
      * 等待 [ContinuousSessionProvider] 的下一次 [推送][ContinuousSessionProvider.push]。
      *
-     * 在 [await] 的实现中，
      * 如果在 [await] 过程中出现异常，会在抛出此异常前，
      * 将此异常使用 [SessionAwaitOnFailureException]
      * 包装并恢复(`resume`)给 [ContinuousSessionProvider.push]。
      *
-     *
      * @param result
      *
      */
+    // TODO @ST?
     public suspend fun await(result: (T) -> R): T
 
     // TODO await 如何延迟响应？
 
 }
 
-
+/**
+ * 组合 [ContinuousSessionProvider] 和 [ContinuousSessionReceiver]
+ * 的 `session` 类型。
+ */
 public interface ContinuousSession<T, R> : ContinuousSessionProvider<T, R>, ContinuousSessionReceiver<T, R>

--- a/simbot-extensions/simbot-extension-continuous-session/src/commonMain/kotlin/love/forte/simbot/extension/continuous/session/ContinuousSessionContext.kt
+++ b/simbot-extensions/simbot-extension-continuous-session/src/commonMain/kotlin/love/forte/simbot/extension/continuous/session/ContinuousSessionContext.kt
@@ -1,0 +1,65 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.extension.continuous.session
+
+import love.forte.simbot.event.Event
+import love.forte.simbot.event.EventResult
+
+
+public fun interface InSession<T, R> {
+    public suspend fun ContinuousSessionReceiver<T, R>.invoke()
+}
+
+/**
+ *
+ * @author ForteScarlet
+ */
+public interface ContinuousSessionContext<T, R> {
+
+    /**
+     * 创建，冲突
+     */
+    public fun session(key: Any, strategy: ConflictStrategy = ConflictStrategy.FAILURE, inSession: InSession<T, R>): ContinuousSessionProvider<T, R>
+
+    public operator fun get(key: Any): ContinuousSessionProvider<T, R>?
+
+    public fun remove(key: Any): ContinuousSessionProvider<T, R>?
+
+    /**
+     * 创建时的冲突策略
+     */
+    public enum class ConflictStrategy {
+        // 报错
+        FAILURE,
+        // 关闭旧的
+        REPLACE,
+        // 获取旧的
+        OLD // TODO name
+    }
+}
+
+/**
+ * 以事件为中心的 [ContinuousSessionContext] 子类型。
+ */
+public interface EventContinuousSessionContext : ContinuousSessionContext<Event, EventResult>

--- a/simbot-extensions/simbot-extension-continuous-session/src/commonMain/kotlin/love/forte/simbot/extension/continuous/session/EventContinuousSessionContext.kt
+++ b/simbot-extensions/simbot-extension-continuous-session/src/commonMain/kotlin/love/forte/simbot/extension/continuous/session/EventContinuousSessionContext.kt
@@ -1,0 +1,102 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+@file:JvmName("EventContinuousSessionContexts")
+@file:JvmMultifileClass
+
+package love.forte.simbot.extension.continuous.session
+
+import kotlinx.coroutines.Job
+import love.forte.simbot.application.Application
+import love.forte.simbot.application.ApplicationConfiguration
+import love.forte.simbot.common.coroutines.mergeWith
+import love.forte.simbot.common.function.ConfigurerFunction
+import love.forte.simbot.common.function.invokeWith
+import love.forte.simbot.event.Event
+import love.forte.simbot.event.EventResult
+import love.forte.simbot.plugin.Plugin
+import love.forte.simbot.plugin.PluginConfigureContext
+import love.forte.simbot.plugin.PluginFactory
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.jvm.JvmMultifileClass
+import kotlin.jvm.JvmName
+
+/**
+ * 以事件为中心的 [ContinuousSessionContext] 子类型。
+ *
+ * ## 插件
+ *
+ * [EventContinuousSessionContext] 实现 [Plugin], 可以作为 [Application] 的插件安装使用。
+ *
+ * ```kotlin
+ * launchSimpleApplication {
+ *     install(EventContinuousSessionContext) {
+ *         // 一些可选的配置...
+ *     }
+ * }
+ * ```
+ *
+ * [EventContinuousSessionContext] 暂时**不支持SPI**，它需要用户明确的按需加载。
+ *
+ * ## 持续会话
+ *
+ * 有关持续会话等详细说明参阅 [ContinuousSessionContext] 的文档说明。
+ *
+ * @see ContinuousSessionContext
+ */
+public interface EventContinuousSessionContext : ContinuousSessionContext<Event, EventResult>, Plugin {
+
+    public companion object Factory :
+        PluginFactory<EventContinuousSessionContext, EventContinuousSessionContextConfiguration> {
+        override val key: PluginFactory.Key = object : PluginFactory.Key {}
+
+        override fun create(
+            context: PluginConfigureContext,
+            configurer: ConfigurerFunction<EventContinuousSessionContextConfiguration>
+        ): EventContinuousSessionContext {
+            val config = EventContinuousSessionContextConfiguration()
+            configurer.invokeWith(config)
+            val newCoroutineContext = config.coroutineContext.mergeWith(context.applicationConfiguration.coroutineContext)
+
+            return EventContinuousSessionContextImpl(newCoroutineContext)
+        }
+    }
+}
+
+private class EventContinuousSessionContextImpl(coroutineContext: CoroutineContext) :
+    EventContinuousSessionContext,
+    ContinuousSessionContext<Event, EventResult> by ContinuousSessionContext(coroutineContext)
+
+/**
+ * [EventContinuousSessionContext.Factory] 使用的配置类。
+ */
+public class EventContinuousSessionContextConfiguration {
+    /**
+     * 用于 [EventContinuousSessionContext] 中的协程上下文。
+     * 值来自 [ApplicationConfiguration.coroutineContext]，但不包含 Job。
+     * 如果配置后 [coroutineContext] 存在 [Job], 则会基于此以及 [ApplicationConfiguration.coroutineContext]
+     * 合成一个新的 [Job]。
+     */
+    public var coroutineContext: CoroutineContext = EmptyCoroutineContext
+}

--- a/simbot-extensions/simbot-extension-continuous-session/src/commonMain/kotlin/love/forte/simbot/extension/continuous/session/exceptions.kt
+++ b/simbot-extensions/simbot-extension-continuous-session/src/commonMain/kotlin/love/forte/simbot/extension/continuous/session/exceptions.kt
@@ -24,6 +24,16 @@
 package love.forte.simbot.extension.continuous.session
 
 /**
+ * 冲突的 session key.
+ */
+public class ConflictSessionKeyException(message: String?) : IllegalArgumentException(message)
+
+/**
+ * 因出现冲突的 session key 而被替换
+ */
+public class ReplacedBecauseOfConflictSessionKeyException(message: String?) : IllegalStateException(message)
+
+/**
  * 当使用 [ContinuousSessionProvider.push] 推送失败时，
  * 会将异常包装在 [SessionPushOnFailureException.cause] 中。
  */

--- a/simbot-extensions/simbot-extension-continuous-session/src/commonMain/kotlin/love/forte/simbot/extension/continuous/session/exceptions.kt
+++ b/simbot-extensions/simbot-extension-continuous-session/src/commonMain/kotlin/love/forte/simbot/extension/continuous/session/exceptions.kt
@@ -1,0 +1,45 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.extension.continuous.session
+
+/**
+ * 当使用 [ContinuousSessionProvider.push] 推送失败时，
+ * 会将异常包装在 [SessionPushOnFailureException.cause] 中。
+ */
+public class SessionPushOnFailureException : IllegalStateException {
+    public constructor(message: String?) : super(message)
+    public constructor(message: String?, cause: Throwable?) : super(message, cause)
+    public constructor(cause: Throwable?) : super(cause)
+}
+
+/**
+ * 当使用 [ContinuousSessionProvider.push] 推送成功、
+ * 但是在 [ContinuousSessionReceiver.await] 过程中出现异常时（例如构造返回给 `push` 的结果时出现异常）
+ * 则此异常会使用 [SessionAwaitOnFailureException] 进行包装。
+ */
+public class SessionAwaitOnFailureException : IllegalStateException {
+    public constructor(message: String?) : super(message)
+    public constructor(message: String?, cause: Throwable?) : super(message, cause)
+    public constructor(cause: Throwable?) : super(cause)
+}

--- a/simbot-extensions/simbot-extension-continuous-session/src/commonTest/kotlin/ContinuousSessionTest.kt
+++ b/simbot-extensions/simbot-extension-continuous-session/src/commonTest/kotlin/ContinuousSessionTest.kt
@@ -1,0 +1,167 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.test.runTest
+import love.forte.simbot.extension.continuous.session.SessionAwaitOnFailureException
+import love.forte.simbot.extension.continuous.session.SessionPushOnFailureException
+import love.forte.simbot.extension.continuous.session.SimpleContinuousSessionContext
+import kotlin.test.*
+import kotlin.time.Duration.Companion.milliseconds
+
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+class ContinuousSessionTest {
+
+    @Test
+    fun sessionPushAndCompletedTest() = runTest {
+        val parentJob = Job()
+        coroutineScope {
+            val key = Any()
+            val context = SimpleContinuousSessionContext<Int, String>(Dispatchers.Default + parentJob)
+            val session = context.session(key) {
+                assertEquals(1, await { it.toString() }.also { println("await: $it") })
+                assertEquals(2, await { it.toString() }.also { println("await: $it") })
+                assertEquals(3, await { it.toString() }.also { println("await: $it") })
+                // done
+            }
+
+            assertEquals("1", session.push(1).also { println("push 1 result: $it") })
+            assertEquals("2", session.push(2).also { println("push 2 result: $it") })
+            assertEquals("3", session.push(3).also { println("push 3 result: $it") })
+
+            val ex = assertFails {
+                session.push(4).also { println("push 4 result: $it") }
+            }
+            ex.printStackTrace()
+            assertIs<SessionPushOnFailureException>(ex)
+            session.join()
+            assertTrue(session.isCompleted)
+            assertFalse(session.isCancelled)
+            // TODO error!
+            // assertNull(context[key])
+        }
+
+        assertTrue(parentJob.isActive)
+    }
+
+    @Test
+    fun sessionPushAndThrowTest() = runTest {
+        val parentJob = Job()
+        coroutineScope {
+            val key = Any()
+            val context = SimpleContinuousSessionContext<Int, String>(Dispatchers.Default + parentJob)
+            val session = context.session(key) {
+                assertEquals(1, await { it.toString() })// .also { println("await: $it") }
+                val ex = assertFails {
+                    await { throw IllegalStateException("error on $it") }// .also { println("await: $it") }
+                }
+
+                //println("await ex = $ex (@${ex.hashCode()})")
+                assertIs<IllegalStateException>(ex)
+                //println("Session done")
+            }
+
+            // launch {
+            assertEquals("1", session.push(1)) // .also { println("push 1 result: $it") }
+
+            val ex = assertFails {
+                session.push(2)//.also { println("push 2 result: $it") }
+            }
+            //println("push ex = $ex (@${ex.hashCode()})")
+            assertIs<SessionAwaitOnFailureException>(ex)
+            session.join()
+            assertTrue(session.isCompleted)
+            assertFalse(session.isCancelled)
+            // TODO error!
+            // assertNull(context[key])
+        }
+
+        assertTrue(parentJob.isActive)
+    }
+
+    @Test
+    fun sessionAwaitTimeoutTest() = runTest {
+        val parentJob = Job()
+        val context = SimpleContinuousSessionContext<Int, String>(Dispatchers.Default + parentJob)
+
+        coroutineScope {
+            val key = Any()
+            val session = context.session(key) {
+                val v1 = withContext(Dispatchers.Default) {
+                    withTimeoutOrNull(50.milliseconds) {
+                        await { it.toString() }
+                    }
+                }
+                assertNull(v1, "Expected timeout value to be null, but was: $v1")
+                assertEquals(1, await { it.toString() })
+            }
+
+            withContext(Dispatchers.Default) {
+                delay(100.milliseconds)
+            }
+
+            assertEquals("1", session.push(1))
+            session.join()
+            assertTrue(session.isCompleted)
+            assertFalse(session.isCancelled)
+            //println("before context: $context")
+            // Expected value to be null, but was: <love.forte.simbot.extension.continuous.session.SimpleSessionImpl@653702a0>.
+            // 但是加上 println 就好了
+            //println(context)
+            assertNull(context[key])
+
+            // val newSession = context.session(key, strategy = ContinuousSessionContext.ConflictStrategy.OLD) {}
+            // println("oldSession: $session")
+            // println("newSession: $newSession")
+            // assertNotEquals(session, newSession)
+        }
+        withContext(Dispatchers.Default) {
+        }
+
+        assertTrue(parentJob.isActive)
+    }
+
+
+}


### PR DESCRIPTION
```kotlin
val session = context.session(Key()) {
    val next = await { v -> v.toResult() } // 假设 toResult() 将事件转化为结果
}         ↑                      |
      |-- | ---------------------|
      |   |-----------|
      ↓               |
val result = session.push(value) // 此处得到 v.toResult() 的结果
```

```mermaid
sequenceDiagram

participant Provider
participant Session
participant Receiver

activate Provider
activate Receiver

Receiver ->> Session : await
deactivate Receiver

Provider ->> Session: push
deactivate Provider

Session -->> Receiver: await
activate Receiver

Receiver -->> Provider: resume(result)
activate Provider
Receiver ->> Receiver: 一些逻辑

Receiver ->> Session : await
deactivate Receiver

Provider ->> Session: push
deactivate Provider
Session -->> Receiver: await
activate Receiver

Receiver -->> Provider: resume(result)
activate Provider

Receiver ->> Receiver: 一些逻辑

Receiver -->> Session: Done.
deactivate Receiver
deactivate Provider
```

但持续会话扩展模块 **暂不发布** (截止到此pr时尚未配置发布)