### PR TITLE
增加一个基于 Spring Boot v2.7.x 的兼容版本 starter 实现模块

### DIFF
--- a/buildSrc/src/main/kotlin/JvmConfig.kt
+++ b/buildSrc/src/main/kotlin/JvmConfig.kt
@@ -95,10 +95,12 @@ inline fun Project.configJavaCompileWithModule(
 
         // see https://kotlinlang.org/docs/gradle-configure-project.html#configure-with-java-modules-jpms-enabled
         if (moduleName != null) {
-            options.compilerArgumentProviders.add(CommandLineArgumentProvider {
-                // Provide compiled Kotlin classes to javac – needed for Java/Kotlin mixed sources to work
-                listOf("--patch-module", "$moduleName=${sourceSets["main"].output.asPath}")
-            })
+            options.compilerArgumentProviders.add(
+                CommandLineArgumentProvider {
+                    // Provide compiled Kotlin classes to javac – needed for Java/Kotlin mixed sources to work
+                    listOf("--patch-module", "$moduleName=${sourceSets["main"].output.asPath}")
+                }
+            )
         }
 
         block()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,6 +65,7 @@ javax-inject = "javax.inject:javax.inject:1"
 javax-annotation-api = "javax.annotation:javax.annotation-api:1.3.2"
 
 # spring-boot-v2
+spring-boot-v2-dependencies = { group = "org.springframework.boot", name = "spring-boot-dependencies", version.ref = "spring-boot-v2" }
 spring-boot-v2-autoconfigure = { group = "org.springframework.boot", name = "spring-boot-autoconfigure", version.ref = "spring-boot-v2" }
 spring-boot-v2-logging = { group = "org.springframework.boot", name = "spring-boot-starter-logging", version.ref = "spring-boot-v2" }
 spring-boot-v2-actuator = { group = "org.springframework.boot", name = "spring-boot-starter-actuator", version.ref = "spring-boot-v2" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -62,7 +62,7 @@ include(":simbot-quantcat:simbot-quantcat-common")
 
 include(":simbot-cores:simbot-core-spring-boot-starter-common")
 include(":simbot-cores:simbot-core-spring-boot-starter") // v3
-//include(":simbot-cores:simbot-core-spring-boot-v2-starter")
+include(":simbot-cores:simbot-core-spring-boot-starter-v2")
 
 // extensions
 include(":simbot-extensions:simbot-extension-continuous-session")

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/README.md
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/README.md
@@ -1,0 +1,6 @@
+# Spring Boot starter 的 Spring Boot v2.7 兼容版本。 
+
+> [!warning]
+> Spring Boot starter 的 v2 版本的维护成本较高，不会持续维护很久。
+> 并且现在 Spring Boot v2.7.x已经在 2023-11-24 结束支持，请考虑迁移至 Spring Boot v3.x。
+ 

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/build.gradle.kts
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/build.gradle.kts
@@ -1,4 +1,29 @@
 /*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+import love.forte.gradle.common.core.project.setup
+
+/*
  *     Copyright (c) 2021-2024. ForteScarlet.
  *
  *     Project    https://github.com/simple-robot/simpler-robot
@@ -22,28 +47,30 @@
  */
 
 plugins {
-    // id("simbot.boot-module-conventions")
-    // `simbot-jvm-maven-publish`
     kotlin("jvm")
     kotlin("plugin.serialization")
     kotlin("kapt")
+    id("simbot.dokka-module-configuration")
 }
 
-configJavaCompileWithModule("simbot.core.springboot.common")
+setup(P.Simbot)
+configJavaCompileWithModule("simbot.spring2boot.starter")
 
 kotlin {
     explicitApi()
     configKotlinJvm(JVMConstants.KT_JVM_TARGET_VALUE)
 }
 
+@Suppress("VulnerableLibrariesLocal")
 dependencies {
     compileOnly(project(":simbot-commons:simbot-common-annotations"))
     api(project(":simbot-quantcat:simbot-quantcat-common"))
     api(project(":simbot-cores:simbot-core"))
     api(project(":simbot-cores:simbot-core-spring-boot-starter-common"))
+    api(kotlin("reflect"))
+    api(libs.kotlinx.serialization.json)
 
     compileOnly(libs.spring.boot.v2.logging)
-
     compileOnly(libs.spring.boot.v2.autoconfigure)
     compileOnly(libs.spring.boot.v2.configuration.processor)
     annotationProcessor(libs.spring.boot.v2.configuration.processor)
@@ -51,12 +78,17 @@ dependencies {
 
     compileOnly(libs.javax.annotation.api)
 
+    testImplementation(kotlin("test"))
+    testImplementation(project(":simbot-commons:simbot-common-annotations"))
+    testImplementation(project(":simbot-test"))
     testImplementation(libs.spring.boot.v2.test)
-    testImplementation(libs.kotlinx.serialization.json)
-    testImplementation(libs.kotlinx.serialization.properties)
-    testImplementation(libs.kotlinx.serialization.protobuf)
     testImplementation(libs.spring.boot.v2.aop)
     testImplementation(libs.spring.boot.v2.autoconfigure)
     testImplementation(libs.spring.boot.v2.configuration.processor)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.spring.boot.v2.logging)
 }
 
+tasks.test {
+    useJUnitPlatform()
+}

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/java/module-info.java
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/java/module-info.java
@@ -1,0 +1,28 @@
+module simbot.spring2boot.starter {
+    // Kotlin
+    requires kotlin.stdlib;
+    requires kotlin.reflect;
+    requires kotlinx.coroutines.core;
+    requires kotlinx.serialization.json;
+    // spring
+    requires spring.core;
+    requires spring.context;
+    requires spring.boot;
+    requires spring.boot.autoconfigure;
+    requires spring.beans;
+    requires spring.aop;
+    // simbot
+    requires transitive simbot.logger;
+    requires simbot.spring.common;
+    requires simbot.common.core;
+    requires static simbot.common.annotations;
+
+    exports love.forte.simbot.spring2;
+    exports love.forte.simbot.spring2.application;
+    exports love.forte.simbot.spring2.configuration;
+    exports love.forte.simbot.spring2.configuration.application;
+    exports love.forte.simbot.spring2.configuration.binder;
+    exports love.forte.simbot.spring2.configuration.config;
+    exports love.forte.simbot.spring2.configuration.listener;
+    exports love.forte.simbot.spring2.warn;
+}

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/EnableSimbot.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/EnableSimbot.kt
@@ -1,0 +1,104 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2
+
+import love.forte.simbot.spring2.configuration.*
+import love.forte.simbot.spring2.configuration.application.*
+import love.forte.simbot.spring2.configuration.binder.DefaultBinderManagerProvidersConfiguration
+import love.forte.simbot.spring2.configuration.binder.ResolveBinderManagerProcessor
+import love.forte.simbot.spring2.configuration.config.DefaultSimbotApplicationConfigurationProcessorConfiguration
+import love.forte.simbot.spring2.configuration.listener.SimbotEventListenerFunctionProcessor
+import love.forte.simbot.spring2.warn.MigratingSpringBootVersion
+import love.forte.simbot.spring2.warn.MigratingSpringBootVersionWarningPrinter
+import org.springframework.context.annotation.Import
+
+/**
+ * 启用 simbot 的各项配置。
+ *
+ * 将其标记在你的启动类或某个配置类上。
+ *
+ * Kotlin
+ *
+ * ```kotlin
+ * @EnableSimbot
+ * @SpringBootApplication
+ * open class MyApplication {
+ *  // ...
+ * }
+ * ```
+ *
+ * ```kotlin
+ * @EnableSimbot
+ * @Configuration
+ * open class MyConfig {
+ *  // ...
+ * }
+ * ```
+ *
+ * Java
+ *
+ * ```java
+ * @EnableSimbot
+ * @SpringBootApplication
+ * public class MyApplication {
+ *  // ...
+ * }
+ * ```
+ *
+ * ```java
+ * @EnableSimbot
+ * @Configuration
+ * public class MyConfig {
+ *  // ...
+ * }
+ * ```
+ *
+ */
+@Target(AnnotationTarget.CLASS)
+@Import(
+    MigratingSpringBootVersionWarningPrinter::class,
+    SimbotSpringPropertiesConfiguration::class,
+    // defaults
+    DefaultSimbotApplicationConfigurationProcessorConfiguration::class,
+    DefaultSimbotDispatcherProcessorConfiguration::class,
+    DefaultSimbotComponentInstallProcessorConfiguration::class,
+    DefaultSimbotPluginInstallProcessorConfiguration::class,
+    DefaultSimbotEventDispatcherProcessorConfiguration::class,
+    DefaultBinderManagerProvidersConfiguration::class,
+    // listeners directly
+    DefaultSimbotEventListenerRegistrarProcessorConfiguration::class,
+    // launcher factory & launcher
+    DefaultSimbotSpringApplicationLauncherFactoryConfiguration::class,
+    DefaultSimbotApplicationLauncherFactoryProcessorConfiguration::class,
+    SimbotApplicationConfiguration::class,
+    // app
+    DefaultSimbotSpringApplicationProcessorConfiguration::class,
+    // binders
+    ResolveBinderManagerProcessor::class,
+    // post listeners
+    SimbotEventListenerFunctionProcessor::class,
+    SimbotApplicationRunner::class
+)
+@MigratingSpringBootVersion
+public annotation class EnableSimbot

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/application/SpringApplication.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/application/SpringApplication.kt
@@ -1,0 +1,191 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.application
+
+import kotlinx.coroutines.Job
+import love.forte.simbot.annotations.ExperimentalSimbotAPI
+import love.forte.simbot.annotations.InternalSimbotAPI
+import love.forte.simbot.application.*
+import love.forte.simbot.bot.BotManager
+import love.forte.simbot.bot.toBotManagers
+import love.forte.simbot.common.function.ConfigurerFunction
+import love.forte.simbot.common.function.invokeBy
+import love.forte.simbot.common.function.invokeWith
+import love.forte.simbot.component.*
+import love.forte.simbot.core.event.createSimpleEventDispatcherImpl
+import love.forte.simbot.core.event.impl.SimpleEventDispatcherConfigurationImpl
+import love.forte.simbot.event.EventDispatcher
+import love.forte.simbot.plugin.Plugin
+import love.forte.simbot.plugin.PluginConfigureContext
+import love.forte.simbot.plugin.PluginFactoriesConfigurator
+import love.forte.simbot.plugin.toPlugins
+import love.forte.simbot.spring.common.application.*
+import love.forte.simbot.spring2.application.internal.SpringApplicationImpl
+import love.forte.simbot.spring2.application.internal.SpringEventDispatcherConfigurationImpl
+
+/**
+ * Factory for [SpringApplication].
+ */
+public object Spring : SpringApplicationFactory {
+    override fun create(
+        configurer: ConfigurerFunction<
+            ApplicationFactoryConfigurer<
+                SpringApplicationBuilder,
+                SpringApplicationEventRegistrar,
+                SpringEventDispatcherConfiguration
+                >
+            >?
+    ): SpringApplicationLauncher {
+        return SpringApplicationLauncherImpl { create0(configurer) }
+    }
+
+    @OptIn(ExperimentalSimbotAPI::class)
+    private fun create0(
+        configurer: ConfigurerFunction<
+            ApplicationFactoryConfigurer<
+                SpringApplicationBuilder,
+                SpringApplicationEventRegistrar,
+                SpringEventDispatcherConfiguration
+                >
+            >?
+    ): SpringApplicationImpl {
+        val springConfigurer = SpringApplicationFactoryConfigurer().invokeBy(configurer)
+        val configuration = springConfigurer.createConfigInternal(SpringApplicationBuilder())
+
+        val registrar = object : AbstractApplicationEventRegistrar(), SpringApplicationEventRegistrar {
+            public override val events: MutableMap<ApplicationLaunchStage<*>, MutableList<ApplicationEventHandler>>
+                get() = super.events
+        }
+
+        // 事件调度器
+        val dispatcherConfiguration = SpringEventDispatcherConfigurationImpl(SimpleEventDispatcherConfigurationImpl())
+        springConfigurer.eventDispatcherConfigurers.forEach(dispatcherConfiguration::invokeBy)
+
+        // 合并 Application coroutineContext into dispatcher coroutineContext, 且不要Job
+        val minJobDispatcherContext = dispatcherConfiguration.coroutineContext.minusKey(Job)
+        val minJobApplicationContext = configuration.coroutineContext.minusKey(Job)
+        dispatcherConfiguration.coroutineContext = minJobApplicationContext + minJobDispatcherContext
+
+        val dispatcher = createSimpleEventDispatcherImpl(dispatcherConfiguration.simple)
+
+        // 事件注册器
+        springConfigurer.applicationEventRegistrarConfigurations.forEach { c ->
+            c.invokeWith(registrar)
+        }
+
+        // components
+        val components = springConfigurer.componentFactoriesConfigurator.createAll(object : ComponentConfigureContext {
+            override val applicationConfiguration: ApplicationConfiguration
+                get() = configuration
+
+            override val applicationEventRegistrar: ApplicationEventRegistrar
+                get() = registrar
+        }).toComponents()
+
+        // plugins
+        val pluginCollections = springConfigurer.pluginFactoriesConfigurator.createAll(object : PluginConfigureContext {
+            override val applicationConfiguration: ApplicationConfiguration
+                get() = configuration
+
+            override val applicationEventRegistrar: ApplicationEventRegistrar
+                get() = registrar
+
+            override val components: Components
+                get() = components
+
+            override val eventDispatcher: EventDispatcher
+                get() = dispatcher
+        })
+
+
+        val plugins = pluginCollections.toPlugins()
+        val botManagers = pluginCollections.filterIsInstance<BotManager>().toBotManagers()
+
+        val events = applicationLaunchStages(registrar.events.mapValues { it.value.toList() })
+
+        return SpringApplicationImpl(
+            configuration,
+            dispatcher,
+            components,
+            plugins,
+            botManagers,
+            events
+        )
+    }
+}
+
+private class SpringApplicationLauncherImpl(
+    private val applicationCreator: () -> SpringApplicationImpl
+) : SpringApplicationLauncher {
+    override suspend fun launch(): SpringApplication {
+        val application = applicationCreator()
+
+        application.events.invokeOnEach(ApplicationLaunchStage.Launch) {
+            invoke(application)
+        }
+
+        return application
+    }
+}
+
+
+private class SpringApplicationFactoryConfigurer(
+    public override val configConfigurers: MutableList<ConfigurerFunction<SpringApplicationBuilder>> = mutableListOf(),
+
+    public override val applicationEventRegistrarConfigurations:
+    MutableList<ConfigurerFunction<SpringApplicationEventRegistrar>> = mutableListOf(),
+
+    public override val eventDispatcherConfigurers:
+    MutableList<ConfigurerFunction<SpringEventDispatcherConfiguration>> = mutableListOf(),
+
+    public override val componentFactoriesConfigurator:
+    ComponentFactoriesConfigurator = ComponentFactoriesConfigurator(),
+    public override val pluginFactoriesConfigurator: PluginFactoriesConfigurator = PluginFactoriesConfigurator(),
+) : AbstractApplicationFactoryConfigurer<
+    SpringApplicationBuilder,
+    SpringApplicationEventRegistrar,
+    SpringEventDispatcherConfiguration
+    >(
+    configConfigurers,
+    applicationEventRegistrarConfigurations,
+    eventDispatcherConfigurers,
+    componentFactoriesConfigurator,
+    pluginFactoriesConfigurator
+) {
+    @OptIn(InternalSimbotAPI::class)
+    fun createConfigInternal(configBuilder: SpringApplicationBuilder): SpringApplicationConfiguration {
+        return createConfig(configBuilder) {
+            it.build()
+        }
+    }
+
+    public override fun createAllComponents(context: ComponentConfigureContext): List<Component> {
+        return super.createAllComponents(context)
+    }
+
+    public override fun createAllPlugins(context: PluginConfigureContext): List<Plugin> {
+        return super.createAllPlugins(context)
+    }
+}
+

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/application/internal/SpringApplicationImpl.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/application/internal/SpringApplicationImpl.kt
@@ -1,0 +1,110 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.application.internal
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import love.forte.simbot.ability.OnCompletion
+import love.forte.simbot.application.ApplicationConfiguration
+import love.forte.simbot.application.ApplicationLaunchStage
+import love.forte.simbot.application.ApplicationLaunchStages
+import love.forte.simbot.application.NormalApplicationEventHandler
+import love.forte.simbot.bot.BotManagers
+import love.forte.simbot.component.Components
+import love.forte.simbot.event.EventDispatcher
+import love.forte.simbot.plugin.Plugins
+import love.forte.simbot.spring.common.application.SpringApplication
+import kotlin.coroutines.CoroutineContext
+
+
+/**
+ * @author ForteScarlet
+ */
+internal class SpringApplicationImpl(
+    override val configuration: ApplicationConfiguration,
+    override val eventDispatcher: EventDispatcher,
+    override val components: Components,
+    override val plugins: Plugins,
+    override val botManagers: BotManagers,
+    val events: ApplicationLaunchStages
+) : SpringApplication {
+    private val job: Job
+    override val coroutineContext: CoroutineContext
+
+    init {
+        val newJob = SupervisorJob(configuration.coroutineContext[Job])
+        val newCoroutineContext = configuration.coroutineContext.minusKey(Job) + newJob
+
+        this.job = newJob
+        this.coroutineContext = newCoroutineContext
+    }
+
+    private inline fun <C : Any, reified H : NormalApplicationEventHandler<C>> invokeNormalHandler(
+        stage: ApplicationLaunchStage<H>, block: H.() -> Unit
+    ) {
+        events[stage]?.forEach { handler ->
+            (handler as? H)?.also { handler0 ->
+                block(handler0)
+            }
+        }
+    }
+
+    override fun onCompletion(handle: OnCompletion) {
+        job.invokeOnCompletion { handle.invoke(it) }
+    }
+
+    override val isActive: Boolean
+        get() = job.isActive
+
+    override val isCompleted: Boolean
+        get() = job.isCompleted
+
+    override fun cancel(reason: Throwable?) {
+        invokeNormalHandler(ApplicationLaunchStage.RequestCancel) {
+            invoke(this@SpringApplicationImpl)
+        }
+
+        job.cancel(reason?.let { CancellationException(reason.message, it) })
+
+        invokeNormalHandler(ApplicationLaunchStage.Cancelled) {
+            invoke(this@SpringApplicationImpl)
+        }
+    }
+
+    override suspend fun join() {
+        job.join()
+    }
+
+    override fun toString(): String {
+        return "SpringApplication(" +
+            "isActive=$isActive, " +
+            "isCompleted=$isCompleted, " +
+            "eventDispatcher=$eventDispatcher, " +
+            "components=$components, " +
+            "plugins=$plugins)"
+    }
+
+
+}

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/application/internal/SpringEventDispatcherConfigurationImpl.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/application/internal/SpringEventDispatcherConfigurationImpl.kt
@@ -1,0 +1,51 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.application.internal
+
+import love.forte.simbot.common.function.ConfigurerFunction
+import love.forte.simbot.core.event.impl.SimpleEventDispatcherConfigurationImpl
+import love.forte.simbot.event.*
+import love.forte.simbot.spring.common.application.SpringEventDispatcherConfiguration
+import kotlin.coroutines.CoroutineContext
+
+internal typealias EventInterceptorConfigPair =
+    Pair<EventInterceptor, ConfigurerFunction<EventInterceptorRegistrationProperties>?>
+
+internal typealias EventDispatchInterceptorConfigPair =
+    Pair<EventDispatchInterceptor, ConfigurerFunction<EventDispatchInterceptorRegistrationProperties>?>
+
+/**
+ *
+ * @author ForteScarlet
+ */
+internal class SpringEventDispatcherConfigurationImpl(
+    internal val simple: SimpleEventDispatcherConfigurationImpl
+) : AbstractEventDispatcherConfiguration(),
+    SpringEventDispatcherConfiguration {
+    override var coroutineContext: CoroutineContext by simple::coroutineContext
+    public override val interceptors:
+        MutableList<EventInterceptorConfigPair> by simple::interceptors
+    public override val dispatchInterceptors:
+        MutableList<EventDispatchInterceptorConfigPair> by simple::dispatchInterceptors
+}

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/DefaultSimbotEventDispatcherProcessor.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/DefaultSimbotEventDispatcherProcessor.kt
@@ -1,0 +1,79 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.configuration
+
+import love.forte.simbot.event.EventDispatcher
+import love.forte.simbot.logger.LoggerFactory
+import love.forte.simbot.logger.logger
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * 配置 [SimbotEventDispatcherProcessor] 的默认实现
+ * [DefaultSimbotEventDispatcherProcessor]
+ * 的配置类。
+ *
+ */
+@Configuration(proxyBeanMethods = false)
+public open class DefaultSimbotEventDispatcherProcessorConfiguration {
+    @Bean(DEFAULT_SIMBOT_EVENT_DISPATCHER_PROCESSOR_BEAN_NAME)
+    @ConditionalOnMissingBean(SimbotEventDispatcherProcessor::class)
+    public open fun defaultSimbotEventDispatcherProcessor(
+        registerProcessor: SimbotEventListenerRegistrarProcessor,
+        @Autowired(required = false) postConfigurers: List<SimbotEventDispatcherPostConfigurer>? = null
+    ): DefaultSimbotEventDispatcherProcessor = DefaultSimbotEventDispatcherProcessor(
+        registerProcessor,
+        postConfigurers ?: emptyList()
+    )
+
+    public companion object {
+        public const val DEFAULT_SIMBOT_EVENT_DISPATCHER_PROCESSOR_BEAN_NAME: String =
+            "love.forte.simbot.spring.configuration.defaultSimbotEventDispatcherProcessor"
+    }
+}
+
+/**
+ * [SimbotEventDispatcherProcessor] 的默认行为实现。
+ * @author ForteScarlet
+ */
+public open class DefaultSimbotEventDispatcherProcessor(
+    private val registerProcessor: SimbotEventListenerRegistrarProcessor,
+    private val postConfigurers: List<SimbotEventDispatcherPostConfigurer>
+) : SimbotEventDispatcherProcessor {
+    override fun process(dispatcher: EventDispatcher) {
+        registerProcessor.process(dispatcher)
+        logger.debug("Processed dispatcher {} by processor {}", dispatcher, registerProcessor)
+
+        postConfigurers.forEach {
+            it.configure(dispatcher)
+            logger.debug("Configured dispatcher {} by {}", dispatcher, it)
+        }
+    }
+
+    public companion object {
+        private val logger = LoggerFactory.logger<DefaultSimbotDispatcherProcessor>()
+    }
+}

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/DefaultSimbotEventListenerRegistrarProcessor.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/DefaultSimbotEventListenerRegistrarProcessor.kt
@@ -1,0 +1,83 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.configuration
+
+import love.forte.simbot.event.EventListener
+import love.forte.simbot.event.EventListenerRegistrar
+import love.forte.simbot.logger.LoggerFactory
+import love.forte.simbot.logger.logger
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+
+/**
+ * 配置 [SimbotEventListenerRegistrarProcessor]
+ * 的默认行为实现类型 [DefaultSimbotEventListenerRegistrarProcessor]
+ * 的配置类。
+ */
+@Configuration(proxyBeanMethods = false)
+public open class DefaultSimbotEventListenerRegistrarProcessorConfiguration {
+    @Bean(DEFAULT_SIMBOT_EVENT_LISTENER_REGISTRAR_PROCESSOR_BEAN_NAME)
+    @ConditionalOnMissingBean(SimbotEventListenerRegistrarProcessor::class)
+    public open fun defaultSimbotEventListenerRegistrarProcessor(
+        @Autowired(required = false) listenerInstances: List<EventListener>? = null,
+        @Autowired(required = false) postConfigurers: List<SimbotEventListenerRegistrarPostConfigurer>? = null,
+    ): DefaultSimbotEventListenerRegistrarProcessor =
+        DefaultSimbotEventListenerRegistrarProcessor(
+            listenerInstances = listenerInstances ?: emptyList(),
+            postConfigurers ?: emptyList()
+        )
+
+    public companion object {
+        public const val DEFAULT_SIMBOT_EVENT_LISTENER_REGISTRAR_PROCESSOR_BEAN_NAME: String =
+            "love.forte.simbot.spring.configuration.defaultSimbotEventListenerRegistrarProcessor"
+    }
+}
+
+/**
+ * [SimbotEventListenerRegistrarProcessor] 的默认行为实现类
+ * @author ForteScarlet
+ */
+public open class DefaultSimbotEventListenerRegistrarProcessor(
+    private val listenerInstances: List<EventListener>,
+    private val postConfigurers: List<SimbotEventListenerRegistrarPostConfigurer>,
+) : SimbotEventListenerRegistrarProcessor {
+    override fun process(registrar: EventListenerRegistrar) {
+        listenerInstances.forEach {
+            registrar.register(it)
+            logger.debug("Registered event listener {}", it)
+        }
+
+        postConfigurers.forEach {
+            it.configure(registrar)
+            logger.debug("Configured event registrar by {}", it)
+        }
+    }
+
+    public companion object {
+        private val logger = LoggerFactory.logger<DefaultSimbotEventListenerRegistrarProcessor>()
+    }
+}

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/SimbotComponentInstallProcessor.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/SimbotComponentInstallProcessor.kt
@@ -1,0 +1,132 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.configuration
+
+import love.forte.simbot.component.ComponentFactory
+import love.forte.simbot.component.ComponentInstaller
+import love.forte.simbot.component.findAndInstallAllComponents
+import love.forte.simbot.logger.LoggerFactory
+import love.forte.simbot.spring.common.application.SpringApplicationConfigurationProperties
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+
+/**
+ * 在 starter 中通过 [ComponentInstaller] 安装组件信息。
+ * 只能存在一个，默认情况下会尝试加载当前所有的
+ * [ComponentFactory] （无配置注册）、可通过 SPI 自动加载的以及 [SimbotComponentInstaller] 并进行处理。
+ *
+ * 注册自定义的 [SimbotComponentInstallProcessor] 可覆盖默认行为。
+ *
+ * @author ForteScarlet
+ */
+public interface SimbotComponentInstallProcessor {
+    /**
+     * 处理 [installer].
+     */
+    public fun process(installer: ComponentInstaller)
+
+}
+
+/**
+ * 在 starter 中的 [SimbotComponentInstallProcessor] 默认实现
+ * [DefaultSimbotComponentInstallProcessor] 行为里对 [ComponentInstaller]
+ * 进行自定义处理的可扩展类型。
+ * 可以注册多个。
+ *
+ * @see SimbotComponentInstallProcessor
+ * @see DefaultSimbotComponentInstallProcessor
+ *
+ */
+public interface SimbotComponentInstaller {
+    public fun install(installer: ComponentInstaller)
+}
+
+/**
+ * 配置 [SimbotComponentInstallProcessor] 默认行为实现的配置类。
+ *
+ */
+@Configuration(proxyBeanMethods = false)
+public open class DefaultSimbotComponentInstallProcessorConfiguration {
+    @Bean(DEFAULT_SIMBOT_COMPONENT_INSTALL_PROCESSOR_BEAN_NAME)
+    @ConditionalOnMissingBean(SimbotComponentInstallProcessor::class)
+    public open fun defaultSimbotComponentInstallProcessor(
+        properties: SpringApplicationConfigurationProperties,
+        @Autowired(required = false) factories: List<ComponentFactory<*, *>>? = null,
+        @Autowired(required = false) installers: List<SimbotComponentInstaller>? = null,
+    ): DefaultSimbotComponentInstallProcessor {
+        return DefaultSimbotComponentInstallProcessor(
+            properties.components.autoInstallProviders,
+            properties.components.autoInstallProviderConfigures,
+            factories ?: emptyList(),
+            installers ?: emptyList()
+        )
+    }
+
+    public companion object {
+        public const val DEFAULT_SIMBOT_COMPONENT_INSTALL_PROCESSOR_BEAN_NAME: String =
+            "love.forte.simbot.spring.configuration.defaultSimbotComponentInstallProcessor"
+    }
+}
+
+/**
+ * [SimbotComponentInstallProcessor] 的默认行为实现
+ */
+public class DefaultSimbotComponentInstallProcessor(
+    private val autoInstallProviders: Boolean,
+    private val autoInstallProviderConfigures: Boolean,
+    private val factories: List<ComponentFactory<*, *>>,
+    private val installers: List<SimbotComponentInstaller>,
+) : SimbotComponentInstallProcessor {
+    override fun process(installer: ComponentInstaller) {
+        if (autoInstallProviders) {
+            installer.findAndInstallAllComponents(autoInstallProviderConfigures)
+            logger.debug(
+                "Automatically install all component providers automatically with autoLoadProviderConfigures={}",
+                autoInstallProviderConfigures
+            )
+        } else {
+            logger.debug("Automatic installation from component providers was disabled")
+            // 自动的
+        }
+
+        // factories
+        factories.forEach {
+            installer.install(it)
+            logger.debug("Installed component factory {} of current factories", it)
+        }
+
+        // installers
+        installers.forEach {
+            it.install(installer)
+            logger.debug("Installed installer by {}", it)
+        }
+    }
+
+    public companion object {
+        private val logger = LoggerFactory.getLogger(DefaultSimbotComponentInstallProcessor::class)
+    }
+}

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/SimbotDispatcherProcessor.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/SimbotDispatcherProcessor.kt
@@ -1,0 +1,159 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.configuration
+
+import love.forte.simbot.event.EventDispatchInterceptor
+import love.forte.simbot.event.EventInterceptor
+import love.forte.simbot.logger.LoggerFactory
+import love.forte.simbot.logger.logger
+import love.forte.simbot.spring.common.application.SpringEventDispatcherConfiguration
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * 用于在 starter 中针对 [SpringEventDispatcherConfiguration] 进行处理的处理器，
+ * 只能存在一个，默认情况下会加载所有的 [SimbotDispatcherConfigurer] 并应用他们的逻辑。
+ *
+ * 可以通过注册自定义的 [SimbotDispatcherProcessor] 来覆盖默认行为。
+ *
+ * @see SimbotDispatcherConfigurer
+ * @see DefaultSimbotDispatcherProcessorConfiguration
+ */
+public interface SimbotDispatcherProcessor {
+    /**
+     * 处理逻辑。
+     */
+    public fun process(configuration: SpringEventDispatcherConfiguration)
+}
+
+/**
+ * 用于在 starter 中配置 [SpringEventDispatcherConfiguration]，
+ * 默认情况下注册到 spring 中生效，可注册多个。
+ *
+ * Kotlin example:
+ *
+ * ```kt
+ * @Component
+ * class MySimbotDispatcherConfigurer : SimbotDispatcherConfigurer {
+ *     // impl...
+ * }
+ * ```
+ *
+ * ```kt
+ * @Configuration
+ * open class MySimbotDispatcherConfiguration {
+ *     @Bean
+ *     open fun myDispatcherConfigurer(): SimbotDispatcherConfigurer = ...
+ * }
+ * ```
+ *
+ * Java example:
+ *
+ * ```java
+ * @Component
+ * public class MySimbotDispatcherConfigurer implements SimbotDispatcherConfigurer {
+ *      // impl...
+ * }
+ * ```
+ *
+ * ```java
+ * @Configuration
+ * public class MySimbotDispatcherConfiguration {
+ *     @Bean
+ *     public SimbotDispatcherConfigurer myDispatcherConfigurer() {
+ *         return ...
+ *     }
+ * }
+ * ```
+ *
+ * @author ForteScarlet
+ */
+public interface SimbotDispatcherConfigurer {
+    /**
+     * 配置 [configuration].
+     */
+    public fun configure(configuration: SpringEventDispatcherConfiguration)
+}
+
+
+/**
+ * 用户注册 [SimbotDispatcherProcessor] 默认行为的配置类。
+ *
+ */
+@Configuration(proxyBeanMethods = false)
+public open class DefaultSimbotDispatcherProcessorConfiguration {
+    @Bean(DEFAULT_SIMBOT_DISPATCHER_PROCESSOR_BEAN_NAME)
+    @ConditionalOnMissingBean(SimbotDispatcherProcessor::class)
+    public open fun defaultSimbotDispatcherProcessor(
+        @Autowired(required = false) configurers: List<SimbotDispatcherConfigurer>? = null,
+        @Autowired(required = false) interceptors: List<EventInterceptor>? = null,
+        @Autowired(required = false) dispatcherInterceptors: List<EventDispatchInterceptor>? = null
+    ): DefaultSimbotDispatcherProcessor {
+        return DefaultSimbotDispatcherProcessor(
+            interceptors = interceptors ?: emptyList(),
+            dispatcherInterceptors = dispatcherInterceptors ?: emptyList(),
+            configurers = configurers ?: emptyList()
+        )
+    }
+
+    public companion object {
+        public const val DEFAULT_SIMBOT_DISPATCHER_PROCESSOR_BEAN_NAME: String =
+            "love.forte.simbot.spring.configuration.defaultSimbotDispatcherProcessor"
+    }
+}
+
+/**
+ * [SimbotDispatcherProcessor] 的默认实现，通过
+ * [DefaultSimbotDispatcherProcessorConfiguration] 向 spring 中配置。
+ */
+public open class DefaultSimbotDispatcherProcessor(
+    private val configurers: List<SimbotDispatcherConfigurer>,
+    private val interceptors: List<EventInterceptor>,
+    private val dispatcherInterceptors: List<EventDispatchInterceptor>
+) :
+    SimbotDispatcherProcessor {
+    override fun process(configuration: SpringEventDispatcherConfiguration) {
+        // 拦截器加载
+        interceptors.forEach {
+            configuration.addInterceptor(it)
+            logger.debug("Added interceptor {}", it)
+        }
+
+        dispatcherInterceptors.forEach {
+            configuration.addDispatchInterceptor(it)
+            logger.debug("Added dispatcher interceptor {}", it)
+        }
+
+        configurers.forEach {
+            it.configure(configuration)
+            logger.debug("Configured {} by configurer {}", configuration, it)
+        }
+    }
+
+    public companion object {
+        private val logger = LoggerFactory.logger<DefaultSimbotDispatcherProcessor>()
+    }
+}

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/SimbotEventManagerProcessor.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/SimbotEventManagerProcessor.kt
@@ -1,0 +1,83 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.configuration
+
+import love.forte.simbot.event.EventDispatcher
+import love.forte.simbot.event.EventListener
+import love.forte.simbot.event.EventListenerRegistrar
+import love.forte.simbot.quantcat.common.annotations.Listener
+
+
+/**
+ * 针对 [EventDispatcher] 的处理器。
+ * 默认会加载使用 [SimbotEventListenerRegistrarProcessor] 和所有 [SimbotEventDispatcherPostConfigurer]。
+ *
+ * @author ForteScarlet
+ */
+public interface SimbotEventDispatcherProcessor {
+    /**
+     * 处理 [dispatcher]
+     */
+    public fun process(dispatcher: EventDispatcher)
+}
+
+/**
+ * 默认行为下对 [EventDispatcher] 的配置接口。
+ *
+ * 可注册多个。
+ *
+ */
+public interface SimbotEventDispatcherPostConfigurer {
+    /**
+     * 配置 [dispatcher]
+     */
+    public fun configure(dispatcher: EventDispatcher)
+}
+
+/**
+ * 针对 [EventListenerRegistrar] 的处理器。
+ * 默认会：
+ * - 加载使用扫描所有 bean 的函数（标记了 [Listener] 的）并转化、
+ * - 所有的注册的 [EventListener] 实例
+ * - 所有 [SimbotEventListenerRegistrarPostConfigurer]。
+ */
+public interface SimbotEventListenerRegistrarProcessor {
+    /**
+     * 处理 [registrar]
+     */
+    public fun process(registrar: EventListenerRegistrar)
+}
+
+/**
+ * 默认行为下对 [EventListenerRegistrar] 的配置接口。
+ *
+ * 可注册多个。
+ *
+ */
+public interface SimbotEventListenerRegistrarPostConfigurer {
+    /**
+     * 配置 [registrar]
+     */
+    public fun configure(registrar: EventListenerRegistrar)
+}

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/SimbotPluginInstallProcessor.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/SimbotPluginInstallProcessor.kt
@@ -1,0 +1,132 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.configuration
+
+import love.forte.simbot.logger.LoggerFactory
+import love.forte.simbot.plugin.PluginFactory
+import love.forte.simbot.plugin.PluginInstaller
+import love.forte.simbot.plugin.findAndInstallAllPlugins
+import love.forte.simbot.spring.common.application.SpringApplicationConfigurationProperties
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * 在 starter 中通过 [PluginInstaller] 安装插件信息。
+ * 只能存在一个，默认情况下会尝试加载当前所有的
+ * [PluginFactory] （无配置注册）、可通过 SPI 自动加载的以及 [SimbotPluginInstaller] 并进行处理。
+ *
+ * 注册自定义的 [SimbotPluginInstallProcessor] 可覆盖默认行为。
+ *
+ * @author ForteScarlet
+ */
+public interface SimbotPluginInstallProcessor {
+    /**
+     * 处理 [installer].
+     */
+    public fun process(installer: PluginInstaller)
+
+}
+
+/**
+ * 在 starter 中的 [SimbotPluginInstallProcessor] 默认实现
+ * [DefaultSimbotPluginInstallProcessor] 行为里对 [PluginInstaller]
+ * 进行自定义处理的可扩展类型。
+ * 可以注册多个。
+ *
+ * @see SimbotPluginInstallProcessor
+ * @see DefaultSimbotPluginInstallProcessor
+ *
+ */
+public interface SimbotPluginInstaller {
+    public fun install(installer: PluginInstaller)
+}
+
+
+/**
+ * 配置 [SimbotPluginInstallProcessor] 默认行为实现的配置类。
+ */
+@Configuration(proxyBeanMethods = false)
+public open class DefaultSimbotPluginInstallProcessorConfiguration {
+    @Bean(DEFAULT_SIMBOT_PLUGIN_INSTALL_PROCESSOR_BEAN_NAME)
+    @ConditionalOnMissingBean(SimbotPluginInstallProcessor::class)
+    public open fun defaultSimbotPluginInstallProcessor(
+        properties: SpringApplicationConfigurationProperties,
+        @Autowired(required = false) factories: List<PluginFactory<*, *>>? = null,
+        @Autowired(required = false) installers: List<SimbotPluginInstaller>? = null,
+    ): DefaultSimbotPluginInstallProcessor {
+        return DefaultSimbotPluginInstallProcessor(
+            properties.plugins.autoInstallProviders,
+            properties.plugins.autoInstallProviderConfigures,
+            factories ?: emptyList(),
+            installers ?: emptyList()
+        )
+    }
+
+    public companion object {
+        public const val DEFAULT_SIMBOT_PLUGIN_INSTALL_PROCESSOR_BEAN_NAME: String =
+            "love.forte.simbot.spring.configuration.defaultSimbotPluginInstallProcessor"
+    }
+}
+
+
+/**
+ * [SimbotPluginInstallProcessor] 的默认行为实现
+ */
+public class DefaultSimbotPluginInstallProcessor(
+    private val autoInstallProviders: Boolean,
+    private val autoInstallProviderConfigures: Boolean,
+    private val factories: List<PluginFactory<*, *>>,
+    private val installers: List<SimbotPluginInstaller>,
+) : SimbotPluginInstallProcessor {
+    override fun process(installer: PluginInstaller) {
+        if (autoInstallProviders) {
+            installer.findAndInstallAllPlugins(autoInstallProviderConfigures)
+            logger.debug(
+                "Automatically install all plugin providers automatically with autoLoadProviderConfigures={}",
+                autoInstallProviderConfigures
+            )
+        } else {
+            logger.debug("Automatic installation from plugin providers was disabled")
+            // 自动的
+        }
+
+        // factories
+        factories.forEach {
+            installer.install(it)
+            logger.debug("Installed plugin factory {} of current factories", it)
+        }
+
+        // installers
+        installers.forEach {
+            it.install(installer)
+            logger.debug("Installed installer by {}", it)
+        }
+    }
+
+    public companion object {
+        private val logger = LoggerFactory.getLogger(DefaultSimbotPluginInstallProcessor::class)
+    }
+}

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/SimbotSpringPropertiesConfiguration.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/SimbotSpringPropertiesConfiguration.kt
@@ -1,0 +1,48 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.configuration
+
+import love.forte.simbot.spring.common.application.SpringApplicationConfigurationProperties
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+
+/**
+ *
+ * @author ForteScarlet
+ */
+@Configuration(proxyBeanMethods = false)
+public open class SimbotSpringPropertiesConfiguration {
+    /**
+     * Simbot spring properties
+     */
+    @Bean
+    @ConditionalOnMissingBean(SpringApplicationConfigurationProperties::class)
+    @ConfigurationProperties("simbot")
+    public open fun springApplicationConfigurationProperties(): SpringApplicationConfigurationProperties {
+        return SpringApplicationConfigurationProperties()
+    }
+}

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/application/DefaultSimbotApplicationLauncherFactory.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/application/DefaultSimbotApplicationLauncherFactory.kt
@@ -1,0 +1,115 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.configuration.application
+
+import love.forte.simbot.application.ApplicationFactoryConfigurer
+import love.forte.simbot.spring.common.application.SpringApplicationBuilder
+import love.forte.simbot.spring.common.application.SpringApplicationEventRegistrar
+import love.forte.simbot.spring.common.application.SpringApplicationLauncher
+import love.forte.simbot.spring.common.application.SpringEventDispatcherConfiguration
+import love.forte.simbot.spring2.application.Spring
+import love.forte.simbot.spring2.configuration.SimbotComponentInstallProcessor
+import love.forte.simbot.spring2.configuration.SimbotDispatcherProcessor
+import love.forte.simbot.spring2.configuration.SimbotPluginInstallProcessor
+import love.forte.simbot.spring2.configuration.config.SimbotApplicationConfigurationProcessor
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * [SimbotApplicationLauncherFactory] 的默认逻辑实现
+ * [DefaultSimbotApplicationLauncherFactory] 的配置类。
+ *
+ */
+@Configuration(proxyBeanMethods = true)
+public open class DefaultSimbotSpringApplicationLauncherFactoryConfiguration {
+    @Bean(DEFAULT_SPRING_APPLICATION_LAUNCHER_PROCESSOR_BEAN_NAME)
+    @ConditionalOnMissingBean(SimbotApplicationLauncherFactory::class)
+    public open fun defaultSpringApplicationLauncherProcessor(
+        @Autowired(required = false) builderPreConfigurers: List<SimbotApplicationLauncherPreConfigurer>? = null,
+        @Autowired(required = false) builderPostConfigurers: List<SimbotApplicationLauncherPostConfigurer>? = null,
+        @Autowired applicationConfigurationProcessor: SimbotApplicationConfigurationProcessor,
+        @Autowired dispatcherProcessor: SimbotDispatcherProcessor,
+        @Autowired componentProcessor: SimbotComponentInstallProcessor,
+        @Autowired pluginProcessor: SimbotPluginInstallProcessor,
+    ): DefaultSimbotApplicationLauncherFactory =
+        DefaultSimbotApplicationLauncherFactory(
+            builderPreConfigurers ?: emptyList(),
+            builderPostConfigurers ?: emptyList(),
+            applicationConfigurationProcessor,
+            dispatcherProcessor,
+            componentProcessor,
+            pluginProcessor,
+        )
+
+    public companion object {
+        public const val DEFAULT_SPRING_APPLICATION_LAUNCHER_PROCESSOR_BEAN_NAME: String =
+            "love.forte.simbot.spring.configuration.defaultSpringApplicationLauncherProcessor"
+    }
+}
+
+
+/**
+ * [SimbotApplicationLauncherFactory] 的默认实现。
+ *
+ */
+public class DefaultSimbotApplicationLauncherFactory(
+    private val builderPreConfigurers: List<SimbotApplicationLauncherPreConfigurer>,
+    private val builderPostConfigurers: List<SimbotApplicationLauncherPostConfigurer>,
+    private val applicationConfigurationProcessor: SimbotApplicationConfigurationProcessor,
+    private val dispatcherProcessor: SimbotDispatcherProcessor,
+    private val componentProcessor: SimbotComponentInstallProcessor,
+    private val pluginProcessor: SimbotPluginInstallProcessor,
+) : SimbotApplicationLauncherFactory {
+    override fun process(factory: Spring): SpringApplicationLauncher {
+        return factory.create {
+            // pre
+            builderPreConfigurers.forEach { it.configure(this) }
+
+            configure0()
+
+            // post
+            builderPostConfigurers.forEach { it.configure(this) }
+        }
+    }
+
+    private fun ApplicationFactoryConfigurer<
+        SpringApplicationBuilder,
+        SpringApplicationEventRegistrar,
+        SpringEventDispatcherConfiguration
+        >.configure0() {
+        config {
+            applicationConfigurationProcessor.process(this)
+        }
+        // dispatchers
+        eventDispatcher {
+            dispatcherProcessor.process(this)
+        }
+        // components
+        componentProcessor.process(this)
+        // plugins
+        pluginProcessor.process(this)
+    }
+}

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/application/DefaultSimbotApplicationProcessor.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/application/DefaultSimbotApplicationProcessor.kt
@@ -1,0 +1,452 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.configuration.application
+
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import love.forte.simbot.bot.*
+import love.forte.simbot.logger.Logger
+import love.forte.simbot.logger.LoggerFactory
+import love.forte.simbot.logger.logger
+import love.forte.simbot.spring.common.BotAutoStartOnFailureException
+import love.forte.simbot.spring.common.BotConfigResourceLoadOnFailureException
+import love.forte.simbot.spring.common.MismatchConfigurableBotManagerException
+import love.forte.simbot.spring.common.application.*
+import love.forte.simbot.spring2.configuration.SimbotEventDispatcherProcessor
+import love.forte.simbot.spring2.configuration.listener.SimbotEventListenerResolver
+import love.forte.simbot.suspendrunner.runInNoScopeBlocking
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.io.Resource
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver
+import java.io.FileNotFoundException
+
+/**
+ * [SimbotApplicationProcessor] 的默认实现
+ * [DefaultSimbotApplicationProcessor]
+ * 的配置器。
+ *
+ *
+ */
+@Configuration(proxyBeanMethods = false)
+public open class DefaultSimbotSpringApplicationProcessorConfiguration {
+    @Bean(DEFAULT_SIMBOT_APPLICATION_PROCESSOR_BEAN_NAME)
+    @ConditionalOnMissingBean(SimbotApplicationProcessor::class)
+    public open fun defaultSimbotApplicationProcessor(
+        properties: SpringApplicationConfigurationProperties,
+        @Autowired(required = false) eventListenerResolvers: List<SimbotEventListenerResolver>? = null,
+        @Autowired(required = false) preConfigurer: List<SimbotApplicationPreConfigurer>? = null,
+        @Autowired(required = false) postConfigurer: List<SimbotApplicationPostConfigurer>? = null,
+        @Autowired(required = false) eventDispatcherProcessor: SimbotEventDispatcherProcessor,
+    ): DefaultSimbotApplicationProcessor =
+        DefaultSimbotApplicationProcessor(
+            properties = properties,
+            eventListenerResolvers = eventListenerResolvers ?: emptyList(),
+            preConfigurer = preConfigurer ?: emptyList(),
+            postConfigurer = postConfigurer ?: emptyList(),
+            eventDispatcherProcessor
+        )
+
+    public companion object {
+        public const val DEFAULT_SIMBOT_APPLICATION_PROCESSOR_BEAN_NAME: String =
+            "love.forte.simbot.spring.configuration.application.defaultSimbotApplicationProcessor"
+    }
+}
+
+
+/**
+ * [SimbotApplicationProcessor] 的默认实现，
+ * 默认行为中会进行如下内容：
+ * - 扫描、加载事件处理器（[SimbotEventListenerResolver]）并注册
+ * - 扫描、加载所有的可注册 bot
+ *
+ * @author ForteScarlet
+ */
+public class DefaultSimbotApplicationProcessor(
+    private val properties: SpringApplicationConfigurationProperties,
+    private val eventListenerResolvers: List<SimbotEventListenerResolver>,
+    private val preConfigurer: List<SimbotApplicationPreConfigurer>,
+    private val postConfigurer: List<SimbotApplicationPostConfigurer>,
+    private val eventDispatcherProcessor: SimbotEventDispatcherProcessor,
+) : SimbotApplicationProcessor {
+    override fun process(application: SpringApplication) {
+        preConfigurer.forEach {
+            it.configure(application)
+            logger.debug("Configured application {} by pre configurer {}", application, it)
+        }
+
+        eventListenerResolvers.forEach {
+            it.resolve(application)
+            logger.debug("Resolved event listener with application {} by listener resolver {}", application, it)
+        }
+
+        process0(application)
+
+        postConfigurer.forEach {
+            it.configure(application)
+            logger.debug("Configured application {} by post configurer {}", application, it)
+        }
+    }
+
+
+    private fun process0(application: SpringApplication) {
+        eventDispatcherProcessor.process(application.eventDispatcher)
+        loadBots(application)
+    }
+
+    private fun loadBots(application: SpringApplication) {
+        BotAutoLoader(properties.bots, application).load()
+    }
+
+
+    public companion object {
+        private val logger = LoggerFactory.logger<DefaultSimbotApplicationProcessor>()
+    }
+}
+
+
+private class BotAutoLoader(
+    val properties: SpringApplicationConfigurationProperties.BotProperties,
+    val application: SpringApplication
+) {
+    @OptIn(ExperimentalSerializationApi::class)
+    val json = Json {
+        isLenient = true
+        ignoreUnknownKeys = true
+        allowTrailingComma = true
+        decodeEnumsCaseInsensitive = true
+        allowSpecialFloatingPointValues = true
+        prettyPrint = false
+        serializersModule = application.components.serializersModule
+    }
+    val botManagers = application.botManagers
+
+    fun load() {
+        val resolver = PathMatchingResourcePatternResolver()
+
+        val botList =
+            properties.configurationJsonResources
+                .asSequence()
+                .flatMap {
+                    try {
+                        resolver.getResources(it).asSequence()
+                    } catch (fne: FileNotFoundException) {
+                        logger.warn(
+                            "Bot configuration resource path [{}] could not be resolved " +
+                                "because of FileNotFoundException(message={}), will be skip.",
+                            it,
+                            fne.localizedMessage,
+                        )
+                        logger.debug(
+                            "Bot configuration resource path [{}] could not be resolved " +
+                                "because of FileNotFoundException(message={}), will be skip.",
+                            it,
+                            fne.localizedMessage,
+                            fne
+                        )
+
+                        emptySequence()
+                    }
+                }
+                .distinct()
+                .mapNotNull { resource ->
+                    logger.debug("Resolving bot auto-register configuration resource: {}", resource)
+                    if (resource.filename == null) {
+                        logger.warn("Filename of resource [{}] is null", resource)
+                    }
+
+                    val content = loadResourceContent(properties.autoRegistrationResourceLoadFailurePolicy, resource)
+                        ?: return@mapNotNull null
+
+                    val configuration = try {
+                        json.decodeFromString(SerializableBotConfiguration.serializer(), content)
+                    } catch (se: Throwable) {
+                        processDecodeFailure(resource, se, properties.autoRegistrationResourceLoadFailurePolicy)
+                        return@mapNotNull null
+                    }
+
+                    var bot: Bot? = null
+
+                    for (manager in botManagers) {
+                        try {
+                            if (manager.configurable(configuration)) {
+                                bot = manager.register(configuration)
+                            }
+                        } catch (e: Throwable) {
+                            processRegisterBotFailed(
+                                properties.autoRegistrationFailurePolicy,
+                                e,
+                                resource,
+                                configuration,
+                                manager
+                            )
+                        }
+                    }
+
+                    if (bot == null) {
+                        mismatchConfigurableManager(
+                            properties.autoRegistrationMismatchConfigurableBotManagerPolicy,
+                            resource,
+                            configuration,
+                            botManagers
+                        )
+                    }
+
+                    bot
+                }
+                .onEach { bot ->
+                    logger.debug("Registered bot: {}", bot)
+                }
+                .toList()
+
+        logger.info("The number of registered bots is {}", botList.size)
+
+        processedBotWithPolicy(botList)
+    }
+
+    /**
+     * 加载资源文本或根据策略处理异常
+     */
+    private fun loadResourceContent(policy: BotConfigResourceLoadFailurePolicy, resource: Resource): String? {
+        var content: String? = null
+        val failures = mutableListOf<Throwable>()
+        if (resource.isFile) {
+            kotlin.runCatching {
+                content = resource.file.readText()
+            }.getOrElse(failures::add)
+        }
+
+        if (content == null) {
+            kotlin.runCatching {
+                content = resource.url.readText()
+            }.getOrElse(failures::add)
+        }
+
+        return content ?: run {
+            val err = BotConfigResourceLoadOnFailureException("Cannot load text content for resource $resource").apply {
+                failures.forEach { addSuppressed(it) }
+            }
+            when (policy) {
+                BotConfigResourceLoadFailurePolicy.ERROR -> throw err
+                BotConfigResourceLoadFailurePolicy.ERROR_LOG -> {
+                    logger.error(err.message, err)
+                    null
+                }
+
+                BotConfigResourceLoadFailurePolicy.WARN -> {
+                    logger.warn(err.message, err)
+                    null
+                }
+
+                BotConfigResourceLoadFailurePolicy.IGNORE -> {
+                    logger.debug(err.message, err)
+                    null
+                }
+            }
+        }
+
+    }
+
+    /**
+     * 根据策略处理无法解析 content 内容的异常
+     */
+    private fun processDecodeFailure(
+        resource: Resource,
+        se: Throwable,
+        policy: BotConfigResourceLoadFailurePolicy
+    ) {
+        val message = se.localizedMessage
+        val errMsg = if (se is SerializationException && message.contains("Polymorphic", ignoreCase = true)) {
+            "JSON resource [$resource] fails to deserialize, " +
+                "and this may be because a component does not support polymorphic configurations, " +
+                "e.g. the configuration class does not implement ${SerializableBotConfiguration::class}, " +
+                "the component does not provide polymorphic serialisation information, etc. " +
+                "The information: $message"
+        } else {
+            "JSON resource [$resource] fails to deserialize, The information: $message"
+        }
+
+        val ex = BotConfigResourceLoadOnFailureException(errMsg, se)
+
+        when (policy) {
+            BotConfigResourceLoadFailurePolicy.ERROR -> throw ex
+            BotConfigResourceLoadFailurePolicy.ERROR_LOG -> logger.error(errMsg, ex)
+            BotConfigResourceLoadFailurePolicy.WARN -> logger.warn(errMsg, ex)
+            BotConfigResourceLoadFailurePolicy.IGNORE -> logger.debug(errMsg, ex)
+        }
+    }
+
+    /**
+     * 根据策略处理注册bot时出现异常的情况。
+     */
+    private fun processRegisterBotFailed(
+        policy: BotRegistrationFailurePolicy,
+        e: Throwable,
+        resource: Resource,
+        configuration: SerializableBotConfiguration,
+        botManager: BotManager
+    ) {
+        val message =
+            "Failed to register bot " +
+                "from resource [$resource] " +
+                "to manager [$botManager] " +
+                "via configuration [$configuration]. " +
+                "The information: ${e.localizedMessage}"
+
+        val ex = BotRegisterFailureException(message, e)
+        when (policy) {
+            BotRegistrationFailurePolicy.ERROR -> throw ex
+            BotRegistrationFailurePolicy.ERROR_LOG -> logger.error(message, ex)
+            BotRegistrationFailurePolicy.WARN -> logger.warn(message, ex)
+            BotRegistrationFailurePolicy.IGNORE -> logger.debug(message, ex)
+        }
+    }
+
+    /**
+     * 根据策略处理无法找到匹配的可配置 [BotManager] 的情况
+     */
+    private fun mismatchConfigurableManager(
+        policy: MismatchConfigurableBotManagerPolicy,
+        resource: Resource,
+        configuration: SerializableBotConfiguration,
+        botManagers: BotManagers
+    ) {
+        val message = "No registrable BotManager " +
+            "matching configuration [$configuration] (type: ${configuration::class}) " +
+            "from resource [$resource] was found in $botManagers"
+
+        val ex = MismatchConfigurableBotManagerException(message)
+
+        when (policy) {
+            MismatchConfigurableBotManagerPolicy.ERROR -> throw ex
+            MismatchConfigurableBotManagerPolicy.ERROR_LOG -> logger.error(message, ex)
+            MismatchConfigurableBotManagerPolicy.WARN -> logger.warn(message, ex)
+            MismatchConfigurableBotManagerPolicy.IGNORE -> logger.debug(message, ex)
+        }
+
+    }
+
+    private fun processedBotWithPolicy(botList: List<Bot>) {
+        val autoStartBots = properties.autoStartBots
+        val policy = properties.autoRegistrationFailurePolicy
+        val autoStartMode = properties.autoStartMode
+
+        logger.debug(
+            "Auto start bots is {} with onFailure policy {} and start mode {}",
+            autoStartBots,
+            policy,
+            autoStartMode
+        )
+
+        if (autoStartBots) {
+            when (autoStartMode) {
+                BotAutoStartMode.SYNC -> startBotsInBlocking(policy, botList)
+                BotAutoStartMode.ASYNC -> startBotsInAsync(policy, botList)
+            }
+        }
+    }
+
+    private fun startBotsInAsync(policy: BotRegistrationFailurePolicy, botList: List<Bot>) {
+        when (policy) {
+            BotRegistrationFailurePolicy.ERROR -> {
+                // 异常通过日志输出并关闭 application: 异步中直接抛异常没什么效果
+                application.launch {
+                    // 任意失败全盘皆输
+                    try {
+                        coroutineScope {
+                            botList.forEach { bot ->
+                                launch { bot.start() }
+                                logger.debug("Launched to start bot {}", bot)
+                            }
+                        }
+                    } catch (e: Throwable) {
+                        val err = BotAutoStartOnFailureException(e)
+                        logger.error(
+                            "There are certain bots that have exceptions in asynchronous startups, " +
+                                "application will be cancelled",
+                            err
+                        )
+                        application.cancel(err)
+                    }
+                }
+            }
+
+            BotRegistrationFailurePolicy.ERROR_LOG -> startBotsInAsyncOnFutureWithLog(botList) { error(it.message, it) }
+            BotRegistrationFailurePolicy.WARN -> startBotsInAsyncOnFutureWithLog(botList) { warn(it.message, it) }
+            BotRegistrationFailurePolicy.IGNORE -> startBotsInAsyncOnFutureWithLog(botList) { debug(it.message, it) }
+        }
+    }
+
+    private inline fun startBotsInAsyncOnFutureWithLog(
+        botList: List<Bot>,
+        crossinline onFailure: Logger.(e: Throwable) -> Unit
+    ) {
+        application.launch {
+            supervisorScope {
+                botList.forEach { bot ->
+                    launch {
+                        kotlin.runCatching { bot.start() }
+                            .getOrElse { e -> logger.onFailure(BotAutoStartOnFailureException(e)) }
+                    }
+                    logger.debug("Launched to start bot {}", bot)
+                }
+            }
+        }
+    }
+
+    /**
+     * 阻塞地依次启动 bot。
+     */
+    private fun startBotsInBlocking(policy: BotRegistrationFailurePolicy, botList: List<Bot>) {
+        runInNoScopeBlocking {
+            for (bot in botList) {
+                logger.debug("Starting bot {}", bot)
+                try {
+                    bot.start()
+                    logger.debug("Bot {} started successfully", bot)
+                } catch (e: Throwable) {
+                    val message = "Bot $bot auto start on failure: ${e.localizedMessage}"
+                    val ex = BotAutoStartOnFailureException(message, e)
+                    when (policy) {
+                        BotRegistrationFailurePolicy.ERROR -> throw ex
+                        BotRegistrationFailurePolicy.ERROR_LOG -> logger.error(message, ex)
+                        BotRegistrationFailurePolicy.WARN -> logger.warn(message, ex)
+                        BotRegistrationFailurePolicy.IGNORE -> logger.debug(message, ex)
+                    }
+                }
+            }
+        }
+    }
+
+
+    companion object {
+        private val logger = LoggerFactory.logger<BotAutoLoader>()
+    }
+}

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/application/SimbotApplicationConfiguration.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/application/SimbotApplicationConfiguration.kt
@@ -1,0 +1,61 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.configuration.application
+
+import love.forte.simbot.spring.common.application.SpringApplication
+import love.forte.simbot.spring.common.application.SpringApplicationLauncher
+import love.forte.simbot.suspendrunner.runInNoScopeBlocking
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+
+/**
+ *
+ * @author ForteScarlet
+ */
+@Configuration(proxyBeanMethods = false)
+public open class SimbotApplicationConfiguration {
+    @Bean(SPRING_APPLICATION_LAUNCHER_BEAN_NAME)
+    public open fun springApplicationLauncher(
+        factory: SimbotApplicationLauncherFactory,
+        processor: SimbotApplicationLauncherFactoryProcessor
+    ): SpringApplicationLauncher =
+        processor.process(factory)
+
+    @Bean(
+        value = [SPRING_APPLICATION_BEAN_NAME],
+        destroyMethod = "cancel"
+    )
+    public open fun springApplication(launcher: SpringApplicationLauncher): SpringApplication = runInNoScopeBlocking {
+        launcher.launch()
+    }
+
+    public companion object {
+        public const val SPRING_APPLICATION_LAUNCHER_BEAN_NAME: String =
+            "love.forte.simbot.spring.configuration.application.defaultSpringApplicationLauncher"
+
+        public const val SPRING_APPLICATION_BEAN_NAME: String =
+            "love.forte.simbot.spring.configuration.application.defaultSpringApplication"
+    }
+}

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/application/SimbotApplicationLauncherFactory.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/application/SimbotApplicationLauncherFactory.kt
@@ -1,0 +1,113 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.configuration.application
+
+import love.forte.simbot.application.ApplicationFactoryConfigurer
+import love.forte.simbot.spring.common.application.SpringApplicationBuilder
+import love.forte.simbot.spring.common.application.SpringApplicationEventRegistrar
+import love.forte.simbot.spring.common.application.SpringApplicationLauncher
+import love.forte.simbot.spring.common.application.SpringEventDispatcherConfiguration
+import love.forte.simbot.spring2.application.Spring
+
+
+/**
+ * 在 simbot 的 starter 中对
+ * [Spring] 进行实际配置处理并得到
+ * [SpringApplicationLauncher] 的处理器。
+ * 只能存在一个，当用户自定义时会覆盖**全部**的默认行为。
+ *
+ * @see DefaultSimbotApplicationLauncherFactory
+ *
+ * @author ForteScarlet
+ */
+public interface SimbotApplicationLauncherFactory {
+
+    /**
+     * 根据 [factory] 进行处理并得到 [SpringApplicationLauncher].
+     */
+    public fun process(factory: Spring): SpringApplicationLauncher
+
+}
+
+/**
+ * 在 [SimbotApplicationLauncherFactory] 的 **默认** 情况下,
+ * 会加载 [SimbotApplicationLauncherPreConfigurer] 和 [SimbotApplicationLauncherPostConfigurer]
+ * 分别在默认加载行为之前和之后插入可自定义的配置逻辑。
+ *
+ * 如果 [SimbotApplicationLauncherFactory] 的默认行为被覆盖则需要自行处理，
+ * 否则不会生效。
+ *
+ * @see SimbotApplicationLauncherFactory
+ * @see DefaultSimbotApplicationLauncherFactory
+ * @see SimbotApplicationLauncherPreConfigurer
+ * @see SimbotApplicationLauncherPostConfigurer
+ */
+public sealed interface SimbotApplicationLauncherConfigurer {
+
+    /**
+     * 配置 [SpringApplicationBuilder].
+     */
+    public fun configure(
+        configurer: ApplicationFactoryConfigurer<
+            SpringApplicationBuilder,
+            SpringApplicationEventRegistrar,
+            SpringEventDispatcherConfiguration
+            >
+    )
+
+}
+
+/**
+ * 在 [SimbotApplicationLauncherFactory] 的 **默认** 情况下,
+ * 会加载 [SimbotApplicationLauncherPreConfigurer] 和 [SimbotApplicationLauncherPostConfigurer]
+ * 会在默认加载行为之前插入可自定义的配置逻辑。
+ *
+ * 如果 [SimbotApplicationLauncherFactory] 的默认行为被覆盖则需要自行处理，
+ * 否则不会生效。
+ *
+ * @see SimbotApplicationLauncherFactory
+ * @see DefaultSimbotApplicationLauncherFactory
+ * @see SimbotApplicationLauncherConfigurer
+ * @see SimbotApplicationLauncherPostConfigurer
+ */
+public interface SimbotApplicationLauncherPreConfigurer :
+    SimbotApplicationLauncherConfigurer
+
+/**
+ * 在 [SimbotApplicationLauncherFactory] 的 **默认** 情况下,
+ * 会在默认加载行为之后插入可自定义的配置逻辑。
+ *
+ * 如果 [SimbotApplicationLauncherFactory] 的默认行为被覆盖则需要自行处理，
+ * 否则不会生效。
+ *
+ * @see SimbotApplicationLauncherFactory
+ * @see DefaultSimbotApplicationLauncherFactory
+ * @see SimbotApplicationLauncherConfigurer
+ * @see SimbotApplicationLauncherPreConfigurer
+ */
+public interface SimbotApplicationLauncherPostConfigurer :
+    SimbotApplicationLauncherConfigurer
+
+
+

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/application/SimbotApplicationLauncherFactoryProcessor.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/application/SimbotApplicationLauncherFactoryProcessor.kt
@@ -1,0 +1,71 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.configuration.application
+
+import love.forte.simbot.spring.common.application.SpringApplicationLauncher
+import love.forte.simbot.spring2.application.Spring
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * 对 [SimbotApplicationLauncherFactory] 的处理器，
+ * 通过 [SimbotApplicationLauncherFactory] 得到一个
+ * 预备启动器 [SpringApplicationLauncher]。
+ *
+ * 默认情况下会直接提供 [Spring] 并构建它。
+ */
+public fun interface SimbotApplicationLauncherFactoryProcessor {
+    /**
+     * 处理 [applicationLauncherFactory]
+     */
+    public fun process(applicationLauncherFactory: SimbotApplicationLauncherFactory): SpringApplicationLauncher
+}
+
+/**
+ * 用于配置 [SimbotApplicationLauncherFactoryProcessor] 的默认实现 [DefaultSimbotApplicationLauncherFactoryProcessor]
+ * 的配置器。
+ */
+@Configuration(proxyBeanMethods = false)
+public open class DefaultSimbotApplicationLauncherFactoryProcessorConfiguration {
+    @Bean(DEFAULT_SIMBOT_APPLICATION_LAUNCHER_FACTORY_PROCESSOR_BEAN_NAME)
+    @ConditionalOnMissingBean(SimbotApplicationLauncherFactoryProcessor::class)
+    public open fun defaultSimbotApplicationLauncherFactoryProcessor():
+        DefaultSimbotApplicationLauncherFactoryProcessor = DefaultSimbotApplicationLauncherFactoryProcessor
+
+    public companion object {
+        public const val DEFAULT_SIMBOT_APPLICATION_LAUNCHER_FACTORY_PROCESSOR_BEAN_NAME: String =
+            "love.forte.simbot.spring.configuration.application.defaultSimbotApplicationLauncherFactoryProcessor"
+    }
+}
+
+/**
+ * [SimbotApplicationLauncherFactoryProcessor] 的默认逻辑实现，
+ * 会直接向 [SimbotApplicationLauncherFactory] 提供一个 [Spring] 并得到
+ * [SpringApplicationLauncher].
+ */
+public object DefaultSimbotApplicationLauncherFactoryProcessor : SimbotApplicationLauncherFactoryProcessor {
+    override fun process(applicationLauncherFactory: SimbotApplicationLauncherFactory): SpringApplicationLauncher =
+        applicationLauncherFactory.process(Spring)
+}

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/application/SimbotApplicationProcessor.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/application/SimbotApplicationProcessor.kt
@@ -1,0 +1,83 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.configuration.application
+
+import love.forte.simbot.spring.common.application.SpringApplication
+import love.forte.simbot.spring.common.application.SpringApplicationLauncher
+
+
+/**
+ * 用于在 [SpringApplicationLauncher] 启动完成得到 [SpringApplication]
+ * 后进行处理的处理器。
+ *
+ * [SimbotApplicationProcessor] 默认使用 [DefaultSimbotApplicationProcessor]，
+ * 可提供自定义类型覆盖默认行为。
+ * 但是注意！覆盖 [SimbotApplicationProcessor] 会导致**所有**默认行为失效，
+ * 例如加载事件处理器、自动加载、注册 bot 并保持整个程序活跃等。
+ *
+ * 如果希望在启动完成得到 [SpringApplication] 并进行默认行为前后执行某些逻辑，
+ * 可考虑使用 [SimbotApplicationConfigurer]。
+ *
+ *
+ */
+public interface SimbotApplicationProcessor {
+    /**
+     * 处理 [SpringApplication].
+     */
+    public fun process(application: SpringApplication)
+
+}
+
+/**
+ * 在 [DefaultSimbotApplicationProcessor]
+ * 中被加载并对 [SpringApplication] 进行配置的配置接口，
+ * 使用 [SimbotApplicationPreConfigurer] 和 [SimbotApplicationPostConfigurer]
+ * 分别代表在进行默认行为之前或之后进行的配置逻辑。
+ *
+ * 可以注册多个。
+ *
+ * @see SimbotApplicationPreConfigurer
+ * @see SimbotApplicationPostConfigurer
+ *
+ */
+public sealed interface SimbotApplicationConfigurer {
+    /**
+     * 使用 [application]
+     */
+    public fun configure(application: SpringApplication)
+}
+
+/**
+ * 在 [DefaultSimbotApplicationProcessor] 进行默认行为之前进行的配置逻辑。
+ * @see SimbotApplicationConfigurer
+ */
+public fun interface SimbotApplicationPreConfigurer : SimbotApplicationConfigurer
+
+/**
+ * 在 [DefaultSimbotApplicationProcessor] 进行默认行为之后进行的配置逻辑。
+ * @see SimbotApplicationConfigurer
+ */
+public fun interface SimbotApplicationPostConfigurer : SimbotApplicationConfigurer
+
+

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/application/SimbotApplicationRunner.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/application/SimbotApplicationRunner.kt
@@ -1,0 +1,130 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.configuration.application
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import love.forte.simbot.application.Application
+import love.forte.simbot.logger.LoggerFactory
+import love.forte.simbot.logger.logger
+import love.forte.simbot.spring.common.application.ApplicationLaunchMode.NONE
+import love.forte.simbot.spring.common.application.ApplicationLaunchMode.THREAD
+import love.forte.simbot.spring.common.application.SpringApplication
+import love.forte.simbot.spring.common.application.SpringApplicationConfigurationProperties
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.context.ApplicationContext
+import org.springframework.context.ApplicationContextAware
+import org.springframework.core.annotation.Order
+
+
+/**
+ *
+ * @author ForteScarlet
+ */
+@Order(Int.MAX_VALUE)
+public open class SimbotApplicationRunner(
+    private val application: SpringApplication,
+    private val properties: SpringApplicationConfigurationProperties,
+    private val applicationProcessor: SimbotApplicationProcessor
+) : ApplicationRunner, ApplicationContextAware {
+    private lateinit var applicationContext: ApplicationContext
+    private var launchThread: ApplicationLaunchThread? = null
+
+    override fun run(args: ApplicationArguments?) {
+        applicationProcessor.process(application)
+        registerOnComplete()
+        launchApp()
+    }
+
+    private fun registerOnComplete() {
+        application.onCompletion { cause ->
+            if (cause != null) {
+                if (cause is CancellationException) {
+                    val cancelCause = cause.cause
+                    if (cancelCause == null) {
+                        logger.info(
+                            "Application {} was cancelled without cause: {}",
+                            application,
+                            cause.message
+                        )
+                    } else {
+                        logger.info(
+                            "Application {} was cancelled with cause: {}",
+                            application,
+                            cause.message,
+                            cause
+                        )
+                    }
+                } else {
+                    // not cancelled exception
+                    logger.error(
+                        "Application {} was on completion with an error: {}",
+                        application,
+                        cause.message,
+                        cause
+                    )
+                }
+            } else {
+                logger.info("Application {} was on completion without cause", application)
+            }
+        }
+    }
+
+    private fun launchApp() {
+        val launchMode = properties.application.applicationLaunchMode
+        logger.info("Launch application {} with mode: {}", application, launchMode)
+        when (launchMode) {
+            THREAD -> {
+                launchThread = ApplicationLaunchThread(application).also {
+                    it.start()
+                    logger.debug("Started application launch thread {}", it)
+                }
+            }
+
+            NONE -> {
+                // nothing.
+            }
+        }
+    }
+
+    override fun setApplicationContext(applicationContext: ApplicationContext) {
+        this.applicationContext = applicationContext
+    }
+
+    private class ApplicationLaunchThread(private val app: Application) : Thread("Simbot-Spring-Launch-Thread") {
+        override fun run() {
+            try {
+                runBlocking { app.join() }
+                logger.info("ApplicationLaunchThread done.")
+            } catch (e: Throwable) {
+                logger.info("ApplicationLaunchThread done on failure: {}", e.localizedMessage, e)
+            }
+        }
+    }
+
+    public companion object {
+        private val logger = LoggerFactory.logger<SimbotApplicationRunner>()
+    }
+}

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/binder/BinderManagerProvider.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/binder/BinderManagerProvider.kt
@@ -1,0 +1,60 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.configuration.binder
+
+import love.forte.simbot.quantcat.common.binder.ParameterBinderFactory
+
+/**
+ * 如果注册 [ParameterBinderFactory] 时 id 出现重复
+ */
+public open class DuplicateBinderIdException(message: String, cause: Throwable? = null) :
+    IllegalArgumentException(message, cause)
+
+/**
+ * 应用于 [ParameterBinderManagerBuilderConfigurer] 的构建器。
+ *
+ */
+public interface ParameterBinderManagerBuilder {
+    /**
+     * 添加一个有 ID 的具体作用域b [ParameterBinderFactory]
+     *
+     * @throws DuplicateBinderIdException 如果 id 出现重复
+     */
+    public fun addBinderFactory(id: String, factory: ParameterBinderFactory)
+
+    /**
+     * 添加一个全局应用的 [ParameterBinderFactory]
+     */
+    public fun addBinderFactory(factory: ParameterBinderFactory)
+}
+
+/**
+ * 在默认行为中会被 [ResolveBinderManagerProcessor] 批量加载并配置。
+ */
+public fun interface ParameterBinderManagerBuilderConfigurer {
+    /**
+     * 配置 [builder]
+     */
+    public fun configure(builder: ParameterBinderManagerBuilder)
+}

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/binder/DefaultBinderManagerProvidersConfiguration.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/binder/DefaultBinderManagerProvidersConfiguration.kt
@@ -1,0 +1,46 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.configuration.binder
+
+import love.forte.simbot.quantcat.common.annotations.FilterValue
+import love.forte.simbot.quantcat.common.annotations.toProperties
+import love.forte.simbot.quantcat.common.binder.impl.EventParameterBinderFactory
+import love.forte.simbot.quantcat.common.binder.impl.KeywordBinderFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import kotlin.reflect.full.findAnnotation
+
+/**
+ * 用以注册部分默认提供的 Spring 环境下全局配置的绑定器配置。
+ */
+@Configuration(proxyBeanMethods = false)
+public open class DefaultBinderManagerProvidersConfiguration {
+    @Bean
+    public open fun eventParameterBinderFactory(): EventParameterBinderFactory = EventParameterBinderFactory
+
+    @Bean
+    public open fun keywordBinderFactory(): KeywordBinderFactory = KeywordBinderFactory { context ->
+        context.parameter.findAnnotation<FilterValue>()?.toProperties()
+    }
+}

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/binder/ResolveBinderManagerProcessor.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/binder/ResolveBinderManagerProcessor.kt
@@ -1,0 +1,196 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.configuration.binder
+
+import love.forte.simbot.annotations.ExperimentalSimbotAPI
+import love.forte.simbot.quantcat.common.annotations.Binder
+import love.forte.simbot.quantcat.common.binder.ParameterBinderFactory
+import love.forte.simbot.quantcat.common.binder.SimpleBinderManager
+import love.forte.simbot.quantcat.common.binder.toBinderFactory
+import love.forte.simbot.spring2.configuration.listener.SimbotEventListenerFunctionProcessor
+import love.forte.simbot.spring2.utils.getKotlinFunctionSafely
+import love.forte.simbot.spring2.utils.getTargetTypeSafely
+import love.forte.simbot.spring2.utils.selectMethodsSafely
+import org.springframework.aop.scope.ScopedProxyUtils
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.beans.factory.support.BeanDefinitionBuilder
+import org.springframework.beans.factory.support.BeanDefinitionRegistry
+import org.springframework.boot.autoconfigure.AutoConfigureBefore
+import org.springframework.context.annotation.ConfigurationClassPostProcessor
+import org.springframework.core.annotation.AnnotationUtils
+
+
+/**
+ * 将标记了 [Binder] 的类型和函数转化为 [ParameterBinderFactory]、
+ * 处理 [ParameterBinderManagerBuilderConfigurer] 以及加载所有的 [ParameterBinderFactory]
+ *
+ * @author ForteScarlet
+ */
+@AutoConfigureBefore(SimbotEventListenerFunctionProcessor::class)
+public open class ResolveBinderManagerProcessor : ConfigurationClassPostProcessor() {
+    protected open lateinit var registry: BeanDefinitionRegistry
+
+    override fun postProcessBeanDefinitionRegistry(registry: BeanDefinitionRegistry) {
+        this.registry = registry
+    }
+
+    @OptIn(ExperimentalSimbotAPI::class)
+    override fun postProcessBeanFactory(beanFactory: ConfigurableListableBeanFactory) {
+        val builder = ParameterBinderManagerBuilderImpl()
+        beanFactory.beanNamesIterator.asSequence()
+            .filter { !ScopedProxyUtils.isScopedTarget(it) }
+            .forEach { beanName ->
+                val beanType = beanFactory.getTargetTypeSafely(beanName) ?: return@forEach
+
+                beanFactory.processToBinderFactoryBuilder(beanName, beanType, builder)
+            }
+
+        val simpleManager = SimpleBinderManager(builder.globalBinders, builder.idBinders)
+        val beanDefinition =
+            BeanDefinitionBuilder.genericBeanDefinition(SimpleBinderManager::class.java) { simpleManager }.apply {
+                setPrimary(false)
+            }.beanDefinition
+
+        registry.registerBeanDefinition(BINDER_MANAGER_BEAN_NAME, beanDefinition)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun ConfigurableListableBeanFactory.processToBinderFactoryBuilder(
+        beanName: String,
+        beanType: Class<*>,
+        builder: ParameterBinderManagerBuilderImpl
+    ) {
+        if (ParameterBinderFactory::class.java.isAssignableFrom(beanType)) {
+            resolveFactoryInstance(beanName, beanType as Class<out ParameterBinderFactory>, builder)
+        }
+
+        if (ParameterBinderManagerBuilderConfigurer::class.java.isAssignableFrom(beanType)) {
+            resolveConfigurer(beanName, beanType as Class<out ParameterBinderManagerBuilderConfigurer>, builder)
+        }
+
+        if (AnnotationUtils.isCandidateClass(beanType, Binder::class.java)) {
+            resolveCandidate(beanName, beanType, builder)
+        }
+    }
+
+    protected open fun ConfigurableListableBeanFactory.resolveFactoryInstance(
+        beanName: String,
+        beanType: Class<out ParameterBinderFactory>,
+        builder: ParameterBinderManagerBuilderImpl
+    ) {
+        val instance = getBean(beanName, beanType)
+        val binder = this.findAnnotationOnBean(beanName, Binder::class.java)
+
+        resolveFactoryWithBinder(binder, beanName, instance, builder)
+    }
+
+    protected open fun ConfigurableListableBeanFactory.resolveConfigurer(
+        beanName: String,
+        beanType: Class<out ParameterBinderManagerBuilderConfigurer>,
+        builder: ParameterBinderManagerBuilderImpl
+    ) {
+        val instance = getBean(beanName, beanType)
+        instance.configure(builder)
+    }
+
+    @OptIn(ExperimentalSimbotAPI::class)
+    protected open fun ConfigurableListableBeanFactory.resolveCandidate(
+        beanName: String,
+        beanType: Class<*>,
+        builder: ParameterBinderManagerBuilderImpl
+    ) {
+        val binderMethods = beanType.selectMethodsSafely<Binder>()?.takeIf { it.isNotEmpty() } ?: return
+
+        binderMethods.forEach { (method, binderAnnotation) ->
+            val function = method.getKotlinFunctionSafely() ?: return@forEach
+            val factory = function.toBinderFactory { getBean(beanName, beanType) }
+
+            resolveFactoryWithBinder(binderAnnotation, beanName, factory, builder)
+        }
+
+    }
+
+    protected open class ParameterBinderManagerBuilderImpl : ParameterBinderManagerBuilder {
+        public open val globalBinders: MutableList<ParameterBinderFactory> = mutableListOf()
+        public open val idBinders: MutableMap<String, ParameterBinderFactory> = mutableMapOf()
+
+        override fun addBinderFactory(id: String, factory: ParameterBinderFactory) {
+            if (idBinders.containsKey(id)) {
+                throw DuplicateBinderIdException("Duplicate binder factory id: $id")
+            }
+
+            idBinders[id] = factory
+        }
+
+        override fun addBinderFactory(factory: ParameterBinderFactory) {
+            globalBinders.add(factory)
+        }
+    }
+
+
+    protected open fun resolveFactoryWithBinder(
+        binder: Binder?,
+        beanName: String,
+        factory: ParameterBinderFactory,
+        builder: ParameterBinderManagerBuilderImpl
+    ) {
+        if (binder == null) {
+            builder.addBinderFactory(factory)
+            return
+        }
+
+        when (binder.scope) {
+            Binder.Scope.GLOBAL -> {
+                builder.addBinderFactory(factory)
+                return
+            }
+
+            Binder.Scope.SPECIFY -> {
+                val binderId = binder.id.takeIf { it.isNotBlank() }
+                require(binderId != null) {
+                    "Scope of @Binder on bean '$beanName' is ${Binder.Scope.SPECIFY}, " +
+                        "but the required property 'id' is empty"
+                }
+                builder.addBinderFactory(binderId, factory)
+            }
+
+            Binder.Scope.DEFAULT -> {
+                val binderId = binder.id.takeIf { it.isNotBlank() }
+                if (binderId != null) {
+                    builder.addBinderFactory(binderId, factory)
+                } else {
+                    builder.addBinderFactory(factory)
+                }
+            }
+        }
+    }
+
+
+    public companion object {
+        public const val BINDER_MANAGER_BEAN_NAME: String =
+            "love.forte.simbot.spring.configuration.binder.resolvedBinderManager"
+
+    }
+}
+

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/binder/SpringAutoInjectBinderFactory.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/binder/SpringAutoInjectBinderFactory.kt
@@ -1,0 +1,49 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.configuration.binder
+
+import love.forte.simbot.quantcat.common.binder.ParameterBinderFactory
+import love.forte.simbot.quantcat.common.binder.ParameterBinderResult
+import org.springframework.beans.factory.BeanFactory
+import kotlin.reflect.KParameter
+
+
+/**
+ *
+ * @author ForteScarlet
+ */
+public class SpringAutoInjectBinderFactory(
+    private val factory: BeanFactory
+) : ParameterBinderFactory {
+
+    override fun resolveToBinder(context: ParameterBinderFactory.Context): ParameterBinderResult {
+        val parameter = context.parameter
+        // skip instance
+        if (parameter.kind == KParameter.Kind.INSTANCE) return ParameterBinderResult.empty()
+
+
+
+        TODO()
+    }
+}

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/config/SimbotApplicationConfigurationProcessor.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/config/SimbotApplicationConfigurationProcessor.kt
@@ -1,0 +1,99 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.configuration.config
+
+import love.forte.simbot.logger.LoggerFactory
+import love.forte.simbot.logger.logger
+import love.forte.simbot.spring.common.application.SpringApplicationBuilder
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+
+/**
+ * 对 [SpringApplicationBuilder] 进行处理的处理器。
+ * 默认逻辑会尝试加载所有的 [SimbotApplicationConfigurationConfigurer]
+ * 并使用它们。
+ *
+ * @author ForteScarlet
+ */
+public fun interface SimbotApplicationConfigurationProcessor {
+    /**
+     * 处理 [builder]
+     */
+    public fun process(builder: SpringApplicationBuilder)
+}
+
+/**
+ * 在 [SimbotApplicationConfigurationProcessor] 的默认行为中
+ * 会被批量加载并依次处理 [SpringApplicationBuilder]
+ *
+ */
+public fun interface SimbotApplicationConfigurationConfigurer {
+    /**
+     * 配置 [builder]
+     */
+    public fun configure(builder: SpringApplicationBuilder)
+}
+
+/**
+ * 用于配置 [SimbotApplicationConfigurationProcessor]
+ * 的默认实现 [DefaultSimbotApplicationConfigurationProcessor]
+ * 的配置器。
+ */
+@Configuration(proxyBeanMethods = false)
+public open class DefaultSimbotApplicationConfigurationProcessorConfiguration {
+    @Bean(DEFAULT_SIMBOT_APPLICATION_CONFIGURATION_PROCESSOR_BEAN_NAME)
+    @ConditionalOnMissingBean(SimbotApplicationConfigurationProcessor::class)
+    public open fun defaultSimbotApplicationConfigurationProcessor(
+        @Autowired(required = false) configurers: List<SimbotApplicationConfigurationConfigurer>? = null
+    ): DefaultSimbotApplicationConfigurationProcessor =
+        DefaultSimbotApplicationConfigurationProcessor(configurers ?: emptyList())
+
+    public companion object {
+        public const val DEFAULT_SIMBOT_APPLICATION_CONFIGURATION_PROCESSOR_BEAN_NAME: String =
+            "love.forte.simbot.spring.configuration.config.defaultSimbotApplicationConfigurationProcessor"
+    }
+}
+
+/**
+ * [SimbotApplicationConfigurationProcessor] 的默认逻辑实现，会使用所有的 [SimbotApplicationConfigurationConfigurer]
+ * 并使用它们进行处理。
+ *
+ */
+public open class DefaultSimbotApplicationConfigurationProcessor(
+    private val configurers: List<SimbotApplicationConfigurationConfigurer>
+) : SimbotApplicationConfigurationProcessor {
+    override fun process(builder: SpringApplicationBuilder) {
+        configurers.forEach {
+            it.configure(builder)
+            logger.debug("Configured builder {} by {}", builder, it)
+        }
+    }
+
+    public companion object {
+        private val logger = LoggerFactory.logger<DefaultSimbotApplicationConfigurationProcessor>()
+    }
+}

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/listener/KFunctionEventListener.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/listener/KFunctionEventListener.kt
@@ -1,0 +1,101 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.configuration.listener
+
+import love.forte.simbot.common.attribute.Attribute
+import love.forte.simbot.common.attribute.AttributeMap
+import love.forte.simbot.common.attribute.AttributeMapContainer
+import love.forte.simbot.common.attribute.attribute
+import love.forte.simbot.event.Event
+import love.forte.simbot.event.EventListenerContext
+import love.forte.simbot.quantcat.common.binder.FunctionalBindableEventListener
+import love.forte.simbot.quantcat.common.binder.ParameterBinder
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+
+
+public abstract class KFunctionEventListener(instance: Any?, caller: KFunction<*>) : FunctionalBindableEventListener(
+    instance,
+    caller
+) {
+    public abstract val attributes: AttributeMap
+
+    @Suppress("MemberVisibilityCanBePrivate")
+    public companion object {
+        /**
+         * [RawFunctionAttribute] 的属性名
+         */
+        public const val RAW_FUNCTION_ATTRIBUTE_NAME: String = "$\$RAW_FUNCTION$"
+
+        /**
+         * 记录 [KFunctionEventListener] 内含原始函数的属性
+         */
+        @JvmField
+        public val RawFunctionAttribute: Attribute<KFunction<*>> = attribute(RAW_FUNCTION_ATTRIBUTE_NAME)
+
+        /**
+         * [RawBindersAttribute] 的属性名
+         */
+        public const val RAW_BINDERS_ATTRIBUTE_NAME: String = "$\$RAW_BINDERS$"
+
+        /**
+         * 记录 [KFunctionEventListener] 内含的最终绑定器集的属性。
+         */
+        @JvmField
+        public val RawBindersAttribute: Attribute<Iterable<ParameterBinder>> = attribute(RAW_BINDERS_ATTRIBUTE_NAME)
+
+        /**
+         * [RawListenTargetAttribute] 的属性名
+         */
+        public const val RAW_LISTEN_TARGET_ATTRIBUTE_NAME: String = "$\$RAW_LISTEN_TARGET$"
+
+        /**
+         * 记录 [KFunctionEventListener] 内含的最终的监听目标事件的类型的属性。
+         */
+        @JvmField
+        public val RawListenTargetAttribute: Attribute<KClass<out Event>> =
+            attribute(RAW_LISTEN_TARGET_ATTRIBUTE_NAME)
+    }
+}
+
+
+/**
+ *
+ * @author ForteScarlet
+ */
+internal class KFunctionEventListenerImpl(
+    instance: Any?,
+    caller: KFunction<*>,
+    override val binders: Array<ParameterBinder>,
+    override val attributes: AttributeMap,
+    private val matcher: suspend (EventListenerContext) -> Boolean
+) : KFunctionEventListener(instance, caller), AttributeMapContainer {
+    override suspend fun match(context: EventListenerContext): Boolean = matcher(context)
+
+    override val attributeMap: AttributeMap
+        get() = attributes
+
+    override fun toString(): String =
+        "KFunctionEventListener(caller=$caller, attributes=$attributes)"
+}

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/listener/KFunctionEventListenerProcessor.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/listener/KFunctionEventListenerProcessor.kt
@@ -1,0 +1,791 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.configuration.listener
+
+import love.forte.simbot.ability.EventMentionAware
+import love.forte.simbot.ability.MentionedTargetAware
+import love.forte.simbot.annotations.InternalSimbotAPI
+import love.forte.simbot.common.PriorityConstant
+import love.forte.simbot.common.attribute.MutableAttributeMap
+import love.forte.simbot.common.attribute.mutableAttributeMapOf
+import love.forte.simbot.common.attribute.set
+import love.forte.simbot.common.function.ConfigurerFunction
+import love.forte.simbot.common.id.StringID.Companion.ID
+import love.forte.simbot.common.id.literal
+import love.forte.simbot.definition.*
+import love.forte.simbot.event.*
+import love.forte.simbot.event.EventResult.Companion.invalid
+import love.forte.simbot.logger.LoggerFactory
+import love.forte.simbot.logger.logger
+import love.forte.simbot.message.At
+import love.forte.simbot.quantcat.common.annotations.*
+import love.forte.simbot.quantcat.common.binder.*
+import love.forte.simbot.quantcat.common.binder.impl.EmptyBinder
+import love.forte.simbot.quantcat.common.binder.impl.MergedBinder
+import love.forte.simbot.quantcat.common.filter.FilterMode
+import love.forte.simbot.quantcat.common.filter.FilterProperties
+import love.forte.simbot.quantcat.common.filter.FilterTargetsProperties
+import love.forte.simbot.quantcat.common.filter.MultiFilterMatchType
+import love.forte.simbot.quantcat.common.interceptor.AnnotationEventInterceptorFactory
+import love.forte.simbot.quantcat.common.keyword.EmptyKeyword
+import love.forte.simbot.quantcat.common.keyword.KeywordListAttribute
+import love.forte.simbot.quantcat.common.keyword.SimpleKeyword
+import love.forte.simbot.spring.common.MultipleIncompatibleTypesEventException
+import love.forte.simbot.spring2.utils.findMergedAnnotationSafely
+import love.forte.simbot.spring2.utils.findRepeatableMergedAnnotationSafely
+import org.springframework.beans.factory.NoSuchBeanDefinitionException
+import org.springframework.context.ApplicationContext
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+import kotlin.reflect.KParameter
+import kotlin.reflect.KVisibility
+import kotlin.reflect.full.createInstance
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.findAnnotations
+import kotlin.reflect.full.isSubclassOf
+import kotlin.reflect.jvm.isAccessible
+import kotlin.reflect.jvm.javaMethod
+
+
+private data class EventFilterData(
+    val priority: Int,
+    val matcher: MatcherFunc
+)
+
+private data class EventInterceptorData(
+    val configurer: ConfigurerFunction<EventInterceptorRegistrationProperties>?,
+    val interceptor: EventInterceptor
+)
+
+
+/**
+ *
+ * @author ForteScarlet
+ */
+internal class KFunctionEventListenerProcessor {
+    private val instanceCache = ConcurrentHashMap<KClass<*>, Any>()
+
+    fun process(
+        beanName: String,
+        function: KFunction<*>,
+        listenerAnnotation: Listener,
+        applyBinder: ApplyBinder?,
+        applicationContext: ApplicationContext,
+        binderManager: BinderManager
+    ): SimbotEventListenerResolver {
+        val id = listenerAnnotation.id
+        val priority = listenerAnnotation.priority
+        val listenTarget = function.listenTarget()
+        val listenerAttributeMap = mutableAttributeMapOf(ConcurrentHashMap())
+        val binders = function.resolveBinders(applicationContext, binderManager, applyBinder)
+
+        // attributes
+        listenerAttributeMap[KFunctionEventListener.RawFunctionAttribute] = function
+        listenerAttributeMap[KFunctionEventListener.RawBindersAttribute] = binders.toList()
+        listenerAttributeMap[KFunctionEventListener.RawListenTargetAttribute] = listenTarget
+
+        val matchers = mutableListOf<MatcherFunc>()
+        matchers.add { listenTarget.isInstance(it.event) }
+
+        val filters = mutableListOf<EventFilterData>()
+        val interceptors = mutableListOf<EventInterceptorData>()
+
+        // filters & interceptors
+        function.filtersAndInterceptorsByFilterAnnotations(
+            applicationContext,
+            listenerAttributeMap,
+            onFilter = { filter ->
+                filters.add(filter)
+            },
+            onInterceptor = { interceptor ->
+                interceptors.add(interceptor)
+            }
+        )
+
+        filters.sortBy { it.priority }
+        filters.forEach {
+            matchers.add(it.matcher)
+        }
+
+        // to array
+        val finalMatchers = matchers.toTypedArray()
+
+
+
+        return SimbotEventListenerResolver { application ->
+            val instance = applicationContext.getBean(beanName)
+            if (function.visibility != KVisibility.PUBLIC) {
+                function.isAccessible = true
+            }
+
+            val listener = KFunctionEventListenerImpl(
+                instance = instance,
+                caller = function,
+                binders = binders.toTypedArray(),
+                attributes = listenerAttributeMap,
+                matcher = { c -> finalMatchers.all { it.invoke(c) } },
+            )
+
+            application.eventDispatcher.register(
+                {
+                    this.priority = priority
+                    interceptors.forEach { (config, interceptor) ->
+                        addInterceptor(config, interceptor)
+                    }
+                },
+                listener
+            )
+
+            logger.debug("Registered listener {} (annotated id={}) from bean named {}", listener, id, beanName)
+        }
+    }
+
+    @OptIn(InternalSimbotAPI::class)
+    private fun KFunction<*>.resolveBinders(
+        applicationContext: ApplicationContext,
+        binderManager: BinderManager,
+        applyBinder: ApplyBinder?
+    ): List<ParameterBinder> {
+        val binderFactories = binderManager.globals.toMutableList()
+        if (applyBinder != null) {
+            for (bid in applyBinder.value) {
+                val b = binderManager[bid]
+                if (b != null) {
+                    binderFactories.add(b)
+                } else {
+                    logger.warn("Applied binder factory id [{}] not found, skip it.", bid)
+                }
+            }
+
+            for (factoryType in applyBinder.factories) {
+                val b = resolveBinderFactoryInstance(instanceCache, applicationContext, factoryType)
+                binderFactories.add(b)
+            }
+        }
+
+        return binderFactoriesToBinders(binderFactories.apply { sortBy { it.priority } })
+    }
+
+    private fun KFunction<*>.binderFactoriesToBinders(
+        factories: List<ParameterBinderFactory>
+    ): List<ParameterBinder> {
+        val binders = parameters.map { parameter ->
+            val bindList = mutableListOf<ParameterBinderResult.NotEmpty>()
+            val bindSpareList = mutableListOf<ParameterBinderResult.NotEmpty>()
+
+            val bindContext = ParameterBinderFactoryContextImpl(
+                this,
+                parameter
+            )
+
+            for (factory in factories) {
+                when (val result = factory.resolveToBinder(bindContext)) {
+                    is ParameterBinderResult.Empty -> continue
+                    is ParameterBinderResult.NotEmpty -> {
+                        // not empty.
+                        when (result) {
+                            is ParameterBinderResult.Normal -> {
+                                if (bindList.isEmpty() || bindList.first() !is ParameterBinderResult.Only) {
+                                    bindList.add(result)
+                                }
+                            }
+
+                            is ParameterBinderResult.Only -> {
+                                if (bindList.isNotEmpty() && bindList.first() is ParameterBinderResult.Only) {
+                                    // 上一个也是Only.
+                                    bindList[0] = result
+                                } else {
+                                    bindList.clear() // clear all
+                                    bindList.add(result)
+                                }
+                            }
+
+                            is ParameterBinderResult.Spare -> {
+                                bindSpareList.add(result)
+                            }
+                        }
+                    }
+                }
+            }
+            bindList.sortBy { it.priority }
+            bindSpareList.sortBy { it.priority }
+
+            logger.trace(
+                "There are actually {} normal binders bound to parameter [{}]. the binders: {}",
+                bindList.size,
+                parameter,
+                bindList
+            )
+            logger.trace(
+                "There are actually {} spare binders bound to parameter [{}]. the binders: {}",
+                bindSpareList.size,
+                parameter,
+                bindSpareList
+            )
+
+            when {
+                bindList.isEmpty() && bindSpareList.isEmpty() -> {
+                    // no binder.
+                    EmptyBinder(parameter)
+                }
+
+                bindList.isEmpty() -> {
+                    // spare as normal.
+                    MergedBinder(bindSpareList.map { it.binder }, emptyList(), parameter)
+                }
+
+                else -> {
+                    MergedBinder(
+                        bindList.map { it.binder },
+                        bindSpareList.map { it.binder }.ifEmpty { emptyList() },
+                        parameter
+                    )
+                }
+            }
+        }
+
+        return binders
+    }
+
+    data class Data(val properties: FilterProperties, val matcher: MatcherFunc?)
+
+    private inline fun KFunction<*>.filtersAndInterceptorsByFilterAnnotations(
+        applicationContext: ApplicationContext,
+        listenerAttributeMap: MutableAttributeMap,
+        onFilter: (EventFilterData) -> Unit,
+        onInterceptor: (EventInterceptorData) -> Unit,
+    ) {
+        // filter annotations
+        val filterAnnotations =
+            javaMethod?.findRepeatableMergedAnnotationSafely<Filter>() ?: findAnnotations<Filter>().toSet()
+        val multiFilter = javaMethod?.findMergedAnnotationSafely<MultiFilter>() ?: findAnnotation<MultiFilter>()
+        val matchType = multiFilter?.matchType ?: MultiFilterMatchType.Default
+
+        val grouped =
+            filterAnnotations
+                .groupingBy { f -> f.mode }
+                .aggregate<Filter, FilterMode, MutableList<Data>> { _, accumulator, element, _ ->
+                    val prop = element.toProperties()
+
+                    val keywordMatchFunc = keywordMatcher(listenerAttributeMap, prop)
+                    val targetsFilterFunc = prop.targets.firstOrNull()?.let(::targetFilterMatcher)
+
+                    val finalMatcherFunc = when {
+                        keywordMatchFunc == null && targetsFilterFunc == null -> null
+                        targetsFilterFunc == null -> keywordMatchFunc
+                        keywordMatchFunc == null -> targetsFilterFunc
+                        else -> {
+                            { c ->
+                                targetsFilterFunc(c) && keywordMatchFunc(c)
+                            }
+                        }
+                    }
+
+                    val data = Data(prop, finalMatcherFunc)
+                    val list: MutableList<Data> =
+                        accumulator?.also { it.add(data) } ?: mutableListOf(data)
+
+                    list
+                }
+
+        grouped[FilterMode.IN_LISTENER]?.mapNotNull {
+            if (it.matcher == null) {
+                return@mapNotNull null
+            }
+
+            EventFilterData(it.properties.priority, it.matcher)
+        }?.also { filterMatchers ->
+            when {
+                filterMatchers.size == 1 -> onFilter(filterMatchers.first())
+                filterMatchers.size > 1 -> merge(matchType, filterMatchers)
+            }
+        }
+
+        grouped[FilterMode.INTERCEPTOR]?.forEach { (properties, matcher) ->
+            if (matcher != null) {
+                val priority = properties.priority
+                val interceptor = EventInterceptor {
+                    if (matcher.invoke(eventListenerContext)) invoke() else invalid()
+                }
+
+                onInterceptor(
+                    EventInterceptorData({
+                        this.priority = priority
+                    }, interceptor)
+                )
+            }
+        }
+
+        // resolve listener-level interceptor
+        resolveListenerInterceptor(applicationContext, onInterceptor)
+    }
+
+    private inline fun KFunction<*>.resolveListenerInterceptor(
+        applicationContext: ApplicationContext,
+        onInterceptor: (EventInterceptorData) -> Unit,
+    ) {
+        val cache = mutableMapOf<KClass<*>, AnnotationEventInterceptorFactory>()
+
+        val interceptors =
+            javaMethod?.findRepeatableMergedAnnotationSafely<Interceptor>() ?: findAnnotations<Interceptor>().toSet()
+        for (interceptorAnno in interceptors) {
+            val factoryType = interceptorAnno.value
+            val errs = ArrayDeque<Throwable>()
+
+            var factory: AnnotationEventInterceptorFactory? = null
+
+            try {
+                factory = applicationContext.getBean(factoryType.java)
+            } catch (noBean: NoSuchBeanDefinitionException) {
+                logger.debug(
+                    "Type of factory {} in @Interceptor on function {} " +
+                        "was not found in spring ApplicationContext, " +
+                        "try to create an instance",
+                    factoryType,
+                    this
+                )
+                errs.add(noBean)
+            }
+
+            // try to create an instance
+            if (factory == null) {
+                factoryType.objectInstance?.also { factory = it }
+            }
+
+            if (factory == null) {
+                runCatching {
+                    factory = cache.computeIfAbsent(factoryType) { factoryType.createInstance() }
+                }.onFailure { e ->
+                    errs.add(e)
+                }
+            }
+
+            val f = factory
+
+            if (f == null) {
+                val msg =
+                    "Can't to get or create an instance for listener " +
+                        "annotated interceptor factory $factoryType on function $this"
+
+                throw ListenerInterceptorFactoryInstantiationFailedException(msg).apply {
+                    errs.forEach { addSuppressed(it) }
+                }
+            }
+
+            val result = f.create(AnnotationEventInterceptorFactoryContextImpl(this, interceptorAnno.priority))
+                ?: continue
+
+            onInterceptor(EventInterceptorData(result.configuration, result.interceptor))
+        }
+
+    }
+
+
+    companion object {
+        private val logger = LoggerFactory.logger<KFunctionEventListenerProcessor>()
+    }
+}
+
+private class AnnotationEventInterceptorFactoryContextImpl(
+    override val function: KFunction<*>,
+    override val priority: Int
+) : AnnotationEventInterceptorFactory.Context {
+    @Suppress("UNCHECKED_CAST")
+    override fun <A : Annotation> findAnnotation(type: KClass<A>): A? =
+        function.javaMethod?.findMergedAnnotationSafely(type)
+            ?: function.annotations.firstOrNull { type.isInstance(it) } as? A
+
+    override fun <A : Annotation> findAnnotations(type: KClass<A>): List<A> =
+        function.javaMethod?.findRepeatableMergedAnnotationSafely(type)?.toList()
+            ?: function.findAnnotations(type)
+}
+
+private class ListenerInterceptorFactoryInstantiationFailedException(message: String?) : RuntimeException(message)
+
+
+private data class ParameterBinderFactoryContextImpl(
+    override val source: KFunction<*>,
+    override val parameter: KParameter
+) : ParameterBinderFactory.Context
+
+
+@Suppress("UNCHECKED_CAST")
+@OptIn(InternalSimbotAPI::class)
+private fun resolveBinderFactoryInstance(
+    instanceCache: MutableMap<KClass<*>, Any>,
+    applicationContext: ApplicationContext,
+    type: KClass<out BaseParameterBinderFactory<*>>
+): ParameterBinderFactory {
+    if (!type.isSubclassOf(ParameterBinderFactory::class)) {
+        throw IllegalArgumentException(
+            "The types in ApplyBinder.factories must be ParameterBinderFactory, " +
+                "but found: $type"
+        )
+    }
+
+    type as KClass<out ParameterBinderFactory>
+
+    val instance = try {
+        applicationContext.getBean(type.java)
+    } catch (ignore: NoSuchBeanDefinitionException) {
+        null
+    }
+
+    if (instance != null) {
+        return instance
+    }
+
+    val objInstance = type.objectInstance
+    if (objInstance != null) {
+        return objInstance
+    }
+
+    // try to create instance
+    return runCatching {
+        instanceCache.computeIfAbsent(type) { it.createInstance() } as ParameterBinderFactory
+    }.getOrElse { e ->
+        throw IllegalArgumentException("Can't create instance for $type", e)
+    }
+}
+
+
+/**
+ * 解析此监听函数所期望监听的事件列表。
+ */
+@Suppress("UNCHECKED_CAST")
+private fun KFunction<*>.listenTarget(): KClass<out Event> {
+    val typeLink = mutableListOf<KClass<*>>()
+    var minType: KClass<out Event>? = null
+
+    parameters.asSequence()
+        .filter { it.kind != KParameter.Kind.INSTANCE }
+        .filter { (it.type.classifier as? KClass<*>)?.isSubclassOf(Event::class) == true }
+        .forEach {
+            val e = it.type.classifier as KClass<out Event>
+            val m = minType
+            when {
+                m == null -> {
+                    minType = e
+                    typeLink.add(e)
+                }
+
+                e == m -> {
+                    // do nothing.
+                }
+
+                e.isSubclassOf(m) -> {
+                    minType = e
+                    typeLink.add(e)
+                }
+
+                else -> {
+                    throw MultipleIncompatibleTypesEventException(
+                        buildString {
+                            append("Current Event types link of function [${this@listenTarget}] is: \n[")
+                            typeLink.forEachIndexed { index, t ->
+                                append("(")
+                                append(t)
+                                append(")")
+                                if (index != typeLink.lastIndex) {
+                                    append(" -> ")
+                                }
+                            }
+                            append("], \nbut now: ")
+                            append(it.type.classifier).append("(").append(it)
+                            append("), it !is ").append(typeLink.last())
+                        }
+                    )
+                }
+            }
+        }
+
+    return minType ?: Event::class
+}
+
+
+private fun keywordMatcher(listenerAttributeMap: MutableAttributeMap, fp: FilterProperties): MatcherFunc? {
+    val value = fp.value
+
+    if (value.isEmpty()) return null
+
+    val matchType = fp.matchType
+    val keyword = if (value.isEmpty()) EmptyKeyword else SimpleKeyword(value, matchType.isPlainText)
+
+    listenerAttributeMap.computeIfAbsent(KeywordListAttribute) { CopyOnWriteArrayList() }.add(keyword)
+
+    listenerAttributeMap[KeywordListAttribute]
+
+    val ifNullPass = fp.ifNullPass
+
+    return m@{ c ->
+        val content = c.plainText
+
+        // 存在匹配词, 尝试匹配
+        if (keyword !== EmptyKeyword) {
+            if (content != null) {
+                if (!matchType.match(keyword, content)) {
+                    return@m false
+                }
+            } else {
+                return@m ifNullPass
+            }
+        }
+
+        // 匹配关键词本身没有, 直接放行.
+        true
+    }
+}
+
+
+private fun targetFilterMatcher(target: FilterTargetsProperties): MatcherFunc? {
+    val matchers = mutableListOf<MatcherFunc>()
+
+    // components
+    with(target.components.toSet()) {
+        if (isNotEmpty()) {
+            matchers.add { c ->
+                val event = c.context.event
+                event !is ComponentEvent || contains(event.component.id)
+            }
+        }
+    }
+
+    // bots
+    with(target.bots.map { it.ID }) {
+        if (isNotEmpty()) {
+            matchers.add { c ->
+                val event = c.context.event
+                event !is BotEvent || all { b -> event.bot.isMe(b) }
+            }
+        }
+    }
+
+    // authors
+    with(target.authors.toSet()) {
+        if (isNotEmpty()) {
+            matchers.add { c ->
+                val event = c.context.event
+                event !is MessageEvent || contains(event.authorId.literal)
+            }
+        }
+    }
+
+    //region actors
+    val actors = target.actors.toSet()
+    val chatRooms = target.chatRooms.toSet()
+    val organizations = target.organizations.toSet()
+    val groups = target.groups.toSet()
+    val guilds = target.guilds.toSet()
+    val contacts = target.contacts.toSet()
+
+    if (
+        actors.isNotEmpty() ||
+        chatRooms.isNotEmpty() ||
+        organizations.isNotEmpty() ||
+        groups.isNotEmpty() ||
+        guilds.isNotEmpty() ||
+        contacts.isNotEmpty()
+    ) {
+        matchers.add { c ->
+            val event = c.event
+            val helper = ContentEventMatchHelper(event)
+
+            with(actors) {
+                if (isNotEmpty()) {
+                    helper.content<Actor>()?.also { ac ->
+                        if (!contains(ac.id.literal)) return@add false
+                    }
+                }
+            }
+
+            with(chatRooms) {
+                if (isNotEmpty()) {
+                    helper.content<ChatRoom>()?.also { cr ->
+                        if (!contains(cr.id.literal)) return@add false
+                    }
+                }
+            }
+
+            with(organizations) {
+                if (isNotEmpty()) {
+                    helper.org<Organization>()?.also { o ->
+                        if (!contains(o.id.literal)) return@add false
+                    }
+                }
+            }
+
+            with(groups) {
+                if (isNotEmpty()) {
+                    helper.org<ChatGroup>()?.also { g ->
+                        if (!contains(g.id.literal)) return@add false
+                    }
+                }
+            }
+
+            with(guilds) {
+                if (isNotEmpty()) {
+                    helper.org<Guild>()?.also { g ->
+                        if (!contains(g.id.literal)) return@add false
+                    }
+                }
+            }
+
+            with(contacts) {
+                if (isNotEmpty()) {
+                    helper.content<Contact>()?.also { c ->
+                        if (!contains(c.id.literal)) return@add false
+                    }
+                }
+            }
+
+            true
+        }
+    }
+    //endregion
+
+    // ats
+    with(target.ats) {
+        if (isNotEmpty()) {
+            val strIdSet = toSet()
+            val idArray = map { it.ID }.toTypedArray()
+
+            matchers.add { c ->
+                val event = c.event
+                if (event !is MessageEvent) {
+                    return@add false
+                }
+
+                val content = event.messageContent
+                if (content is MentionedTargetAware) {
+                    return@add idArray.all { t -> content.isMentioned(t) }
+                }
+
+                content.messages.any {
+                    it is At && strIdSet.contains(it.target.literal)
+                }
+            }
+        }
+    }
+
+    // at bot
+    if (target.atBot) {
+        matchers.add { c ->
+            val event = c.event
+            if (event !is BotEvent) return@add true
+
+            val bot = event.bot
+            if (bot is EventMentionAware) {
+                bot.isMention(event)
+            } else {
+                if (event !is MessageEvent) {
+                    return@add true
+                }
+
+                event.messageContent.messages.any {
+                    it is At && bot.isMe(it.target)
+                }
+            }
+        }
+
+    }
+
+    if (matchers.isEmpty()) return null
+    if (matchers.size == 1) return matchers.first()
+
+    val array = matchers.toTypedArray()
+    return { context ->
+        array.all { it.invoke(context) }
+    }
+}
+
+private class ContentEventMatchHelper(private val event: Event) {
+    /**
+     * 如果事件是 [ContentEvent], 可初始化
+     */
+    var content: Any? = null
+
+    /**
+     * 如果事件是 [OrganizationSourceEvent] 或 [OrganizationEvent], 可初始化
+     */
+    var org: Organization? = null
+
+    suspend inline fun <reified T> content(): T? {
+        if (content == null) {
+            if (event !is ContentEvent) {
+                return null
+            }
+
+            content = event.content().also { c ->
+                if (org == null && event is OrganizationEvent) {
+                    org = c as Organization
+                }
+            }
+        }
+
+        return content as? T
+    }
+
+    suspend inline fun <reified T : Organization> org(): T? {
+        if (org == null) {
+            if (content is Organization) {
+                org = content as Organization
+                return org as? T
+            }
+
+            if (event is OrganizationEvent) {
+                org = event.content().also {
+                    if (content == null) {
+                        content = org
+                    }
+                }
+            }
+            if (event is OrganizationSourceEvent) {
+                org = event.source()
+            }
+        }
+
+        return org as? T
+    }
+}
+
+private fun merge(type: MultiFilterMatchType, func: Collection<EventFilterData>): EventFilterData {
+    val funcArray = func.sortedBy { it.priority }.map { it.matcher }.toTypedArray()
+    return when (type) {
+        MultiFilterMatchType.ANY -> EventFilterData(PriorityConstant.DEFAULT) { c ->
+            funcArray.any { m -> m.invoke(c) }
+        }
+
+        MultiFilterMatchType.ALL -> EventFilterData(PriorityConstant.DEFAULT) { c ->
+            funcArray.all { m -> m.invoke(c) }
+        }
+
+        MultiFilterMatchType.NONE -> EventFilterData(PriorityConstant.DEFAULT) { c ->
+            funcArray.none { m -> m.invoke(c) }
+        }
+    }
+}
+
+private typealias MatcherFunc = suspend (EventListenerContext) -> Boolean

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/listener/SimbotEventListenerFunctionProcessor.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/configuration/listener/SimbotEventListenerFunctionProcessor.kt
@@ -1,0 +1,154 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.configuration.listener
+
+import love.forte.simbot.application.Application
+import love.forte.simbot.event.EventListener
+import love.forte.simbot.logger.LoggerFactory
+import love.forte.simbot.logger.logger
+import love.forte.simbot.quantcat.common.annotations.ApplyBinder
+import love.forte.simbot.quantcat.common.annotations.Listener
+import love.forte.simbot.quantcat.common.binder.BinderManager
+import love.forte.simbot.spring2.utils.findMergedAnnotationSafely
+import love.forte.simbot.spring2.utils.getKotlinFunctionSafely
+import love.forte.simbot.spring2.utils.getTargetTypeSafely
+import love.forte.simbot.spring2.utils.selectMethodsSafely
+import org.springframework.aop.scope.ScopedProxyUtils
+import org.springframework.beans.factory.config.BeanDefinition
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.beans.factory.support.BeanDefinitionBuilder
+import org.springframework.beans.factory.support.BeanDefinitionRegistry
+import org.springframework.context.ApplicationContext
+import org.springframework.context.ApplicationContextAware
+import org.springframework.context.annotation.ConfigurationClassPostProcessor
+import org.springframework.core.annotation.AnnotationUtils
+import java.lang.reflect.Method
+import kotlin.reflect.KFunction
+
+/**
+ * 用于通过 [Application] 注册 [EventListener] 的函数接口。
+ * 主要是用于通过 [SimbotEventListenerFunctionProcessor] 生成。
+ */
+public fun interface SimbotEventListenerResolver {
+    public fun resolve(application: Application)
+}
+
+/**
+ * 将所有 bean 中标记了 [Listener] 的函数解析为 [SimbotEventListenerResolver]
+ *
+ * @author ForteScarlet
+ */
+public open class SimbotEventListenerFunctionProcessor : ApplicationContextAware, ConfigurationClassPostProcessor() {
+    private val processor = KFunctionEventListenerProcessor()
+
+    private lateinit var applicationContext: ApplicationContext
+    private lateinit var registry: BeanDefinitionRegistry
+
+    override fun setApplicationContext(applicationContext: ApplicationContext) {
+        this.applicationContext = applicationContext
+    }
+
+    override fun postProcessBeanDefinitionRegistry(registry: BeanDefinitionRegistry) {
+        this.registry = registry
+    }
+
+    override fun postProcessBeanFactory(beanFactory: ConfigurableListableBeanFactory) {
+        beanFactory.beanNamesIterator.asSequence()
+            .filter { !ScopedProxyUtils.isScopedTarget(it) }
+            .forEach { beanName ->
+                val beanType = beanFactory.getTargetTypeSafely(beanName) ?: return@forEach
+
+                beanFactory.processListener(beanName, beanType)
+            }
+    }
+
+
+    private fun ConfigurableListableBeanFactory.processListener(
+        beanName: String,
+        beanType: Class<*>,
+    ) {
+        if (!AnnotationUtils.isCandidateClass(beanType, Listener::class.java)) {
+            return
+        }
+
+        val annotatedMethods = beanType.selectMethodsSafely<Listener>()?.takeIf { it.isNotEmpty() } ?: return
+
+        logger.debug("Resolve candidate class {} bean named {} with any @Listener methods", beanType, beanName)
+
+        annotatedMethods.forEach { (method, listenerAnnotation) ->
+            val function = method.getKotlinFunctionSafely() ?: return@forEach
+
+            val applyBinder = method.findMergedAnnotationSafely<ApplyBinder>()
+
+            val eventListenerResolverDescription =
+                resolveMethodToListener(beanName, function, listenerAnnotation, applyBinder)
+
+            val beanDefinition = resolveToBeanDefinition(eventListenerResolverDescription)
+            val beanDefinitionName = generatedListenerBeanName(beanName, method)
+
+            logger.debug(
+                "Generate event listener resolver bean definition {} named {}",
+                beanDefinition,
+                beanDefinitionName
+            )
+
+            registry.registerBeanDefinition(beanDefinitionName, beanDefinition)
+        }
+    }
+
+    private fun ConfigurableListableBeanFactory.resolveMethodToListener(
+        beanName: String,
+        function: KFunction<*>,
+        listenerAnnotation: Listener,
+        applyBinder: ApplyBinder?,
+    ): (() -> SimbotEventListenerResolver) {
+        return {
+            val binderManagerInstance = getBean(BinderManager::class.java)
+            processor.process(
+                beanName,
+                function,
+                listenerAnnotation,
+                applyBinder,
+                applicationContext,
+                binderManagerInstance
+            )
+        }
+    }
+
+    private fun resolveToBeanDefinition(instanceSupplier: () -> SimbotEventListenerResolver): BeanDefinition {
+        return BeanDefinitionBuilder.genericBeanDefinition(
+            SimbotEventListenerResolver::class.java,
+            instanceSupplier
+        ).setPrimary(false)
+            .beanDefinition
+    }
+
+    public companion object {
+        private val logger = LoggerFactory.logger<SimbotEventListenerFunctionProcessor>()
+    }
+}
+
+
+private fun generatedListenerBeanName(beanName: String, method: Method): String =
+    "$beanName${method.toGenericString()}#GENERATED_LISTENER"

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/utils/ConfigurableListableBeanFactoryUtils.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/utils/ConfigurableListableBeanFactoryUtils.kt
@@ -1,0 +1,91 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.utils
+
+import org.springframework.aop.framework.autoproxy.AutoProxyUtils
+import org.springframework.aop.scope.ScopedObject
+import org.springframework.aop.scope.ScopedProxyUtils
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.core.MethodIntrospector
+import org.springframework.core.annotation.AnnotatedElementUtils
+import java.lang.reflect.AnnotatedElement
+import java.lang.reflect.Method
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+import kotlin.reflect.jvm.kotlinFunction
+
+
+internal fun ConfigurableListableBeanFactory.getTargetTypeSafely(beanName: String): Class<*>? {
+    val type = kotlin.runCatching { AutoProxyUtils.determineTargetClass(this, beanName) }.getOrNull() ?: return null
+
+    return if (ScopedObject::class.java.isAssignableFrom(type)) {
+        return kotlin.runCatching {
+            AutoProxyUtils.determineTargetClass(this, ScopedProxyUtils.getTargetBeanName(beanName))
+        }.getOrElse { type }
+    } else {
+        type
+    }
+}
+
+internal fun Method.getKotlinFunctionSafely(): KFunction<*>? {
+    return kotlin.runCatching { kotlinFunction }.getOrNull()
+}
+
+internal inline fun <reified A : Annotation> Class<*>.selectMethodsSafely(): Map<Method, A>? {
+    return selectMethodsSafely(A::class)
+}
+
+internal inline fun <reified A : Annotation> AnnotatedElement.findMergedAnnotationSafely(): A? {
+    return findMergedAnnotationSafely(A::class)
+}
+
+internal inline fun <reified A : Annotation> AnnotatedElement.findRepeatableMergedAnnotationSafely(): Set<A>? {
+    return findRepeatableMergedAnnotationSafely(A::class)
+}
+
+@PublishedApi
+internal fun <A : Annotation> Class<*>.selectMethodsSafely(type: KClass<A>): Map<Method, A>? {
+    return runCatching {
+        MethodIntrospector.selectMethods(
+            this,
+            MethodIntrospector.MetadataLookup { method ->
+                AnnotatedElementUtils.findMergedAnnotation(method, type.java)
+            }
+        )
+    }.getOrNull()
+}
+
+@PublishedApi
+internal fun <A : Annotation> AnnotatedElement.findMergedAnnotationSafely(type: KClass<A>): A? {
+    return runCatching {
+        AnnotatedElementUtils.findMergedAnnotation(this, type.java)
+    }.getOrNull()
+}
+
+@PublishedApi
+internal fun <A : Annotation> AnnotatedElement.findRepeatableMergedAnnotationSafely(type: KClass<A>): Set<A>? {
+    return runCatching {
+        AnnotatedElementUtils.findMergedRepeatableAnnotations(this, type.java)
+    }.getOrNull()
+}

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/warn/MigratingSpringBootVersion.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/main/kotlin/love/forte/simbot/spring2/warn/MigratingSpringBootVersion.kt
@@ -1,0 +1,65 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.warn
+
+import love.forte.simbot.logger.LoggerFactory
+import org.springframework.boot.CommandLineRunner
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.Ordered
+
+
+/**
+ * 请尽可能考虑迁移至 Spring Boot v3.x.
+ * @author ForteScarlet
+ */
+@RequiresOptIn(
+    message = MIGRATING_SPRING_BOOT_VERSION_WARNING
+)
+@Retention(AnnotationRetention.BINARY)
+@MustBeDocumented
+public annotation class MigratingSpringBootVersion
+
+/**
+ * @suppress
+ */
+public const val MIGRATING_SPRING_BOOT_VERSION_WARNING: String =
+    "Spring Boot starter 的 v2 版本的维护成本较高，不会持续维护很久。" +
+        "并且现在 Spring Boot v2.7.x已经在 2023-11-24 结束支持，" +
+        "请考虑迁移至 Spring Boot v3.x。"
+
+/**
+ * 版本迁移警告。
+ */
+@Configuration(proxyBeanMethods = false)
+public open class MigratingSpringBootVersionWarningPrinter : CommandLineRunner, Ordered {
+    public companion object {
+        private val logger = LoggerFactory.getLogger(MigratingSpringBootVersionWarningPrinter::class)
+    }
+
+    override fun run(vararg args: String?) {
+        logger.warn(MIGRATING_SPRING_BOOT_VERSION_WARNING)
+    }
+
+    override fun getOrder(): Int = Ordered.HIGHEST_PRECEDENCE
+}

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/src/test/kotlin/love/forte/simbot/spring2/test/apptest/AppTests.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/src/test/kotlin/love/forte/simbot/spring2/test/apptest/AppTests.kt
@@ -1,0 +1,184 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring2.test.apptest
+
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.test.runTest
+import love.forte.simbot.annotations.ExperimentalSimbotAPI
+import love.forte.simbot.application.Application
+import love.forte.simbot.application.onLaunch
+import love.forte.simbot.common.id.IntID.Companion.ID
+import love.forte.simbot.event.*
+import love.forte.simbot.message.Face
+import love.forte.simbot.message.messagesOf
+import love.forte.simbot.message.toText
+import love.forte.simbot.plugin.PluginInstaller
+import love.forte.simbot.plugin.createPlugin
+import love.forte.simbot.quantcat.common.annotations.ContentTrim
+import love.forte.simbot.quantcat.common.annotations.Filter
+import love.forte.simbot.quantcat.common.annotations.Listener
+import love.forte.simbot.spring2.EnableSimbot
+import love.forte.simbot.spring2.configuration.SimbotPluginInstaller
+import love.forte.simbot.spring2.warn.MigratingSpringBootVersion
+import love.forte.simbot.test.event.TestMessageEvent
+import love.forte.simbot.test.message.TestMessageContent
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.stereotype.Component
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import kotlin.coroutines.resume
+
+@OptIn(MigratingSpringBootVersion::class)
+@EnableSimbot
+@SpringBootApplication
+open class AppTestMain
+
+private val eventChannel = Channel<Event> { }
+private lateinit var continuationDeferred: CompletableDeferred<CancellableContinuation<String?>>
+
+private const val VALUE = " 你好 "
+
+
+/**
+ *
+ * @author ForteScarlet
+ */
+@SpringBootTest(
+    classes = [AppTestMain::class, EventListener::class, TestPluginInstaller::class],
+    properties = [
+        "logging.level.love.forte.simbot=DEBUG"
+    ]
+)
+// @RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
+class AppTests {
+
+    @Autowired(required = false)
+    lateinit var application: Application
+
+    @Test
+    fun launchApplication() {
+        runTest {
+            val resumed = suspendCancellableCoroutine {
+                continuationDeferred = CompletableDeferred(it)
+                val event = TestMessageEvent().apply {
+                    messageContent = TestMessageContent(
+                        messages = messagesOf(VALUE.toText())
+                    )
+                }
+                application.launch { eventChannel.send(event) }
+            }
+
+            Assertions.assertEquals(VALUE.trim(), resumed)
+        }
+    }
+
+    @Test
+    fun launchApplicationDoubleText() {
+        runTest {
+            val resumed = suspendCancellableCoroutine {
+                continuationDeferred = CompletableDeferred(it)
+                val event = TestMessageEvent().apply {
+                    messageContent = TestMessageContent(
+                        messages = messagesOf(VALUE.toText(), Face(1.ID), VALUE.toText())
+                    )
+                }
+                application.launch { eventChannel.send(event) }
+            }
+
+            Assertions.assertEquals((VALUE + VALUE).trim(), resumed)
+        }
+    }
+}
+
+@Component
+private class TestPluginInstaller : SimbotPluginInstaller {
+    @OptIn(ExperimentalSimbotAPI::class)
+    override fun install(installer: PluginInstaller) {
+        val plugin = createPlugin("spring.test") {
+            val dispatcher = eventDispatcher
+            applicationEventRegistrar.onLaunch { app ->
+                app.launch {
+                    eventChannel.consumeEach { event ->
+                        app.launch {
+                            dispatcher.push(event)
+                                .onEachError { it.content.printStackTrace(System.out) }
+                                .onEachError { Assertions.assertInstanceOf(InternalTestError::class.java, it.content) }
+                                .filterNotError()
+                                .collect { result ->
+                                    Assertions.assertFalse(result is StandardEventResult.Error)
+
+                                    println("Event result: $result")
+                                }
+                        }
+                    }
+                }
+            }
+        }
+
+        installer.install(plugin)
+    }
+}
+
+
+@Component
+private class EventListener(private val application: Application) {
+
+    @Listener
+    @ContentTrim
+    private suspend fun Event.handle(context: EventListenerContext, name: String? = "forte") {
+        println("Event.id: $id")
+        println("EventListenerContext: $context")
+        println("EventListenerContext.plainText: '${context.plainText}'")
+        Assertions.assertEquals("forte", name)
+        println("On Event: $this, app: $application")
+        val continuation = continuationDeferred.await()
+        suspendCancellableCoroutine {
+            it.resume(Unit)
+            continuation.resume(context.plainText)
+        }
+    }
+
+    @Listener
+    @Filter("hello")
+    private fun handleWithErrorButBeFiltered(e: Event) {
+        throw InternalTestError()
+    }
+
+    @Listener
+    private fun handleWithError(e: Event) {
+        throw InternalTestError()
+    }
+}
+
+private class InternalTestError : RuntimeException()


### PR DESCRIPTION
> [!warning]
> Spring Boot starter 的 v2 版本的维护成本较高，不会持续维护很久。
> 并且现在 Spring Boot v2.7.x已经在 2023-11-24 结束支持，请考虑迁移至 Spring Boot v3.x。