### PR TITLE
将 suspend-transformer 模块的异步相关API和 `Collectable` 的异步相关API内所有的 `CoroutineScope` 参数默认值调整为 `GlobalScope` 并增加与之相关的部分警告或说明

### DIFF
--- a/.github/workflows/test-v4-branch.yml
+++ b/.github/workflows/test-v4-branch.yml
@@ -16,7 +16,6 @@ jobs:
         os: [ macos-latest, windows-latest, ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
-    
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
@@ -35,3 +34,10 @@ jobs:
             --info 
             --warning-mode all
 
+      - name: Upload test reports
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: TestReports
+          path: build/test-reports
+          retention-days: 7

--- a/.github/workflows/test-v4-branch.yml
+++ b/.github/workflows/test-v4-branch.yml
@@ -38,6 +38,6 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
-          name: TestReports
+          name: test-reports-${{ matrix.os }}
           path: build/test-reports
           retention-days: 7

--- a/simbot-commons/simbot-common-core/src/commonMain/kotlin/love/forte/simbot/common/coroutines/Dispatchers.kt
+++ b/simbot-commons/simbot-common-core/src/commonMain/kotlin/love/forte/simbot/common/coroutines/Dispatchers.kt
@@ -1,0 +1,34 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.common.coroutines
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * 在 JVM 和 native 平台下，得到 `Dispatchers.IO`;
+ * 在其他没有 `IO` 调度器的平台下得到 [Dispatchers.Default]。
+ *
+ */
+public expect val Dispatchers.IOOrDefault: CoroutineDispatcher

--- a/simbot-commons/simbot-common-core/src/jsMain/kotlin/love/forte/simbot/common/coroutines/Dispatchers.js.kt
+++ b/simbot-commons/simbot-common-core/src/jsMain/kotlin/love/forte/simbot/common/coroutines/Dispatchers.js.kt
@@ -1,0 +1,35 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.common.coroutines
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * 得到 [Dispatchers.Default]。
+ *
+ * @see Dispatchers.Default
+ */
+public actual inline val Dispatchers.IOOrDefault: CoroutineDispatcher
+    get() = Default

--- a/simbot-commons/simbot-common-core/src/jvmMain/kotlin/love/forte/simbot/common/coroutines/Dispatchers.jvm.kt
+++ b/simbot-commons/simbot-common-core/src/jvmMain/kotlin/love/forte/simbot/common/coroutines/Dispatchers.jvm.kt
@@ -1,0 +1,35 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.common.coroutines
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * 得到 [Dispatchers.IO]。
+ *
+ * @see Dispatchers.IO
+ */
+public actual inline val Dispatchers.IOOrDefault: CoroutineDispatcher
+    get() = IO

--- a/simbot-commons/simbot-common-core/src/nativeMain/kotlin/love/forte/simbot/common/coroutines/Dispatchers.native.kt
+++ b/simbot-commons/simbot-common-core/src/nativeMain/kotlin/love/forte/simbot/common/coroutines/Dispatchers.native.kt
@@ -1,0 +1,36 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.common.coroutines
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+
+/**
+ * 得到 [Dispatchers.IO]。
+ *
+ * @see Dispatchers.IO
+ */
+public actual inline val Dispatchers.IOOrDefault: CoroutineDispatcher
+    get() = IO

--- a/simbot-commons/simbot-common-core/src/wasmJsMain/kotlin/love/forte/simbot/common/coroutines/Dispatchers.wasmjs.kt
+++ b/simbot-commons/simbot-common-core/src/wasmJsMain/kotlin/love/forte/simbot/common/coroutines/Dispatchers.wasmjs.kt
@@ -1,0 +1,35 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.common.coroutines
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * 得到 [Dispatchers.Default]。
+ *
+ * @see Dispatchers.Default
+ */
+public actual inline val Dispatchers.IOOrDefault: CoroutineDispatcher
+    get() = Default

--- a/simbot-commons/simbot-common-suspend-runner/src/jvmMain/kotlin/love/forte/simbot/suspendrunner/reserve/SuspendReserves.jvm.kt
+++ b/simbot-commons/simbot-common-suspend-runner/src/jvmMain/kotlin/love/forte/simbot/suspendrunner/reserve/SuspendReserves.jvm.kt
@@ -4,7 +4,7 @@
  *     Project    https://github.com/simple-robot/simpler-robot
  *     Email      ForteScarlet@163.com
  *
- *     This file is part of the Simple Robot Library.
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Lesser General Public License as published by
@@ -33,6 +33,8 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.future.future
 import kotlinx.coroutines.reactor.flux
 import kotlinx.coroutines.reactor.mono
+import love.forte.simbot.annotations.InternalSimbotAPI
+import love.forte.simbot.suspendrunner.DefaultBlockingContext
 import love.forte.simbot.suspendrunner.runInNoScopeBlocking
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -56,11 +58,12 @@ public fun <T> block(): SuspendReserve.Transformer<T, T> =
     BlockingTransformer as SuspendReserve.Transformer<T, T>
 
 private object BlockingTransformer : SuspendReserve.Transformer<Any?, Any?> {
+    @OptIn(InternalSimbotAPI::class)
     override fun <T1> invoke(
         scope: CoroutineScope,
         context: CoroutineContext,
         block: suspend () -> T1
-    ): Any? = runInNoScopeBlocking { block() }
+    ): Any? = runInNoScopeBlocking(DefaultBlockingContext + context) { block() }
 }
 
 /**

--- a/simbot-commons/simbot-common-suspend-runner/src/jvmTest/java/JavaBlockingRunTest.java
+++ b/simbot-commons/simbot-common-suspend-runner/src/jvmTest/java/JavaBlockingRunTest.java
@@ -57,6 +57,11 @@ public class JavaBlockingRunTest {
         Assertions.assertTrue((now - startNano) > TimeUnit.MILLISECONDS.toNanos(100));
     }
 
+    private void checkDuration(long startNano, long expectDurationNano) {
+        final var now = System.nanoTime();
+        Assertions.assertTrue((now - startNano) > expectDurationNano);
+    }
+
     @Test
     public void blockingRun() {
         final var start = System.nanoTime();
@@ -82,11 +87,12 @@ public class JavaBlockingRunTest {
         final var start = System.nanoTime();
         final var foo = new SuspendFoo();
         final var nameMono = foo.runReserve(EXPECT_NAME).transform(SuspendReserves.mono());
-        final var name = nameMono.block(Duration.ofMillis(150L));
+        final var duration = Duration.ofSeconds(5);
+        final var name = nameMono.block(duration);
         // .subscribeOn(parallelScheduler)
 
         Assertions.assertEquals(name, EXPECT_NAME);
-        checkDuration(start);
+        checkDuration(start, duration.toNanos());
     }
 
     @Test

--- a/simbot-commons/simbot-common-suspend-runner/src/jvmTest/java/JavaBlockingRunTest.java
+++ b/simbot-commons/simbot-common-suspend-runner/src/jvmTest/java/JavaBlockingRunTest.java
@@ -23,98 +23,73 @@
 
 import love.forte.simbot.suspendrunner.SuspendFoo;
 import love.forte.simbot.suspendrunner.reserve.SuspendReserves;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import reactor.core.scheduler.Scheduler;
-import reactor.core.scheduler.Schedulers;
 
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 
 /**
  * @author ForteScarlet
  */
 public class JavaBlockingRunTest {
 
-    private static Scheduler parallelScheduler;
-
-    @BeforeAll
-    public static void initScheduler() {
-        parallelScheduler = Schedulers.newParallel("parallel", 4);
-    }
-
-    @AfterAll
-    public static void disposeScheduler() {
-        parallelScheduler.dispose();
-    }
+//    private static Scheduler parallelScheduler;
+//
+//    @BeforeAll
+//    public static void initScheduler() {
+//        parallelScheduler = Schedulers.newParallel("parallel", 4);
+//    }
+//
+//    @AfterAll
+//    public static void disposeScheduler() {
+//        parallelScheduler.dispose();
+//    }
 
     private static final String EXPECT_NAME = "forte";
 
-    private void checkDuration(long startNano) {
-        final var now = System.nanoTime();
-        Assertions.assertTrue((now - startNano) > TimeUnit.MILLISECONDS.toNanos(100));
-    }
-
-    private void checkDuration(long startNano, long expectDurationNano) {
-        final var now = System.nanoTime();
-        Assertions.assertTrue((now - startNano) > expectDurationNano);
-    }
 
     @Test
     public void blockingRun() {
-        final var start = System.nanoTime();
         final var foo = new SuspendFoo();
         final var name = foo.runReserve(EXPECT_NAME).transform(SuspendReserves.block());
         Assertions.assertEquals(name, EXPECT_NAME);
-        checkDuration(start);
     }
 
     @Test
     public void asyncRun() {
-        final var start = System.nanoTime();
         final var foo = new SuspendFoo();
         final var nameFuture = foo.runReserve(EXPECT_NAME).transform(SuspendReserves.async());
         final var name = nameFuture.join();
 
         Assertions.assertEquals(name, EXPECT_NAME);
-        checkDuration(start);
     }
 
     @Test
     public void monoRun() {
-        final var start = System.nanoTime();
         final var foo = new SuspendFoo();
         final var nameMono = foo.runReserve(EXPECT_NAME).transform(SuspendReserves.mono());
         final var duration = Duration.ofSeconds(5);
         final var name = nameMono.block(duration);
-        // .subscribeOn(parallelScheduler)
 
         Assertions.assertEquals(name, EXPECT_NAME);
-        checkDuration(start, duration.toNanos());
     }
 
     @Test
     public void rx2Run() {
-        final var start = System.nanoTime();
         final var foo = new SuspendFoo();
         final var nameMaybe = foo.runReserve(EXPECT_NAME).transform(SuspendReserves.rx2Maybe());
         final var name = nameMaybe.blockingGet();
 
         Assertions.assertEquals(name, EXPECT_NAME);
-        checkDuration(start);
     }
 
     @Test
     public void rx3Run() {
-        final var start = System.nanoTime();
         final var foo = new SuspendFoo();
         final var nameMaybe = foo.runReserve(EXPECT_NAME).transform(SuspendReserves.rx3Maybe());
         final var name = nameMaybe.blockingGet();
 
         Assertions.assertEquals(name, EXPECT_NAME);
-        checkDuration(start);
     }
 
 }

--- a/simbot-commons/simbot-common-suspend-runner/src/jvmTest/java/JavaBlockingRunTest.java
+++ b/simbot-commons/simbot-common-suspend-runner/src/jvmTest/java/JavaBlockingRunTest.java
@@ -4,7 +4,7 @@
  *     Project    https://github.com/simple-robot/simpler-robot
  *     Email      ForteScarlet@163.com
  *
- *     This file is part of the Simple Robot Library.
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Lesser General Public License as published by
@@ -23,8 +23,12 @@
 
 import love.forte.simbot.suspendrunner.SuspendFoo;
 import love.forte.simbot.suspendrunner.reserve.SuspendReserves;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -33,6 +37,18 @@ import java.util.concurrent.TimeUnit;
  * @author ForteScarlet
  */
 public class JavaBlockingRunTest {
+
+    private static Scheduler parallelScheduler;
+
+    @BeforeAll
+    public static void initScheduler() {
+        parallelScheduler = Schedulers.newParallel("parallel", 4);
+    }
+
+    @AfterAll
+    public static void disposeScheduler() {
+        parallelScheduler.dispose();
+    }
 
     private static final String EXPECT_NAME = "forte";
 
@@ -67,6 +83,7 @@ public class JavaBlockingRunTest {
         final var foo = new SuspendFoo();
         final var nameMono = foo.runReserve(EXPECT_NAME).transform(SuspendReserves.mono());
         final var name = nameMono.block(Duration.ofMillis(150L));
+        // .subscribeOn(parallelScheduler)
 
         Assertions.assertEquals(name, EXPECT_NAME);
         checkDuration(start);

--- a/simbot-commons/simbot-common-suspend-runner/src/jvmTest/kotlin/love/forte/simbot/suspendrunner/SuspendFoo.kt
+++ b/simbot-commons/simbot-common-suspend-runner/src/jvmTest/kotlin/love/forte/simbot/suspendrunner/SuspendFoo.kt
@@ -4,7 +4,7 @@
  *     Project    https://github.com/simple-robot/simpler-robot
  *     Email      ForteScarlet@163.com
  *
- *     This file is part of the Simple Robot Library.
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Lesser General Public License as published by
@@ -45,7 +45,9 @@ package love.forte.simbot.suspendrunner/*
  */
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import love.forte.simbot.annotations.InternalSimbotAPI
 import love.forte.simbot.suspendrunner.reserve.suspendReserve
 import kotlin.coroutines.CoroutineContext
@@ -60,7 +62,9 @@ class SuspendFoo : CoroutineScope {
 
     @JvmSynthetic
     suspend fun run(name: String): String {
-        delay(100)
+        withContext(Dispatchers.IO) {
+            delay(100)
+        }
         return name
     }
 


### PR DESCRIPTION
在 Java 用户无法得知作用域的情况下，内部构建的隐藏作用域和 `GlobalScope` 相比，可能不如直接使用 `GlobalScope`。