### PR TITLE
更新 Kotlin 至 v2.0.0 

### DIFF
--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -41,6 +41,12 @@ jobs:
 
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@main
+        with:
+          upload-result: true
+          github-token: ${{ secrets.FORLIY_ACCESS_TOKEN }}
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }} # read the steps about it below
           GITHUB_TOKEN: ${{ secrets.FORLIY_ACCESS_TOKEN }}
+
+
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,20 +74,6 @@ subprojects {
             return@afterEvaluate
         }
 
-        fun Project.hasKtP(): Boolean {
-            return plugins.findPlugin("org.jetbrains.kotlin.jvm") != null ||
-                plugins.findPlugin("org.jetbrains.kotlin.multiplatform") != null
-        }
-
-        if (hasKtP()) {
-//            apply(plugin = "io.gitlab.arturbosch.detekt")
-            // applyDetekt()
-            if ("gradle" !in name) {
-                useK2()
-                logger.info("Enable K2 for {}", this)
-            }
-        }
-
         applyKover(root)
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,8 +34,9 @@ plugins {
 
     // https://www.jetbrains.com/help/qodana/code-coverage.html
     // https://github.com/Kotlin/kotlinx-kover
-    id("org.jetbrains.kotlinx.kover") version "0.7.6"
+    alias(libs.plugins.kotlinxKover)
 
+    alias(libs.plugins.kotlinxBinaryCompatibilityValidator)
 }
 
 setup(P.Simbot)
@@ -83,7 +84,7 @@ dependencies {
     detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:${libs.versions.detekt.get()}")
 }
 
-// config detekt
+//region config detekt
 detekt {
     source.setFrom(subprojects.map { it.projectDir.absoluteFile })
     config.setFrom(rootDir.resolve("config/detekt/detekt.yml"))
@@ -131,6 +132,28 @@ fun Project.applyKover(rp: Project) {
             kover(project(path))
         }
     }
+}
+//endregion
+
+apiValidation {
+    ignoredPackages.add("*.internal.*")
+
+    this.ignoredProjects.addAll(
+        listOf(
+            "interface-uml-processor",
+            "simbot-test",
+        )
+    )
+
+    // 实验性和内部API可能无法保证二进制兼容
+    nonPublicMarkers.addAll(
+        listOf(
+            "love.forte.simbot.annotations.ExperimentalSimbotAPI",
+            "love.forte.simbot.annotations.InternalSimbotAPI",
+        ),
+    )
+
+    apiDumpDirectory = "api"
 }
 
 idea {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ import love.forte.gradle.common.core.project.setup
 plugins {
     idea
     id("simbot.dokka-multi-module")
-    id("com.github.gmazzo.buildconfig") version "4.1.2" apply false
+    id("com.github.gmazzo.buildconfig") version "5.3.5" apply false
     alias(libs.plugins.detekt)
     id("simbot.nexus-publish")
     id("simbot.changelog-generator")

--- a/buildSrc/src/main/kotlin/JsConfig.kt
+++ b/buildSrc/src/main/kotlin/JsConfig.kt
@@ -4,7 +4,7 @@
  *     Project    https://github.com/simple-robot/simpler-robot
  *     Email      ForteScarlet@163.com
  *
- *     This file is part of the Simple Robot Library.
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Lesser General Public License as published by
@@ -46,7 +46,7 @@ inline fun KotlinJsTargetDsl.configJs(
 
     if (browser) {
         browser {
-            testTask{
+            testTask {
                 useKarma {
                     useChromeHeadless()
                     // useConfigDirectory(File(project.rootProject.projectDir, "karma"))
@@ -71,19 +71,20 @@ fun Project.configJsTestTasks() {
     }
 }
 
+@Suppress("UNUSED_PARAMETER")
 inline fun KotlinWasmJsTargetDsl.configWasmJs(
     nodeJs: Boolean = true,
     browser: Boolean = true,
     block: () -> Unit = {}
 ) {
-    if (nodeJs && isLinux) {
+    // if (nodeJs && isLinux) {
         // win in candy node `21.0.0-v8-canary202309143a48826a08` is not supported
         // nodejs()
-    }
+    // }
 
     if (browser) {
         browser {
-            testTask{
+            testTask {
                 useKarma {
                     useChromeHeadless()
                     // useConfigDirectory(File(project.rootProject.projectDir, "karma"))
@@ -101,8 +102,8 @@ inline fun Project.configWasmJsTest(block: () -> Unit = {}) {
         // see https://youtrack.jetbrains.com/issue/KT-63014/Running-tests-with-wasmJs-in-1.9.20-requires-Chrome-Canary#focus=Comments-27-8321383.0-0
         rootProject.the<NodeJsRootExtension>().apply {
             // nodeVersion = "21.0.0-v8-canary202309143a48826a08"
-            nodeVersion = "21.0.0-v8-canary202309143a48826a08"
-            nodeDownloadBaseUrl = "https://nodejs.org/download/v8-canary"
+            version = "21.0.0-v8-canary202309143a48826a08"
+            downloadBaseUrl = "https://nodejs.org/download/v8-canary"
         }
 
         tasks.withType<org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask>().configureEach {

--- a/buildSrc/src/main/kotlin/JvmConfig.kt
+++ b/buildSrc/src/main/kotlin/JvmConfig.kt
@@ -24,11 +24,11 @@
 import org.gradle.api.Project
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.compile.JavaCompile
-import org.gradle.kotlin.dsl.assign
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.getByName
 import org.gradle.kotlin.dsl.withType
 import org.gradle.process.CommandLineArgumentProvider
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
@@ -36,13 +36,14 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinTopLevelExtension
 import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 
 
+@OptIn(ExperimentalKotlinGradlePluginApi::class)
 inline fun KotlinJvmTarget.configJava(crossinline block: KotlinJvmTarget.() -> Unit = {}) {
     withJava()
-    compilations.all {
-        kotlinOptions {
-            javaParameters = true
-            freeCompilerArgs = freeCompilerArgs + listOf("-Xjvm-default=all")
-        }
+    compilerOptions {
+        javaParameters.set(true)
+        freeCompilerArgs.addAll(
+            "-Xjvm-default=all"
+        )
     }
 
     testRuns["test"].executionTask.configure {
@@ -75,7 +76,7 @@ inline fun KotlinJvmProjectExtension.configKotlinJvm(
 ) {
     configJavaToolchain(jdkVersion)
     compilerOptions {
-        javaParameters = true
+        javaParameters.set(true)
         jvmTarget.set(JvmTarget.fromTarget(jdkVersion.toString()))
         // freeCompilerArgs.addAll("-Xjvm-default=all", "-Xjsr305=strict")
         freeCompilerArgs.set(freeCompilerArgs.getOrElse(emptyList()) + listOf("-Xjvm-default=all", "-Xjsr305=strict"))

--- a/buildSrc/src/main/kotlin/K2Config.kt
+++ b/buildSrc/src/main/kotlin/K2Config.kt
@@ -22,16 +22,10 @@
  */
 
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.withType
 
 
+@Deprecated("Kt is already applied")
+@Suppress("UNUSED_PARAMETER", "UnusedReceiverParameter")
 fun Project.useK2(languageVersion: String = "2.0") {
-    logger.warn("暂时关闭K2, 等待稳定版。The input languageVersion = {}", languageVersion)
-    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-        kotlinOptions {
-            // useK2
-            // TODO 暂时关闭，等待 Kt2.0
-            // this.languageVersion = languageVersion
-        }
-    }
+    // Nothing.
 }

--- a/buildSrc/src/main/kotlin/P.kt
+++ b/buildSrc/src/main/kotlin/P.kt
@@ -85,7 +85,7 @@ sealed class P(override val group: String) : ProjectDetail() {
     val versionWithoutSnapshot: Version
 
     init {
-        val mainVersion = version(4, 0, 0) - version("beta3")
+        val mainVersion = version(4, 0, 0) - version("RC1")
 
         fun initVersionWithoutSnapshot(status: Version?): Version = if (status == null) {
             mainVersion

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,8 @@ spring-boot-v3 = "3.2.1"
 openjdk-jmh = "1.36"
 ktor = "2.3.8"
 slf4j = "2.0.12"
+# https://kotlinlang.org/docs/ksp-quickstart.html
+# https://github.com/google/ksp
 ksp = "1.9.23-1.0.19"
 # https://square.github.io/kotlinpoet/
 kotlinPoet = "1.16.0"
@@ -26,7 +28,7 @@ detekt = "1.23.3"
 
 [libraries]
 # jetbrains-annotation
-jetbrains-annotations = "org.jetbrains:annotations:24.0.1"
+jetbrains-annotations = "org.jetbrains:annotations:24.1.0"
 
 # dokka
 dokka-plugin = { group = "org.jetbrains.dokka", name = "dokka-gradle-plugin", version.ref = "dokka" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,9 +22,6 @@ suspendReversal = "0.2.0"
 gradleCommon = "0.3.0"
 # tests
 mockk = "1.13.10"
-# binary-compatibility-validator
-# https://github.com/Kotlin/binary-compatibility-validator
-binary-compatibility-validator = "0.15.0-Beta.2"
 # detekt
 # https://detekt.dev/docs/intro
 detekt = "1.23.3"
@@ -146,8 +143,13 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kotlinxBenchmark = { id = "org.jetbrains.kotlinx.benchmark", version.ref = "kotlinxBenchmark" }
 kotlinAllOpen = { id = "org.jetbrains.kotlin.plugin.allopen", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+# Kover
+# https://www.jetbrains.com/help/qodana/code-coverage.html
+# https://github.com/Kotlin/kotlinx-kover
+kotlinxKover = { id = "org.jetbrains.kotlinx.kover", version = "0.8.0" }
 # binary-compatibility-validator
-kotlinxBinaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binary-compatibility-validator" }
+# https://github.com/Kotlin/binary-compatibility-validator
+kotlinxBinaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.15.0-Beta.2" }
 
 [bundles]
 gradle-common = ["gradle-common-core", "gradle-common-multiplatform", "gradle-common-publication"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-kotlin = "1.9.23"
+kotlin = "2.0.0"
 dokka = "1.9.20"
-kotlinx-coroutines = "1.8.0"
+kotlinx-coroutines = "1.8.1"
 kotlinx-serialization = "1.6.3"
 spring-boot-v2 = "2.7.18"
 spring-boot-v3 = "3.2.1"
@@ -10,18 +10,21 @@ ktor = "2.3.8"
 slf4j = "2.0.12"
 # https://kotlinlang.org/docs/ksp-quickstart.html
 # https://github.com/google/ksp
-ksp = "1.9.23-1.0.19"
+ksp = "2.0.0-1.0.21"
 # https://square.github.io/kotlinpoet/
 kotlinPoet = "1.16.0"
 # https://github.com/Kotlin/kotlinx-benchmark
 kotlinxBenchmark = "0.4.10"
 reactor = "3.6.2"
 # simbots
-suspendTransform = "0.7.0-beta1"
+suspendTransform = "0.8.0-beta1"
 suspendReversal = "0.2.0"
-gradleCommon = "0.2.0"
+gradleCommon = "0.3.0"
 # tests
 mockk = "1.13.10"
+# binary-compatibility-validator
+# https://github.com/Kotlin/binary-compatibility-validator
+binary-compatibility-validator = "0.15.0-Beta.2"
 # detekt
 # https://detekt.dev/docs/intro
 detekt = "1.23.3"
@@ -137,11 +140,14 @@ mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 # benchmark
 kotlinx-benchmark-runtime = { group = "org.jetbrains.kotlinx", name = "kotlinx-benchmark-runtime", version.ref = "kotlinxBenchmark" }
 
+
 [plugins]
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kotlinxBenchmark = { id = "org.jetbrains.kotlinx.benchmark", version.ref = "kotlinxBenchmark" }
 kotlinAllOpen = { id = "org.jetbrains.kotlin.plugin.allopen", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+# binary-compatibility-validator
+kotlinxBinaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binary-compatibility-validator" }
 
 [bundles]
 gradle-common = ["gradle-common-core", "gradle-common-multiplatform", "gradle-common-publication"]

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -85,7 +85,7 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/estree@*", "@types/estree@^1.0.0":
+"@types/estree@*", "@types/estree@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
@@ -102,10 +102,10 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@webassemblyjs/ast@1.11.6", "@webassemblyjs/ast@^1.11.5":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.6.tgz#db046555d3c413f8966ca50a95176a0e2c642e24"
-  integrity sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==
+"@webassemblyjs/ast@1.12.1", "@webassemblyjs/ast@^1.12.1":
+  version "1.12.1"
+  resolved "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz#bb16a0e8b1914f979f45864c23819cc3e3f0d4bb"
+  integrity sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==
   dependencies:
     "@webassemblyjs/helper-numbers" "1.11.6"
     "@webassemblyjs/helper-wasm-bytecode" "1.11.6"
@@ -120,10 +120,10 @@
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz#6132f68c4acd59dcd141c44b18cbebbd9f2fa768"
   integrity sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==
 
-"@webassemblyjs/helper-buffer@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.6.tgz#b66d73c43e296fd5e88006f18524feb0f2c7c093"
-  integrity sha512-z3nFzdcp1mb8nEOFFk8DrYLpHvhKC3grJD2ardfKOzmbmJvEf/tPIqCY+sNcwZIY8ZD7IkB2l7/pqhUhqm7hLA==
+"@webassemblyjs/helper-buffer@1.12.1":
+  version "1.12.1"
+  resolved "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz#6df20d272ea5439bf20ab3492b7fb70e9bfcb3f6"
+  integrity sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw==
 
 "@webassemblyjs/helper-numbers@1.11.6":
   version "1.11.6"
@@ -139,15 +139,15 @@
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz#bb2ebdb3b83aa26d9baad4c46d4315283acd51e9"
   integrity sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==
 
-"@webassemblyjs/helper-wasm-section@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.6.tgz#ff97f3863c55ee7f580fd5c41a381e9def4aa577"
-  integrity sha512-LPpZbSOwTpEC2cgn4hTydySy1Ke+XEu+ETXuoyvuyezHO3Kjdu90KK95Sh9xTbmjrCsUwvWwCOQQNta37VrS9g==
+"@webassemblyjs/helper-wasm-section@1.12.1":
+  version "1.12.1"
+  resolved "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz#3da623233ae1a60409b509a52ade9bc22a37f7bf"
+  integrity sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==
   dependencies:
-    "@webassemblyjs/ast" "1.11.6"
-    "@webassemblyjs/helper-buffer" "1.11.6"
+    "@webassemblyjs/ast" "1.12.1"
+    "@webassemblyjs/helper-buffer" "1.12.1"
     "@webassemblyjs/helper-wasm-bytecode" "1.11.6"
-    "@webassemblyjs/wasm-gen" "1.11.6"
+    "@webassemblyjs/wasm-gen" "1.12.1"
 
 "@webassemblyjs/ieee754@1.11.6":
   version "1.11.6"
@@ -168,74 +168,74 @@
   resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.6.tgz#90f8bc34c561595fe156603be7253cdbcd0fab5a"
   integrity sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==
 
-"@webassemblyjs/wasm-edit@^1.11.5":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.6.tgz#c72fa8220524c9b416249f3d94c2958dfe70ceab"
-  integrity sha512-Ybn2I6fnfIGuCR+Faaz7YcvtBKxvoLV3Lebn1tM4o/IAJzmi9AWYIPWpyBfU8cC+JxAO57bk4+zdsTjJR+VTOw==
+"@webassemblyjs/wasm-edit@^1.12.1":
+  version "1.12.1"
+  resolved "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz#9f9f3ff52a14c980939be0ef9d5df9ebc678ae3b"
+  integrity sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==
   dependencies:
-    "@webassemblyjs/ast" "1.11.6"
-    "@webassemblyjs/helper-buffer" "1.11.6"
+    "@webassemblyjs/ast" "1.12.1"
+    "@webassemblyjs/helper-buffer" "1.12.1"
     "@webassemblyjs/helper-wasm-bytecode" "1.11.6"
-    "@webassemblyjs/helper-wasm-section" "1.11.6"
-    "@webassemblyjs/wasm-gen" "1.11.6"
-    "@webassemblyjs/wasm-opt" "1.11.6"
-    "@webassemblyjs/wasm-parser" "1.11.6"
-    "@webassemblyjs/wast-printer" "1.11.6"
+    "@webassemblyjs/helper-wasm-section" "1.12.1"
+    "@webassemblyjs/wasm-gen" "1.12.1"
+    "@webassemblyjs/wasm-opt" "1.12.1"
+    "@webassemblyjs/wasm-parser" "1.12.1"
+    "@webassemblyjs/wast-printer" "1.12.1"
 
-"@webassemblyjs/wasm-gen@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.6.tgz#fb5283e0e8b4551cc4e9c3c0d7184a65faf7c268"
-  integrity sha512-3XOqkZP/y6B4F0PBAXvI1/bky7GryoogUtfwExeP/v7Nzwo1QLcq5oQmpKlftZLbT+ERUOAZVQjuNVak6UXjPA==
+"@webassemblyjs/wasm-gen@1.12.1":
+  version "1.12.1"
+  resolved "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz#a6520601da1b5700448273666a71ad0a45d78547"
+  integrity sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==
   dependencies:
-    "@webassemblyjs/ast" "1.11.6"
+    "@webassemblyjs/ast" "1.12.1"
     "@webassemblyjs/helper-wasm-bytecode" "1.11.6"
     "@webassemblyjs/ieee754" "1.11.6"
     "@webassemblyjs/leb128" "1.11.6"
     "@webassemblyjs/utf8" "1.11.6"
 
-"@webassemblyjs/wasm-opt@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.6.tgz#d9a22d651248422ca498b09aa3232a81041487c2"
-  integrity sha512-cOrKuLRE7PCe6AsOVl7WasYf3wbSo4CeOk6PkrjS7g57MFfVUF9u6ysQBBODX0LdgSvQqRiGz3CXvIDKcPNy4g==
+"@webassemblyjs/wasm-opt@1.12.1":
+  version "1.12.1"
+  resolved "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz#9e6e81475dfcfb62dab574ac2dda38226c232bc5"
+  integrity sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==
   dependencies:
-    "@webassemblyjs/ast" "1.11.6"
-    "@webassemblyjs/helper-buffer" "1.11.6"
-    "@webassemblyjs/wasm-gen" "1.11.6"
-    "@webassemblyjs/wasm-parser" "1.11.6"
+    "@webassemblyjs/ast" "1.12.1"
+    "@webassemblyjs/helper-buffer" "1.12.1"
+    "@webassemblyjs/wasm-gen" "1.12.1"
+    "@webassemblyjs/wasm-parser" "1.12.1"
 
-"@webassemblyjs/wasm-parser@1.11.6", "@webassemblyjs/wasm-parser@^1.11.5":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.6.tgz#bb85378c527df824004812bbdb784eea539174a1"
-  integrity sha512-6ZwPeGzMJM3Dqp3hCsLgESxBGtT/OeCvCZ4TA1JUPYgmhAx38tTPR9JaKy0S5H3evQpO/h2uWs2j6Yc/fjkpTQ==
+"@webassemblyjs/wasm-parser@1.12.1", "@webassemblyjs/wasm-parser@^1.12.1":
+  version "1.12.1"
+  resolved "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz#c47acb90e6f083391e3fa61d113650eea1e95937"
+  integrity sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==
   dependencies:
-    "@webassemblyjs/ast" "1.11.6"
+    "@webassemblyjs/ast" "1.12.1"
     "@webassemblyjs/helper-api-error" "1.11.6"
     "@webassemblyjs/helper-wasm-bytecode" "1.11.6"
     "@webassemblyjs/ieee754" "1.11.6"
     "@webassemblyjs/leb128" "1.11.6"
     "@webassemblyjs/utf8" "1.11.6"
 
-"@webassemblyjs/wast-printer@1.11.6":
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.11.6.tgz#a7bf8dd7e362aeb1668ff43f35cb849f188eff20"
-  integrity sha512-JM7AhRcE+yW2GWYaKeHL5vt4xqee5N2WcezptmgyhNS+ScggqcT1OtXykhAb13Sn5Yas0j2uv9tHgrjwvzAP4A==
+"@webassemblyjs/wast-printer@1.12.1":
+  version "1.12.1"
+  resolved "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz#bcecf661d7d1abdaf989d8341a4833e33e2b31ac"
+  integrity sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==
   dependencies:
-    "@webassemblyjs/ast" "1.11.6"
+    "@webassemblyjs/ast" "1.12.1"
     "@xtuc/long" "4.2.2"
 
-"@webpack-cli/configtest@^2.1.0":
+"@webpack-cli/configtest@^2.1.1":
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-2.1.1.tgz#3b2f852e91dac6e3b85fb2a314fb8bef46d94646"
+  resolved "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz#3b2f852e91dac6e3b85fb2a314fb8bef46d94646"
   integrity sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==
 
-"@webpack-cli/info@^2.0.1":
+"@webpack-cli/info@^2.0.2":
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-2.0.2.tgz#cc3fbf22efeb88ff62310cf885c5b09f44ae0fdd"
+  resolved "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz#cc3fbf22efeb88ff62310cf885c5b09f44ae0fdd"
   integrity sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==
 
-"@webpack-cli/serve@^2.0.3":
+"@webpack-cli/serve@^2.0.5":
   version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.5.tgz#325db42395cd49fe6c14057f9a900e427df8810e"
+  resolved "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz#325db42395cd49fe6c14057f9a900e427df8810e"
   integrity sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==
 
 "@xtuc/ieee754@^1.2.0":
@@ -247,11 +247,6 @@
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
-
-abab@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
-  integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
 
 abort-controller@3.0.0:
   version "3.0.0"
@@ -268,9 +263,9 @@ accepts@~1.3.4:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
-acorn-import-assertions@^1.7.6:
+acorn-import-assertions@^1.9.0:
   version "1.9.0"
-  resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz#507276249d684797c84e0734ef84860334cfb1ac"
+  resolved "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz#507276249d684797c84e0734ef84860334cfb1ac"
   integrity sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==
 
 acorn@^8.7.1, acorn@^8.8.2:
@@ -383,13 +378,13 @@ browser-stdout@1.3.1:
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
-browserslist@^4.14.5:
-  version "4.22.2"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.22.2.tgz#704c4943072bd81ea18997f3bd2180e89c77874b"
-  integrity sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==
+browserslist@^4.21.10:
+  version "4.23.0"
+  resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz#8f3acc2bbe73af7213399430890f86c63a5674ab"
+  integrity sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==
   dependencies:
-    caniuse-lite "^1.0.30001565"
-    electron-to-chromium "^1.4.601"
+    caniuse-lite "^1.0.30001587"
+    electron-to-chromium "^1.4.668"
     node-releases "^2.0.14"
     update-browserslist-db "^1.0.13"
 
@@ -417,10 +412,10 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-caniuse-lite@^1.0.30001565:
-  version "1.0.30001576"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz#893be772cf8ee6056d6c1e2d07df365b9ec0a5c4"
-  integrity sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==
+caniuse-lite@^1.0.30001587:
+  version "1.0.30001621"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001621.tgz#4adcb443c8b9c8303e04498318f987616b8fea2e"
+  integrity sha512-+NLXZiviFFKX0fk8Piwv3PfLPGtRqJeq2TiNoUff/qB5KJgwecJTvCXDpmlyP/eCI/GUEmp/h/y5j0yckiiZrA==
 
 chalk@^4.1.0:
   version "4.1.2"
@@ -610,10 +605,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-electron-to-chromium@^1.4.601:
-  version "1.4.625"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.625.tgz#a9a1d18ee911f9074a9c42d9e84b1c79b29f4059"
-  integrity sha512-DENMhh3MFgaPDoXWrVIqSPInQoLImywfCwrSmVl3cf9QHzoZSiutHwGaB/Ql3VkqcQV30rzgdM+BjKqBAJxo5Q==
+electron-to-chromium@^1.4.668:
+  version "1.4.783"
+  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.783.tgz#933887165b8b6025a81663d2d97cf4b85cde27b2"
+  integrity sha512-bT0jEz/Xz1fahQpbZ1D7LgmPYZ3iHVY39NcWWro1+hA2IvjiPeaXtfSqrQ+nXjApMvQRE2ASt1itSLRrebHMRQ==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -646,10 +641,10 @@ engine.io@~6.5.2:
     engine.io-parser "~5.2.1"
     ws "~8.11.0"
 
-enhanced-resolve@^5.13.0:
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz#1af946c7d93603eb88e9896cee4904dc012e9c35"
-  integrity sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==
+enhanced-resolve@^5.16.0:
+  version "5.16.1"
+  resolved "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.16.1.tgz#e8bc63d51b826d6f1cbc0a150ecb5a8b0c62e567"
+  integrity sha512-4U5pNsuDl0EhuZpq46M5xPslstkviJuhrdobaRDBk2Jy2KO37FDAJl4lb2KlNabxT0m4MTK2UHNrsAcphE8nyw==
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
@@ -851,17 +846,16 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
-  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
+glob@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
     inherits "2"
-    minimatch "^3.0.4"
+    minimatch "^5.0.1"
     once "^1.3.0"
-    path-is-absolute "^1.0.0"
 
 glob@^7.1.3, glob@^7.1.7:
   version "7.2.3"
@@ -882,7 +876,7 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.10, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
+graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.10, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -1103,19 +1097,19 @@ karma-sourcemap-loader@0.4.0:
   dependencies:
     graceful-fs "^4.2.10"
 
-karma-webpack@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/karma-webpack/-/karma-webpack-5.0.0.tgz#2a2c7b80163fe7ffd1010f83f5507f95ef39f840"
-  integrity sha512-+54i/cd3/piZuP3dr54+NcFeKOPnys5QeM1IY+0SPASwrtHsliXUiCL50iW+K9WWA7RvamC4macvvQ86l3KtaA==
+karma-webpack@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/karma-webpack/-/karma-webpack-5.0.1.tgz#4eafd31bbe684a747a6e8f3e4ad373e53979ced4"
+  integrity sha512-oo38O+P3W2mSPCSUrQdySSPv1LvPpXP+f+bBimNomS5sW+1V4SuhCuW8TfJzV+rDv921w2fDSDw0xJbPe6U+kQ==
   dependencies:
     glob "^7.1.3"
-    minimatch "^3.0.4"
+    minimatch "^9.0.3"
     webpack-merge "^4.1.5"
 
-karma@6.4.2:
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/karma/-/karma-6.4.2.tgz#a983f874cee6f35990c4b2dcc3d274653714de8e"
-  integrity sha512-C6SU/53LB31BEgRg+omznBEMY4SjHU3ricV6zBcAe1EeILKkeScr+fZXtaI5WyDbkVowJxxAI6h73NcFPmXolQ==
+karma@6.4.3:
+  version "6.4.3"
+  resolved "https://registry.npmjs.org/karma/-/karma-6.4.3.tgz#763e500f99597218bbb536de1a14acc4ceea7ce8"
+  integrity sha512-LuucC/RE92tJ8mlCwqEoRWXP38UMAqpnq98vktmS9SznSoUPPUJQbc91dHcxcunROvfQjdORVA/YFviH+Xci9Q==
   dependencies:
     "@colors/colors" "1.5.0"
     body-parser "^1.19.0"
@@ -1136,7 +1130,7 @@ karma@6.4.2:
     qjobs "^1.2.0"
     range-parser "^1.2.1"
     rimraf "^3.0.2"
-    socket.io "^4.4.1"
+    socket.io "^4.7.2"
     source-map "^0.6.1"
     tmp "^0.2.1"
     ua-parser-js "^0.7.30"
@@ -1231,6 +1225,20 @@ minimatch@^3.0.4, minimatch@^3.1.1:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^5.0.1:
+  version "5.1.6"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@^9.0.3:
+  version "9.0.4"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz#8e49c731d1749cbec05050ee5145147b32496a51"
+  integrity sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimist@^1.2.3, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
@@ -1243,10 +1251,10 @@ mkdirp@^0.5.5:
   dependencies:
     minimist "^1.2.6"
 
-mocha@10.2.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.2.0.tgz#1fd4a7c32ba5ac372e03a17eef435bd00e5c68b8"
-  integrity sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==
+mocha@10.3.0:
+  version "10.3.0"
+  resolved "https://registry.npmjs.org/mocha/-/mocha-10.3.0.tgz#0e185c49e6dccf582035c05fa91084a4ff6e3fe9"
+  integrity sha512-uF2XJs+7xSLsrmIvn37i/wnc91nw7XjOQB8ccyx5aEgdnohr7n+rEiZP23WkCYHjilR6+EboEnbq/ZQDz4LSbg==
   dependencies:
     ansi-colors "4.1.1"
     browser-stdout "1.3.1"
@@ -1255,13 +1263,12 @@ mocha@10.2.0:
     diff "5.0.0"
     escape-string-regexp "4.0.0"
     find-up "5.0.0"
-    glob "7.2.0"
+    glob "8.1.0"
     he "1.2.0"
     js-yaml "4.1.0"
     log-symbols "4.1.0"
     minimatch "5.0.1"
     ms "2.1.3"
-    nanoid "3.3.3"
     serialize-javascript "6.0.0"
     strip-json-comments "3.1.1"
     supports-color "8.1.1"
@@ -1284,11 +1291,6 @@ ms@2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
-nanoid@3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
-  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
 
 negotiator@0.6.3:
   version "0.6.3"
@@ -1529,9 +1531,9 @@ safe-buffer@^5.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-schema-utils@^3.1.1, schema-utils@^3.1.2:
+schema-utils@^3.1.1, schema-utils@^3.2.0:
   version "3.3.0"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.3.0.tgz#f50a88877c3c01652a15b622ae9e9795df7a60fe"
+  resolved "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz#f50a88877c3c01652a15b622ae9e9795df7a60fe"
   integrity sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==
   dependencies:
     "@types/json-schema" "^7.0.8"
@@ -1610,10 +1612,10 @@ socket.io-parser@~4.2.4:
     "@socket.io/component-emitter" "~3.1.0"
     debug "~4.3.1"
 
-socket.io@^4.4.1:
-  version "4.7.3"
-  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-4.7.3.tgz#a0f1a4511eb23fe182ae3a018875a31501be3ffc"
-  integrity sha512-SE+UIQXBQE+GPG2oszWMlsEmWtHVqw/h1VrYJGK5/MC7CH5p58N448HwIrtREcvR4jfdOJAY4ieQfxMr55qbbw==
+socket.io@^4.7.2:
+  version "4.7.5"
+  resolved "https://registry.npmjs.org/socket.io/-/socket.io-4.7.5.tgz#56eb2d976aef9d1445f373a62d781a41c7add8f8"
+  integrity sha512-DmeAkF6cwM9jSfmp6Dr/5/mfMwb5Z5qRrSXLpo3Fq5SqyU8CMF15jIN4ZhfSwu35ksM1qmHZDQ/DK5XTccSTvA==
   dependencies:
     accepts "~1.3.4"
     base64id "~2.0.0"
@@ -1628,12 +1630,11 @@ source-map-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
-source-map-loader@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-4.0.1.tgz#72f00d05f5d1f90f80974eda781cbd7107c125f2"
-  integrity sha512-oqXpzDIByKONVY8g1NUPOTQhe0UTU5bWUl32GSkqK2LjJj0HmwTMVKxcUip0RgAYhY1mqgOxjbQM48a0mmeNfA==
+source-map-loader@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/source-map-loader/-/source-map-loader-5.0.0.tgz#f593a916e1cc54471cfc8851b905c8a845fc7e38"
+  integrity sha512-k2Dur7CbSLcAH73sBcIkV5xjPV4SzqO1NJ7+XaQl8if3VODDUj3FNchNGpqgJSKbvUfJuhVdv8K2Eu8/TNl2eA==
   dependencies:
-    abab "^2.0.6"
     iconv-lite "^0.6.3"
     source-map-js "^1.0.2"
 
@@ -1714,9 +1715,9 @@ tapable@^2.1.1, tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-terser-webpack-plugin@^5.3.7:
+terser-webpack-plugin@^5.3.10:
   version "5.3.10"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz#904f4c9193c6fd2a03f693a2150c62a92f40d199"
+  resolved "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz#904f4c9193c6fd2a03f693a2150c62a92f40d199"
   integrity sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.20"
@@ -1767,10 +1768,10 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
-  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+typescript@5.4.3:
+  version "5.4.3"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz#5c6fedd4c87bee01cd7a528a30145521f8e0feff"
+  integrity sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==
 
 ua-parser-js@^0.7.30:
   version "0.7.37"
@@ -1822,10 +1823,10 @@ void-elements@^2.0.0:
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   integrity sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==
 
-watchpack@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz#fa33032374962c78113f93c7f2fb4c54c9862a5d"
-  integrity sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==
+watchpack@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.npmjs.org/watchpack/-/watchpack-2.4.1.tgz#29308f2cac150fa8e4c92f90e0ec954a9fed7fff"
+  integrity sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==
   dependencies:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
@@ -1835,15 +1836,15 @@ webidl-conversions@^3.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
 
-webpack-cli@5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-5.1.0.tgz#abc4b1f44b50250f2632d8b8b536cfe2f6257891"
-  integrity sha512-a7KRJnCxejFoDpYTOwzm5o21ZXMaNqtRlvS183XzGDUPRdVEzJNImcQokqYZ8BNTnk9DkKiuWxw75+DCCoZ26w==
+webpack-cli@5.1.4:
+  version "5.1.4"
+  resolved "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz#c8e046ba7eaae4911d7e71e2b25b776fcc35759b"
+  integrity sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==
   dependencies:
     "@discoveryjs/json-ext" "^0.5.0"
-    "@webpack-cli/configtest" "^2.1.0"
-    "@webpack-cli/info" "^2.0.1"
-    "@webpack-cli/serve" "^2.0.3"
+    "@webpack-cli/configtest" "^2.1.1"
+    "@webpack-cli/info" "^2.0.2"
+    "@webpack-cli/serve" "^2.0.5"
     colorette "^2.0.14"
     commander "^10.0.1"
     cross-spawn "^7.0.3"
@@ -1875,34 +1876,34 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@5.82.0:
-  version "5.82.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.82.0.tgz#3c0d074dec79401db026b4ba0fb23d6333f88e7d"
-  integrity sha512-iGNA2fHhnDcV1bONdUu554eZx+XeldsaeQ8T67H6KKHl2nUSwX8Zm7cmzOA46ox/X1ARxf7Bjv8wQ/HsB5fxBg==
+webpack@5.91.0:
+  version "5.91.0"
+  resolved "https://registry.npmjs.org/webpack/-/webpack-5.91.0.tgz#ffa92c1c618d18c878f06892bbdc3373c71a01d9"
+  integrity sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
-    "@types/estree" "^1.0.0"
-    "@webassemblyjs/ast" "^1.11.5"
-    "@webassemblyjs/wasm-edit" "^1.11.5"
-    "@webassemblyjs/wasm-parser" "^1.11.5"
+    "@types/estree" "^1.0.5"
+    "@webassemblyjs/ast" "^1.12.1"
+    "@webassemblyjs/wasm-edit" "^1.12.1"
+    "@webassemblyjs/wasm-parser" "^1.12.1"
     acorn "^8.7.1"
-    acorn-import-assertions "^1.7.6"
-    browserslist "^4.14.5"
+    acorn-import-assertions "^1.9.0"
+    browserslist "^4.21.10"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.13.0"
+    enhanced-resolve "^5.16.0"
     es-module-lexer "^1.2.1"
     eslint-scope "5.1.1"
     events "^3.2.0"
     glob-to-regexp "^0.4.1"
-    graceful-fs "^4.2.9"
+    graceful-fs "^4.2.11"
     json-parse-even-better-errors "^2.3.1"
     loader-runner "^4.2.0"
     mime-types "^2.1.27"
     neo-async "^2.6.2"
-    schema-utils "^3.1.2"
+    schema-utils "^3.2.0"
     tapable "^2.1.1"
-    terser-webpack-plugin "^5.3.7"
-    watchpack "^2.4.0"
+    terser-webpack-plugin "^5.3.10"
+    watchpack "^2.4.1"
     webpack-sources "^3.2.3"
 
 whatwg-url@^5.0.0:

--- a/simbot-api/api/simbot-api.api
+++ b/simbot-api/api/simbot-api.api
@@ -1,0 +1,2492 @@
+public abstract interface class love/forte/simbot/ability/CompletionAware {
+	public abstract fun onCompletion (Llove/forte/simbot/ability/OnCompletion;)V
+}
+
+public class love/forte/simbot/ability/DeleteFailureException : java/lang/IllegalStateException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public abstract interface class love/forte/simbot/ability/DeleteOption {
+}
+
+public abstract interface class love/forte/simbot/ability/DeleteSupport {
+	public abstract synthetic fun delete ([Llove/forte/simbot/ability/DeleteOption;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun deleteAsync ([Llove/forte/simbot/ability/DeleteOption;)Ljava/util/concurrent/CompletableFuture;
+	public fun deleteBlocking ([Llove/forte/simbot/ability/DeleteOption;)V
+	public fun deleteReserve ([Llove/forte/simbot/ability/DeleteOption;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public final class love/forte/simbot/ability/DeleteSupports {
+	public static final fun ifIgnoreOnAnyFailure-6yohGmw (ILkotlin/jvm/functions/Function0;)I
+	public static final fun ifIgnoreOnFailure-6yohGmw (ILkotlin/jvm/functions/Function0;)I
+	public static final fun ifIgnoreOnNoSuchTarget-6yohGmw (ILkotlin/jvm/functions/Function0;)I
+	public static final fun ifIgnoreOnUnsupported-6yohGmw (ILkotlin/jvm/functions/Function0;)I
+	public static final fun isIgnoreOnAnyFailure--EroimE (I)Z
+	public static final fun isIgnoreOnFailure--EroimE (I)Z
+	public static final fun isIgnoreOnNoSuchTarget--EroimE (I)Z
+	public static final fun isIgnoreOnUnsupported--EroimE (I)Z
+}
+
+public abstract interface class love/forte/simbot/ability/EventMentionAware {
+	public abstract fun isMention (Llove/forte/simbot/event/Event;)Z
+}
+
+public abstract interface class love/forte/simbot/ability/LifecycleAware {
+	public abstract fun isActive ()Z
+	public abstract fun isCompleted ()Z
+}
+
+public abstract interface class love/forte/simbot/ability/MentionedTargetAware {
+	public abstract fun isMentioned (Llove/forte/simbot/common/id/ID;)Z
+}
+
+public abstract interface class love/forte/simbot/ability/OnCompletion {
+	public abstract fun invoke (Ljava/lang/Throwable;)V
+}
+
+public abstract interface class love/forte/simbot/ability/ReplySupport {
+	public abstract synthetic fun reply (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun reply (Llove/forte/simbot/message/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun reply (Llove/forte/simbot/message/MessageContent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun replyAsync (Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public fun replyAsync (Llove/forte/simbot/message/Message;)Ljava/util/concurrent/CompletableFuture;
+	public fun replyAsync (Llove/forte/simbot/message/MessageContent;)Ljava/util/concurrent/CompletableFuture;
+	public fun replyBlocking (Ljava/lang/String;)Llove/forte/simbot/message/MessageReceipt;
+	public fun replyBlocking (Llove/forte/simbot/message/Message;)Llove/forte/simbot/message/MessageReceipt;
+	public fun replyBlocking (Llove/forte/simbot/message/MessageContent;)Llove/forte/simbot/message/MessageReceipt;
+	public fun replyReserve (Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun replyReserve (Llove/forte/simbot/message/Message;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun replyReserve (Llove/forte/simbot/message/MessageContent;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/ability/SendSupport {
+	public abstract synthetic fun send (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun send (Llove/forte/simbot/message/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun send (Llove/forte/simbot/message/MessageContent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendAsync (Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public fun sendAsync (Llove/forte/simbot/message/Message;)Ljava/util/concurrent/CompletableFuture;
+	public fun sendAsync (Llove/forte/simbot/message/MessageContent;)Ljava/util/concurrent/CompletableFuture;
+	public fun sendBlocking (Ljava/lang/String;)Llove/forte/simbot/message/MessageReceipt;
+	public fun sendBlocking (Llove/forte/simbot/message/Message;)Llove/forte/simbot/message/MessageReceipt;
+	public fun sendBlocking (Llove/forte/simbot/message/MessageContent;)Llove/forte/simbot/message/MessageReceipt;
+	public fun sendReserve (Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun sendReserve (Llove/forte/simbot/message/Message;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun sendReserve (Llove/forte/simbot/message/MessageContent;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public final class love/forte/simbot/ability/StandardDeleteOption : java/lang/Enum, love/forte/simbot/ability/DeleteOption {
+	public static final field Companion Llove/forte/simbot/ability/StandardDeleteOption$Companion;
+	public static final field IGNORE_ON_ANY_FAILURE Llove/forte/simbot/ability/StandardDeleteOption;
+	public static final field IGNORE_ON_FAILURE Llove/forte/simbot/ability/StandardDeleteOption;
+	public static final field IGNORE_ON_NO_SUCH_TARGET Llove/forte/simbot/ability/StandardDeleteOption;
+	public static final field IGNORE_ON_UNSUPPORTED Llove/forte/simbot/ability/StandardDeleteOption;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Llove/forte/simbot/ability/StandardDeleteOption;
+	public static fun values ()[Llove/forte/simbot/ability/StandardDeleteOption;
+}
+
+public final class love/forte/simbot/ability/StandardDeleteOption$Companion {
+	public final fun inStandardAnalysis-6bCWJ4M ([Llove/forte/simbot/ability/DeleteOption;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)I
+	public static synthetic fun inStandardAnalysis-6bCWJ4M$default (Llove/forte/simbot/ability/StandardDeleteOption$Companion;[Llove/forte/simbot/ability/DeleteOption;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)I
+	public final fun standardAnalysis-lEC9akc ([Llove/forte/simbot/ability/DeleteOption;Lkotlin/jvm/functions/Function1;)I
+	public static synthetic fun standardAnalysis-lEC9akc$default (Llove/forte/simbot/ability/StandardDeleteOption$Companion;[Llove/forte/simbot/ability/DeleteOption;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)I
+}
+
+public final class love/forte/simbot/ability/StandardDeleteOption$StandardAnalysis {
+	public static final synthetic fun box-impl (I)Llove/forte/simbot/ability/StandardDeleteOption$StandardAnalysis;
+	public static fun constructor-impl (I)I
+	public static final fun contains-impl (ILlove/forte/simbot/ability/StandardDeleteOption;)Z
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public static final fun isEmpty-impl (I)Z
+	public static final fun isFull-impl (I)Z
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public abstract class love/forte/simbot/application/AbstractApplicationBuilder : love/forte/simbot/application/ApplicationBuilder {
+	public fun <init> ()V
+	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	public fun setCoroutineContext (Lkotlin/coroutines/CoroutineContext;)V
+}
+
+public abstract class love/forte/simbot/application/AbstractApplicationEventRegistrar : love/forte/simbot/application/ApplicationEventRegistrar {
+	public fun <init> ()V
+	public fun addEventHandler (Llove/forte/simbot/application/ApplicationLaunchStage;Llove/forte/simbot/application/ApplicationEventHandler;)V
+	protected fun getEvents ()Ljava/util/Map;
+}
+
+public abstract class love/forte/simbot/application/AbstractApplicationFactoryConfigurer : love/forte/simbot/application/ApplicationFactoryConfigurer {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Llove/forte/simbot/component/ComponentFactoriesConfigurator;Llove/forte/simbot/plugin/PluginFactoriesConfigurator;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Llove/forte/simbot/component/ComponentFactoriesConfigurator;Llove/forte/simbot/plugin/PluginFactoriesConfigurator;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun config (Llove/forte/simbot/common/function/ConfigurerFunction;)V
+	protected fun createAllComponents (Llove/forte/simbot/component/ComponentConfigureContext;)Ljava/util/List;
+	protected fun createAllPlugins (Llove/forte/simbot/plugin/PluginConfigureContext;)Ljava/util/List;
+	protected final fun createConfig (Llove/forte/simbot/application/ApplicationBuilder;Lkotlin/jvm/functions/Function1;)Llove/forte/simbot/application/ApplicationConfiguration;
+	public fun eventDispatcher (Llove/forte/simbot/common/function/ConfigurerFunction;)V
+	protected fun getApplicationEventRegistrarConfigurations ()Ljava/util/List;
+	protected fun getComponentFactoriesConfigurator ()Llove/forte/simbot/component/ComponentFactoriesConfigurator;
+	protected fun getConfigConfigurers ()Ljava/util/List;
+	protected fun getEventDispatcherConfigurers ()Ljava/util/List;
+	protected fun getPluginFactoriesConfigurator ()Llove/forte/simbot/plugin/PluginFactoriesConfigurator;
+	public fun install (Llove/forte/simbot/component/ComponentFactory;Llove/forte/simbot/common/function/ConfigurerFunction;)V
+	public fun install (Llove/forte/simbot/plugin/PluginFactory;Llove/forte/simbot/common/function/ConfigurerFunction;)V
+	public fun stageEvents (Llove/forte/simbot/common/function/ConfigurerFunction;)V
+}
+
+public abstract interface class love/forte/simbot/application/Application : kotlinx/coroutines/CoroutineScope, love/forte/simbot/ability/CompletionAware, love/forte/simbot/ability/LifecycleAware {
+	public fun asFuture ()Ljava/util/concurrent/CompletableFuture;
+	public fun cancel ()V
+	public abstract fun cancel (Ljava/lang/Throwable;)V
+	public abstract fun getBotManagers ()Llove/forte/simbot/bot/BotManagers;
+	public abstract fun getComponents ()Llove/forte/simbot/component/Components;
+	public abstract fun getConfiguration ()Llove/forte/simbot/application/ApplicationConfiguration;
+	public abstract fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	public abstract fun getEventDispatcher ()Llove/forte/simbot/event/EventDispatcher;
+	public abstract fun getPlugins ()Llove/forte/simbot/plugin/Plugins;
+	public abstract synthetic fun join (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun joinBlocking ()V
+	public fun joinReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/application/ApplicationBuilder {
+	public abstract fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	public abstract fun setCoroutineContext (Lkotlin/coroutines/CoroutineContext;)V
+}
+
+public abstract interface class love/forte/simbot/application/ApplicationConfiguration {
+	public abstract fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+}
+
+public abstract interface class love/forte/simbot/application/ApplicationEventHandler {
+}
+
+public final class love/forte/simbot/application/ApplicationEventHandlerKt {
+	public static final fun applicationLaunchStages (Ljava/util/Map;)Llove/forte/simbot/application/ApplicationLaunchStages;
+	public static final fun onCancelled (Llove/forte/simbot/application/ApplicationEventRegistrar;Llove/forte/simbot/application/NormalApplicationEventHandler;)V
+	public static final fun onLaunch (Llove/forte/simbot/application/ApplicationEventRegistrar;Llove/forte/simbot/application/SuspendApplicationEventHandler;)V
+	public static final fun onRequestCancel (Llove/forte/simbot/application/ApplicationEventRegistrar;Llove/forte/simbot/application/NormalApplicationEventHandler;)V
+}
+
+public abstract interface class love/forte/simbot/application/ApplicationEventRegistrar {
+	public abstract fun addEventHandler (Llove/forte/simbot/application/ApplicationLaunchStage;Llove/forte/simbot/application/ApplicationEventHandler;)V
+}
+
+public abstract interface class love/forte/simbot/application/ApplicationFactory {
+	public fun create ()Llove/forte/simbot/application/ApplicationLauncher;
+	public abstract fun create (Llove/forte/simbot/common/function/ConfigurerFunction;)Llove/forte/simbot/application/ApplicationLauncher;
+}
+
+public abstract interface class love/forte/simbot/application/ApplicationFactoryConfigurer : love/forte/simbot/component/ComponentInstaller, love/forte/simbot/plugin/PluginInstaller {
+	public abstract fun config (Llove/forte/simbot/common/function/ConfigurerFunction;)V
+	public abstract fun eventDispatcher (Llove/forte/simbot/common/function/ConfigurerFunction;)V
+	public fun install (Llove/forte/simbot/component/ComponentFactory;)V
+	public abstract fun install (Llove/forte/simbot/component/ComponentFactory;Llove/forte/simbot/common/function/ConfigurerFunction;)V
+	public fun install (Llove/forte/simbot/plugin/PluginFactory;)V
+	public abstract fun install (Llove/forte/simbot/plugin/PluginFactory;Llove/forte/simbot/common/function/ConfigurerFunction;)V
+	public abstract fun stageEvents (Llove/forte/simbot/common/function/ConfigurerFunction;)V
+}
+
+public abstract interface annotation class love/forte/simbot/application/ApplicationFactoryConfigurerDSL : java/lang/annotation/Annotation {
+}
+
+public final class love/forte/simbot/application/ApplicationLaunchBlockingFailureException : java/lang/RuntimeException {
+}
+
+public abstract class love/forte/simbot/application/ApplicationLaunchStage {
+}
+
+public final class love/forte/simbot/application/ApplicationLaunchStage$Cancelled : love/forte/simbot/application/ApplicationLaunchStage {
+	public static final field INSTANCE Llove/forte/simbot/application/ApplicationLaunchStage$Cancelled;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/application/ApplicationLaunchStage$Launch : love/forte/simbot/application/ApplicationLaunchStage {
+	public static final field INSTANCE Llove/forte/simbot/application/ApplicationLaunchStage$Launch;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/application/ApplicationLaunchStage$RequestCancel : love/forte/simbot/application/ApplicationLaunchStage {
+	public static final field INSTANCE Llove/forte/simbot/application/ApplicationLaunchStage$RequestCancel;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/application/ApplicationLaunchStages {
+	public abstract fun get (Llove/forte/simbot/application/ApplicationLaunchStage;)Ljava/lang/Iterable;
+}
+
+public abstract interface class love/forte/simbot/application/ApplicationLauncher {
+	public abstract synthetic fun launch (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun launchIn (Lkotlinx/coroutines/CoroutineScope;)Llove/forte/simbot/common/async/Async;
+	public fun launchInGlobal ()Llove/forte/simbot/common/async/Async;
+}
+
+public final class love/forte/simbot/application/Applications {
+	public static final fun asCompletableFuture (Llove/forte/simbot/application/Application;)Ljava/util/concurrent/CompletableFuture;
+	public static final synthetic fun launchApplication (Llove/forte/simbot/application/ApplicationFactory;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun launchApplication$default (Llove/forte/simbot/application/ApplicationFactory;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun launchApplicationAsync (Lkotlinx/coroutines/CoroutineScope;Llove/forte/simbot/application/ApplicationFactory;)Llove/forte/simbot/common/async/Async;
+	public static final fun launchApplicationAsync (Lkotlinx/coroutines/CoroutineScope;Llove/forte/simbot/application/ApplicationFactory;Llove/forte/simbot/common/function/ConfigurerFunction;)Llove/forte/simbot/common/async/Async;
+	public static final fun launchApplicationAsync (Llove/forte/simbot/application/ApplicationFactory;)Llove/forte/simbot/common/async/Async;
+	public static final fun launchApplicationAsync (Llove/forte/simbot/application/ApplicationFactory;Llove/forte/simbot/common/function/ConfigurerFunction;)Llove/forte/simbot/common/async/Async;
+	public static synthetic fun launchApplicationAsync$default (Lkotlinx/coroutines/CoroutineScope;Llove/forte/simbot/application/ApplicationFactory;Llove/forte/simbot/common/function/ConfigurerFunction;ILjava/lang/Object;)Llove/forte/simbot/common/async/Async;
+	public static synthetic fun launchApplicationAsync$default (Llove/forte/simbot/application/ApplicationFactory;Llove/forte/simbot/common/function/ConfigurerFunction;ILjava/lang/Object;)Llove/forte/simbot/common/async/Async;
+	public static final fun launchApplicationBlocking (Llove/forte/simbot/application/ApplicationFactory;)Llove/forte/simbot/application/Application;
+	public static final fun launchApplicationBlocking (Llove/forte/simbot/application/ApplicationFactory;Llove/forte/simbot/common/function/ConfigurerFunction;)Llove/forte/simbot/application/Application;
+	public static synthetic fun launchApplicationBlocking$default (Llove/forte/simbot/application/ApplicationFactory;Llove/forte/simbot/common/function/ConfigurerFunction;ILjava/lang/Object;)Llove/forte/simbot/application/Application;
+	public static final fun listeners (Llove/forte/simbot/application/Application;Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface class love/forte/simbot/application/JAsyncApplicationLauncher {
+	public static final field Companion Llove/forte/simbot/application/JAsyncApplicationLauncher$Companion;
+	public abstract fun launch ()Ljava/util/concurrent/CompletionStage;
+	public static fun toEventListener (Llove/forte/simbot/application/JAsyncApplicationLauncher;)Llove/forte/simbot/application/ApplicationLauncher;
+}
+
+public final class love/forte/simbot/application/JAsyncApplicationLauncher$Companion {
+	public final fun toEventListener (Llove/forte/simbot/application/JAsyncApplicationLauncher;)Llove/forte/simbot/application/ApplicationLauncher;
+}
+
+public abstract interface class love/forte/simbot/application/JAsyncSuspendApplicationEventHandler {
+	public static final field Companion Llove/forte/simbot/application/JAsyncSuspendApplicationEventHandler$Companion;
+	public abstract fun invoke (Ljava/lang/Object;)Ljava/util/concurrent/CompletionStage;
+	public static fun toHandler (Llove/forte/simbot/application/JAsyncSuspendApplicationEventHandler;)Llove/forte/simbot/application/SuspendApplicationEventHandler;
+}
+
+public final class love/forte/simbot/application/JAsyncSuspendApplicationEventHandler$Companion {
+	public final fun toHandler (Llove/forte/simbot/application/JAsyncSuspendApplicationEventHandler;)Llove/forte/simbot/application/SuspendApplicationEventHandler;
+}
+
+public abstract interface class love/forte/simbot/application/JBlockingApplicationLauncher {
+	public static final field Companion Llove/forte/simbot/application/JBlockingApplicationLauncher$Companion;
+	public abstract fun launch ()Llove/forte/simbot/application/Application;
+	public static fun toEventListener (Llove/forte/simbot/application/JBlockingApplicationLauncher;)Llove/forte/simbot/application/ApplicationLauncher;
+	public static fun toEventListener (Llove/forte/simbot/application/JBlockingApplicationLauncher;Lkotlin/coroutines/CoroutineContext;)Llove/forte/simbot/application/ApplicationLauncher;
+}
+
+public final class love/forte/simbot/application/JBlockingApplicationLauncher$Companion {
+	public final fun toEventListener (Llove/forte/simbot/application/JBlockingApplicationLauncher;)Llove/forte/simbot/application/ApplicationLauncher;
+	public final fun toEventListener (Llove/forte/simbot/application/JBlockingApplicationLauncher;Lkotlin/coroutines/CoroutineContext;)Llove/forte/simbot/application/ApplicationLauncher;
+	public static synthetic fun toEventListener$default (Llove/forte/simbot/application/JBlockingApplicationLauncher$Companion;Llove/forte/simbot/application/JBlockingApplicationLauncher;Lkotlin/coroutines/CoroutineContext;ILjava/lang/Object;)Llove/forte/simbot/application/ApplicationLauncher;
+}
+
+public abstract interface class love/forte/simbot/application/JBlockingSuspendApplicationEventHandler {
+	public static final field Companion Llove/forte/simbot/application/JBlockingSuspendApplicationEventHandler$Companion;
+	public abstract fun invoke (Ljava/lang/Object;)V
+	public static fun toHandler (Lkotlin/coroutines/CoroutineContext;Llove/forte/simbot/application/JBlockingSuspendApplicationEventHandler;)Llove/forte/simbot/application/SuspendApplicationEventHandler;
+	public static fun toHandler (Llove/forte/simbot/application/JBlockingSuspendApplicationEventHandler;)Llove/forte/simbot/application/SuspendApplicationEventHandler;
+}
+
+public final class love/forte/simbot/application/JBlockingSuspendApplicationEventHandler$Companion {
+	public final fun toHandler (Lkotlin/coroutines/CoroutineContext;Llove/forte/simbot/application/JBlockingSuspendApplicationEventHandler;)Llove/forte/simbot/application/SuspendApplicationEventHandler;
+	public final fun toHandler (Llove/forte/simbot/application/JBlockingSuspendApplicationEventHandler;)Llove/forte/simbot/application/SuspendApplicationEventHandler;
+	public static synthetic fun toHandler$default (Llove/forte/simbot/application/JBlockingSuspendApplicationEventHandler$Companion;Lkotlin/coroutines/CoroutineContext;Llove/forte/simbot/application/JBlockingSuspendApplicationEventHandler;ILjava/lang/Object;)Llove/forte/simbot/application/SuspendApplicationEventHandler;
+}
+
+public abstract interface class love/forte/simbot/application/NormalApplicationEventHandler : love/forte/simbot/application/ApplicationEventHandler {
+	public abstract fun invoke (Ljava/lang/Object;)V
+}
+
+public abstract interface class love/forte/simbot/application/SuspendApplicationEventHandler : love/forte/simbot/application/ApplicationEventHandler {
+	public abstract synthetic fun invoke (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/bot/AutoConfigurableBotPlugin : love/forte/simbot/bot/BotPlugin {
+	public abstract fun configurable (Llove/forte/simbot/bot/SerializableBotConfiguration;)Z
+	public abstract fun register (Llove/forte/simbot/bot/SerializableBotConfiguration;)Llove/forte/simbot/bot/Bot;
+}
+
+public abstract interface class love/forte/simbot/bot/Bot : kotlinx/coroutines/CoroutineScope, love/forte/simbot/ability/CompletionAware, love/forte/simbot/ability/LifecycleAware, love/forte/simbot/bot/BotRelations, love/forte/simbot/common/id/IDContainer {
+	public fun asFuture ()Ljava/util/concurrent/CompletableFuture;
+	public fun cancel ()V
+	public abstract fun cancel (Ljava/lang/Throwable;)V
+	public abstract fun getComponent ()Llove/forte/simbot/component/Component;
+	public abstract fun getId ()Llove/forte/simbot/common/id/ID;
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun isMe (Llove/forte/simbot/common/id/ID;)Z
+	public abstract fun isStarted ()Z
+	public abstract synthetic fun join (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun joinBlocking ()V
+	public fun joinReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun start (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun startAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun startBlocking ()V
+	public fun startReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public class love/forte/simbot/bot/BotException : java/lang/RuntimeException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public abstract interface class love/forte/simbot/bot/BotManager : love/forte/simbot/ability/CompletionAware, love/forte/simbot/ability/LifecycleAware, love/forte/simbot/bot/AutoConfigurableBotPlugin {
+	public abstract fun all ()Lkotlin/sequences/Sequence;
+	public fun all (Llove/forte/simbot/common/id/ID;)Lkotlin/sequences/Sequence;
+	public fun asFuture ()Ljava/util/concurrent/CompletableFuture;
+	public abstract fun cancel (Ljava/lang/Throwable;)V
+	public static synthetic fun cancel$default (Llove/forte/simbot/bot/BotManager;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public fun find (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/bot/Bot;
+	public abstract fun get (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/bot/Bot;
+	public abstract synthetic fun join (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun joinBlocking ()V
+	public fun joinReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/bot/BotManagerFactory : love/forte/simbot/plugin/PluginFactory {
+}
+
+public abstract interface class love/forte/simbot/bot/BotManagerFactory$Key : love/forte/simbot/plugin/PluginFactory$Key {
+}
+
+public final class love/forte/simbot/bot/BotManagerUtil {
+	public static final fun toBotManagers (Ljava/util/Collection;)Llove/forte/simbot/bot/BotManagers;
+}
+
+public abstract interface class love/forte/simbot/bot/BotManagers : java/util/Collection, kotlin/jvm/internal/markers/KMappedMarker {
+	public fun allBots ()Lkotlin/sequences/Sequence;
+}
+
+public abstract interface class love/forte/simbot/bot/BotPlugin : love/forte/simbot/plugin/Plugin {
+}
+
+public final class love/forte/simbot/bot/BotPluginKt {
+	public static final fun tryRegister (Llove/forte/simbot/bot/AutoConfigurableBotPlugin;Llove/forte/simbot/bot/SerializableBotConfiguration;)Llove/forte/simbot/bot/Bot;
+	public static final fun tryRegister (Llove/forte/simbot/bot/AutoConfigurableBotPlugin;Llove/forte/simbot/bot/SerializableBotConfiguration;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public class love/forte/simbot/bot/BotRegisterFailureException : love/forte/simbot/bot/BotException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public abstract interface class love/forte/simbot/bot/BotRelations {
+	public abstract fun getContactRelation ()Llove/forte/simbot/bot/ContactRelation;
+	public abstract fun getGroupRelation ()Llove/forte/simbot/bot/GroupRelation;
+	public abstract fun getGuildRelation ()Llove/forte/simbot/bot/GuildRelation;
+}
+
+public class love/forte/simbot/bot/ConflictBotException : love/forte/simbot/bot/BotException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public abstract interface class love/forte/simbot/bot/ContactRelation {
+	public abstract synthetic fun contact (Llove/forte/simbot/common/id/ID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun contactCount (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getContact (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/definition/Contact;
+	public fun getContactAsync (Llove/forte/simbot/common/id/ID;)Ljava/util/concurrent/CompletableFuture;
+	public fun getContactCount ()I
+	public fun getContactCountAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContactCountReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun getContactReserve (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getContacts ()Llove/forte/simbot/common/collectable/Collectable;
+}
+
+public abstract interface class love/forte/simbot/bot/GroupRelation {
+	public fun getGroup (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/definition/ChatGroup;
+	public fun getGroupAsync (Llove/forte/simbot/common/id/ID;)Ljava/util/concurrent/CompletableFuture;
+	public fun getGroupCount ()I
+	public fun getGroupCountAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getGroupCountReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun getGroupReserve (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getGroups ()Llove/forte/simbot/common/collectable/Collectable;
+	public abstract synthetic fun group (Llove/forte/simbot/common/id/ID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun groupCount (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/bot/GuildRelation {
+	public fun getGuild (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/definition/Guild;
+	public fun getGuildAsync (Llove/forte/simbot/common/id/ID;)Ljava/util/concurrent/CompletableFuture;
+	public fun getGuildCount ()I
+	public fun getGuildCountAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getGuildCountReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun getGuildReserve (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getGuilds ()Llove/forte/simbot/common/collectable/Collectable;
+	public abstract synthetic fun guild (Llove/forte/simbot/common/id/ID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun guildCount (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract class love/forte/simbot/bot/JobBasedBot : love/forte/simbot/bot/Bot {
+	public fun <init> ()V
+	public fun cancel (Ljava/lang/Throwable;)V
+	protected abstract fun getJob ()Lkotlinx/coroutines/Job;
+	public final fun getOnJoin ()Lkotlinx/coroutines/selects/SelectClause0;
+	public fun isActive ()Z
+	public fun isCompleted ()Z
+	public fun isStarted ()Z
+	public synthetic fun join (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onCompletion (Llove/forte/simbot/ability/OnCompletion;)V
+	protected fun setStarted (Z)V
+}
+
+public abstract class love/forte/simbot/bot/JobBasedBotManager : love/forte/simbot/bot/BotManager {
+	public fun <init> ()V
+	public fun cancel (Ljava/lang/Throwable;)V
+	protected abstract fun getJob ()Lkotlinx/coroutines/Job;
+	public fun isActive ()Z
+	public fun isCompleted ()Z
+	public synthetic fun join (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onCompletion (Llove/forte/simbot/ability/OnCompletion;)V
+}
+
+public class love/forte/simbot/bot/NoSuchBotException : love/forte/simbot/bot/BotException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public final class love/forte/simbot/bot/NotSerializedBotConfiguration : love/forte/simbot/bot/SerializableBotConfiguration {
+	public static final field Companion Llove/forte/simbot/bot/NotSerializedBotConfiguration$Companion;
+	public fun <init> (Llove/forte/simbot/resource/StringResource;Ljava/lang/String;)V
+	public final fun component1 ()Llove/forte/simbot/resource/StringResource;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Llove/forte/simbot/resource/StringResource;Ljava/lang/String;)Llove/forte/simbot/bot/NotSerializedBotConfiguration;
+	public static synthetic fun copy$default (Llove/forte/simbot/bot/NotSerializedBotConfiguration;Llove/forte/simbot/resource/StringResource;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/bot/NotSerializedBotConfiguration;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getText ()Llove/forte/simbot/resource/StringResource;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static final fun resolveType (Ljava/lang/String;)Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/bot/NotSerializedBotConfiguration$Companion {
+	public final fun resolveType (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public abstract class love/forte/simbot/bot/SerializableBotConfiguration {
+	public static final field Companion Llove/forte/simbot/bot/SerializableBotConfiguration$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public static final synthetic fun write$Self (Llove/forte/simbot/bot/SerializableBotConfiguration;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class love/forte/simbot/bot/SerializableBotConfiguration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/bot/SerializableBotConfigurationKt {
+	public static final fun serializableBotConfigurationPolymorphic (Lkotlinx/serialization/modules/SerializersModuleBuilder;Lkotlin/jvm/functions/Function1;)V
+}
+
+public class love/forte/simbot/bot/UnsupportedBotConfigurationException : java/lang/IllegalArgumentException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public abstract class love/forte/simbot/bot/configuration/DispatcherConfiguration {
+	public static final field Companion Llove/forte/simbot/bot/configuration/DispatcherConfiguration$Companion;
+	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public abstract fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public static final synthetic fun write$Self (Llove/forte/simbot/bot/configuration/DispatcherConfiguration;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class love/forte/simbot/bot/configuration/DispatcherConfiguration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/bot/configuration/DispatcherConfiguration$Custom : love/forte/simbot/bot/configuration/DispatcherConfiguration {
+	public static final field Companion Llove/forte/simbot/bot/configuration/DispatcherConfiguration$Custom$Companion;
+	public fun <init> (ILjava/lang/Integer;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/bot/configuration/DispatcherConfiguration;)V
+	public synthetic fun <init> (ILjava/lang/Integer;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/bot/configuration/DispatcherConfiguration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Llove/forte/simbot/bot/configuration/DispatcherConfiguration;
+	public final fun copy (ILjava/lang/Integer;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/bot/configuration/DispatcherConfiguration;)Llove/forte/simbot/bot/configuration/DispatcherConfiguration$Custom;
+	public static synthetic fun copy$default (Llove/forte/simbot/bot/configuration/DispatcherConfiguration$Custom;ILjava/lang/Integer;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/bot/configuration/DispatcherConfiguration;ILjava/lang/Object;)Llove/forte/simbot/bot/configuration/DispatcherConfiguration$Custom;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCoreThreads ()I
+	public final fun getDemote ()Llove/forte/simbot/bot/configuration/DispatcherConfiguration;
+	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public final fun getKeepAliveMillis ()Ljava/lang/Long;
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getMaxThreads ()Ljava/lang/Integer;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/bot/configuration/DispatcherConfiguration$Custom$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/bot/configuration/DispatcherConfiguration$Custom$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/bot/configuration/DispatcherConfiguration$Custom;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/bot/configuration/DispatcherConfiguration$Custom;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/bot/configuration/DispatcherConfiguration$Custom$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/bot/configuration/DispatcherConfiguration$Default : love/forte/simbot/bot/configuration/DispatcherConfiguration$KotlinCoroutineDispatchers {
+	public static final field INSTANCE Llove/forte/simbot/bot/configuration/DispatcherConfiguration$Default;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public fun hashCode ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/bot/configuration/DispatcherConfiguration$IO : love/forte/simbot/bot/configuration/DispatcherConfiguration {
+	public static final field Companion Llove/forte/simbot/bot/configuration/DispatcherConfiguration$IO$Companion;
+	public fun <init> ()V
+	public fun <init> (Llove/forte/simbot/bot/configuration/DispatcherConfiguration;)V
+	public synthetic fun <init> (Llove/forte/simbot/bot/configuration/DispatcherConfiguration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Llove/forte/simbot/bot/configuration/DispatcherConfiguration;
+	public final fun copy (Llove/forte/simbot/bot/configuration/DispatcherConfiguration;)Llove/forte/simbot/bot/configuration/DispatcherConfiguration$IO;
+	public static synthetic fun copy$default (Llove/forte/simbot/bot/configuration/DispatcherConfiguration$IO;Llove/forte/simbot/bot/configuration/DispatcherConfiguration;ILjava/lang/Object;)Llove/forte/simbot/bot/configuration/DispatcherConfiguration$IO;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDemote ()Llove/forte/simbot/bot/configuration/DispatcherConfiguration;
+	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/bot/configuration/DispatcherConfiguration$IO$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/bot/configuration/DispatcherConfiguration$IO$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/bot/configuration/DispatcherConfiguration$IO;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/bot/configuration/DispatcherConfiguration$IO;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/bot/configuration/DispatcherConfiguration$IO$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class love/forte/simbot/bot/configuration/DispatcherConfiguration$KotlinCoroutineDispatchers : love/forte/simbot/bot/configuration/DispatcherConfiguration {
+}
+
+public final class love/forte/simbot/bot/configuration/DispatcherConfiguration$Main : love/forte/simbot/bot/configuration/DispatcherConfiguration$KotlinCoroutineDispatchers {
+	public static final field INSTANCE Llove/forte/simbot/bot/configuration/DispatcherConfiguration$Main;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public fun hashCode ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/bot/configuration/DispatcherConfiguration$Unconfined : love/forte/simbot/bot/configuration/DispatcherConfiguration$KotlinCoroutineDispatchers {
+	public static final field INSTANCE Llove/forte/simbot/bot/configuration/DispatcherConfiguration$Unconfined;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public fun hashCode ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/bot/configuration/DispatcherConfiguration$Virtual : love/forte/simbot/bot/configuration/DispatcherConfiguration {
+	public static final field Companion Llove/forte/simbot/bot/configuration/DispatcherConfiguration$Virtual$Companion;
+	public fun <init> ()V
+	public fun <init> (Llove/forte/simbot/bot/configuration/DispatcherConfiguration;)V
+	public synthetic fun <init> (Llove/forte/simbot/bot/configuration/DispatcherConfiguration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Llove/forte/simbot/bot/configuration/DispatcherConfiguration;
+	public final fun copy (Llove/forte/simbot/bot/configuration/DispatcherConfiguration;)Llove/forte/simbot/bot/configuration/DispatcherConfiguration$Virtual;
+	public static synthetic fun copy$default (Llove/forte/simbot/bot/configuration/DispatcherConfiguration$Virtual;Llove/forte/simbot/bot/configuration/DispatcherConfiguration;ILjava/lang/Object;)Llove/forte/simbot/bot/configuration/DispatcherConfiguration$Virtual;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDemote ()Llove/forte/simbot/bot/configuration/DispatcherConfiguration;
+	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/bot/configuration/DispatcherConfiguration$Virtual$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/bot/configuration/DispatcherConfiguration$Virtual$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/bot/configuration/DispatcherConfiguration$Virtual;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/bot/configuration/DispatcherConfiguration$Virtual;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/bot/configuration/DispatcherConfiguration$Virtual$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class love/forte/simbot/bot/configuration/ProxyConfiguration {
+	public static final field Companion Llove/forte/simbot/bot/configuration/ProxyConfiguration$Companion;
+	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public abstract fun getValue ()Llove/forte/simbot/bot/configuration/ProxyValue;
+	public static final synthetic fun write$Self (Llove/forte/simbot/bot/configuration/ProxyConfiguration;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class love/forte/simbot/bot/configuration/ProxyConfiguration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/bot/configuration/ProxyConfiguration$Http : love/forte/simbot/bot/configuration/ProxyConfiguration {
+	public static final field Companion Llove/forte/simbot/bot/configuration/ProxyConfiguration$Http$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Llove/forte/simbot/bot/configuration/ProxyConfiguration$Http;
+	public static synthetic fun copy$default (Llove/forte/simbot/bot/configuration/ProxyConfiguration$Http;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/bot/configuration/ProxyConfiguration$Http;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUrl ()Ljava/lang/String;
+	public fun getValue ()Llove/forte/simbot/bot/configuration/ProxyValue$Http;
+	public synthetic fun getValue ()Llove/forte/simbot/bot/configuration/ProxyValue;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/bot/configuration/ProxyConfiguration$Http$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/bot/configuration/ProxyConfiguration$Http$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/bot/configuration/ProxyConfiguration$Http;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/bot/configuration/ProxyConfiguration$Http;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/bot/configuration/ProxyConfiguration$Http$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/bot/configuration/ProxyConfiguration$Socks : love/forte/simbot/bot/configuration/ProxyConfiguration {
+	public static final field Companion Llove/forte/simbot/bot/configuration/ProxyConfiguration$Socks$Companion;
+	public fun <init> (Ljava/lang/String;I)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun copy (Ljava/lang/String;I)Llove/forte/simbot/bot/configuration/ProxyConfiguration$Socks;
+	public static synthetic fun copy$default (Llove/forte/simbot/bot/configuration/ProxyConfiguration$Socks;Ljava/lang/String;IILjava/lang/Object;)Llove/forte/simbot/bot/configuration/ProxyConfiguration$Socks;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHost ()Ljava/lang/String;
+	public final fun getPort ()I
+	public fun getValue ()Llove/forte/simbot/bot/configuration/ProxyValue$Socks;
+	public synthetic fun getValue ()Llove/forte/simbot/bot/configuration/ProxyValue;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/bot/configuration/ProxyConfiguration$Socks$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/bot/configuration/ProxyConfiguration$Socks$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/bot/configuration/ProxyConfiguration$Socks;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/bot/configuration/ProxyConfiguration$Socks;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/bot/configuration/ProxyConfiguration$Socks$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class love/forte/simbot/bot/configuration/ProxyValue {
+}
+
+public final class love/forte/simbot/bot/configuration/ProxyValue$Http : love/forte/simbot/bot/configuration/ProxyValue {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Llove/forte/simbot/bot/configuration/ProxyValue$Http;
+	public static synthetic fun copy$default (Llove/forte/simbot/bot/configuration/ProxyValue$Http;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/bot/configuration/ProxyValue$Http;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/bot/configuration/ProxyValue$Socks : love/forte/simbot/bot/configuration/ProxyValue {
+	public fun <init> (Ljava/lang/String;I)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun copy (Ljava/lang/String;I)Llove/forte/simbot/bot/configuration/ProxyValue$Socks;
+	public static synthetic fun copy$default (Llove/forte/simbot/bot/configuration/ProxyValue$Socks;Ljava/lang/String;IILjava/lang/Object;)Llove/forte/simbot/bot/configuration/ProxyValue$Socks;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHost ()Ljava/lang/String;
+	public final fun getPort ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/component/Component {
+	public static final field CLASS_DISCRIMINATOR Ljava/lang/String;
+	public static final field Companion Llove/forte/simbot/component/Component$Companion;
+	public abstract fun getId ()Ljava/lang/String;
+	public abstract fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
+}
+
+public final class love/forte/simbot/component/Component$Companion {
+	public static final field CLASS_DISCRIMINATOR Ljava/lang/String;
+}
+
+public final class love/forte/simbot/component/ComponentAlreadyExistsException : love/forte/simbot/component/ComponentException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public abstract interface class love/forte/simbot/component/ComponentConfigureContext {
+	public abstract fun getApplicationConfiguration ()Llove/forte/simbot/application/ApplicationConfiguration;
+	public abstract fun getApplicationEventRegistrar ()Llove/forte/simbot/application/ApplicationEventRegistrar;
+}
+
+public class love/forte/simbot/component/ComponentException : java/lang/RuntimeException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public final class love/forte/simbot/component/ComponentFactoriesConfigurator : love/forte/simbot/common/function/MergeableFactoriesConfigurator {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public abstract interface class love/forte/simbot/component/ComponentFactory : love/forte/simbot/common/function/MergeableFactory {
+}
+
+public abstract interface class love/forte/simbot/component/ComponentFactory$Key : love/forte/simbot/common/function/MergeableFactory$Key {
+}
+
+public abstract interface class love/forte/simbot/component/ComponentFactoryConfigurerProvider {
+	public abstract fun configure (Ljava/lang/Object;)V
+}
+
+public abstract interface class love/forte/simbot/component/ComponentFactoryProvider {
+	public fun loadConfigurers ()Lkotlin/sequences/Sequence;
+	public fun loadConfigures ()Lkotlin/sequences/Sequence;
+	public abstract fun provide ()Llove/forte/simbot/component/ComponentFactory;
+}
+
+public final class love/forte/simbot/component/ComponentFactoryProviders {
+	public static final fun addComponentFactoryProvider (Lkotlin/jvm/functions/Function0;)V
+	public static final fun clearComponentFactoryProviders ()V
+	public static final fun findAndInstallAllComponents (Llove/forte/simbot/component/ComponentInstaller;Z)V
+	public static final fun loadComponentFactoriesFromProviders (Ljava/lang/ClassLoader;Z)Lkotlin/sequences/Sequence;
+	public static final fun loadComponentFactoriesFromProviders (Z)Lkotlin/sequences/Sequence;
+	public static final fun loadComponentProviders ()Lkotlin/sequences/Sequence;
+	public static final fun loadComponentProviders (Ljava/lang/ClassLoader;)Lkotlin/sequences/Sequence;
+}
+
+public abstract interface class love/forte/simbot/component/ComponentInstaller {
+	public fun install (Llove/forte/simbot/component/ComponentFactory;)V
+	public abstract fun install (Llove/forte/simbot/component/ComponentFactory;Llove/forte/simbot/common/function/ConfigurerFunction;)V
+}
+
+public final class love/forte/simbot/component/ComponentUtil {
+	public static final fun toComponents (Ljava/util/Collection;)Llove/forte/simbot/component/Components;
+}
+
+public abstract interface class love/forte/simbot/component/Components : java/util/Collection, kotlin/jvm/internal/markers/KMappedMarker {
+	public fun findById (Ljava/lang/String;)Llove/forte/simbot/component/Component;
+	public abstract fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
+}
+
+public final class love/forte/simbot/component/NoSuchComponentException : love/forte/simbot/component/ComponentException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public abstract interface class love/forte/simbot/definition/Actor : kotlinx/coroutines/CoroutineScope, love/forte/simbot/common/id/IDContainer {
+	public abstract fun getId ()Llove/forte/simbot/common/id/ID;
+}
+
+public abstract interface class love/forte/simbot/definition/Category {
+	public abstract fun getId ()Llove/forte/simbot/common/id/ID;
+	public fun getName ()Ljava/lang/String;
+	public fun getNameAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getNameReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun name (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/definition/Channel : love/forte/simbot/definition/Actor {
+	public abstract fun getCategory ()Llove/forte/simbot/definition/Category;
+	public abstract fun getId ()Llove/forte/simbot/common/id/ID;
+	public abstract fun getName ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/definition/ChatChannel : love/forte/simbot/definition/Channel, love/forte/simbot/definition/ChatRoom {
+}
+
+public abstract interface class love/forte/simbot/definition/ChatGroup : love/forte/simbot/definition/ChatRoom, love/forte/simbot/definition/Organization {
+	public abstract fun getId ()Llove/forte/simbot/common/id/ID;
+	public abstract fun getName ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/definition/ChatRoom : love/forte/simbot/ability/SendSupport, love/forte/simbot/definition/Actor {
+	public abstract fun getName ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/definition/Contact : love/forte/simbot/ability/SendSupport, love/forte/simbot/definition/User {
+	public abstract fun getName ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/definition/Guild : love/forte/simbot/definition/Organization {
+	public abstract synthetic fun channel (Llove/forte/simbot/common/id/ID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun chatChannel (Llove/forte/simbot/common/id/ID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getChannel (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/definition/Channel;
+	public fun getChannelAsync (Llove/forte/simbot/common/id/ID;)Ljava/util/concurrent/CompletableFuture;
+	public fun getChannelReserve (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getChannels ()Llove/forte/simbot/common/collectable/Collectable;
+	public fun getChatChannel (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/definition/ChatChannel;
+	public fun getChatChannelAsync (Llove/forte/simbot/common/id/ID;)Ljava/util/concurrent/CompletableFuture;
+	public fun getChatChannelReserve (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getChatChannels ()Llove/forte/simbot/common/collectable/Collectable;
+	public abstract fun getId ()Llove/forte/simbot/common/id/ID;
+	public abstract fun getName ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/definition/Member : love/forte/simbot/ability/SendSupport, love/forte/simbot/definition/User {
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getNick ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/definition/Organization : love/forte/simbot/definition/Actor {
+	public abstract synthetic fun botAsMember (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getBotAsMember ()Llove/forte/simbot/definition/Member;
+	public fun getBotAsMemberAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getBotAsMemberReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun getMember (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/definition/Member;
+	public fun getMemberAsync (Llove/forte/simbot/common/id/ID;)Ljava/util/concurrent/CompletableFuture;
+	public fun getMemberReserve (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getMembers ()Llove/forte/simbot/common/collectable/Collectable;
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getOwnerId ()Llove/forte/simbot/common/id/ID;
+	public abstract fun getRoles ()Llove/forte/simbot/common/collectable/Collectable;
+	public abstract synthetic fun member (Llove/forte/simbot/common/id/ID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/definition/Role {
+	public abstract fun getId ()Llove/forte/simbot/common/id/ID;
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun isAdmin ()Z
+}
+
+public abstract interface class love/forte/simbot/definition/User : love/forte/simbot/definition/Actor {
+	public abstract fun getAvatar ()Ljava/lang/String;
+	public abstract fun getName ()Ljava/lang/String;
+}
+
+public abstract class love/forte/simbot/event/AbstractEventDispatcherConfiguration : love/forte/simbot/event/EventDispatcherConfiguration {
+	public fun <init> ()V
+	public fun addDispatchInterceptor (Llove/forte/simbot/common/function/ConfigurerFunction;Llove/forte/simbot/event/EventDispatchInterceptor;)V
+	public fun addInterceptor (Llove/forte/simbot/common/function/ConfigurerFunction;Llove/forte/simbot/event/EventInterceptor;)V
+	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	protected fun getDispatchInterceptors ()Ljava/util/List;
+	protected fun getInterceptors ()Ljava/util/List;
+	public fun setCoroutineContext (Lkotlin/coroutines/CoroutineContext;)V
+}
+
+public abstract interface class love/forte/simbot/event/ActorAuthorAwareMessageEvent : love/forte/simbot/event/AuthorAwareMessageEvent {
+	public abstract synthetic fun author (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getAuthor ()Llove/forte/simbot/common/id/IDContainer;
+	public fun getAuthor ()Llove/forte/simbot/definition/Actor;
+	public fun getAuthorAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getAuthorReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/event/ActorEvent : love/forte/simbot/event/BotEvent, love/forte/simbot/event/ContentEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/event/AuthorAwareMessageEvent : love/forte/simbot/event/MessageEvent {
+	public abstract synthetic fun author (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getAuthor ()Llove/forte/simbot/common/id/IDContainer;
+	public fun getAuthorAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getAuthorReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/event/BotEvent : love/forte/simbot/event/ComponentEvent {
+	public abstract fun getBot ()Llove/forte/simbot/bot/Bot;
+	public fun getComponent ()Llove/forte/simbot/component/Component;
+}
+
+public abstract interface class love/forte/simbot/event/BotRegisteredEvent : love/forte/simbot/event/BotStageEvent {
+}
+
+public abstract interface class love/forte/simbot/event/BotStageEvent : love/forte/simbot/event/BotEvent {
+	public abstract fun getBot ()Llove/forte/simbot/bot/Bot;
+}
+
+public abstract interface class love/forte/simbot/event/BotStartedEvent : love/forte/simbot/event/BotStageEvent {
+}
+
+public abstract interface class love/forte/simbot/event/ChangeEvent : love/forte/simbot/event/ContentEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getContent ()Ljava/lang/Object;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/event/ChannelEvent : love/forte/simbot/event/ActorEvent, love/forte/simbot/event/OrganizationSourceEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContent ()Llove/forte/simbot/definition/Channel;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun getSource ()Ljava/lang/Object;
+	public fun getSource ()Llove/forte/simbot/definition/Guild;
+	public synthetic fun getSource ()Llove/forte/simbot/definition/Organization;
+	public fun getSourceAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getSourceReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun source (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/event/ChatChannelEvent : love/forte/simbot/event/ChannelEvent, love/forte/simbot/event/ChatRoomEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Channel;
+	public fun getContent ()Llove/forte/simbot/definition/ChatChannel;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/ChatRoom;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/event/ChatChannelMessageEvent : love/forte/simbot/event/ChatChannelEvent, love/forte/simbot/event/ChatRoomMessageEvent, love/forte/simbot/event/MemberAuthorAwareMessageEvent {
+}
+
+public abstract interface class love/forte/simbot/event/ChatGroupEvent : love/forte/simbot/event/ChatRoomEvent, love/forte/simbot/event/OrganizationEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContent ()Llove/forte/simbot/definition/ChatGroup;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/ChatRoom;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/event/ChatGroupJoinRequestEvent : love/forte/simbot/event/ChatGroupEvent, love/forte/simbot/event/OrganizationJoinRequestEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContent ()Llove/forte/simbot/definition/ChatGroup;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/ChatRoom;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/event/ChatGroupMemberDecreaseEvent : love/forte/simbot/event/ChatGroupMemberIncreaseOrDecreaseEvent, love/forte/simbot/event/MemberDecreaseEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContent ()Llove/forte/simbot/definition/ChatGroup;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/ChatRoom;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/event/ChatGroupMemberEvent : love/forte/simbot/event/MemberEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContent ()Llove/forte/simbot/definition/Member;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun getSource ()Ljava/lang/Object;
+	public fun getSource ()Llove/forte/simbot/definition/ChatGroup;
+	public synthetic fun getSource ()Llove/forte/simbot/definition/Organization;
+	public fun getSourceAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getSourceReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun source (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/event/ChatGroupMemberIncreaseEvent : love/forte/simbot/event/ChatGroupMemberIncreaseOrDecreaseEvent, love/forte/simbot/event/MemberIncreaseEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContent ()Llove/forte/simbot/definition/ChatGroup;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/ChatRoom;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/event/ChatGroupMemberIncreaseOrDecreaseEvent : love/forte/simbot/event/ChatGroupEvent, love/forte/simbot/event/MemberIncreaseOrDecreaseEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContent ()Llove/forte/simbot/definition/ChatGroup;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/ChatRoom;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/event/ChatGroupMemberMessageEvent : love/forte/simbot/event/MemberEvent, love/forte/simbot/event/MessageEvent {
+	public synthetic fun getSource ()Ljava/lang/Object;
+	public fun getSource ()Llove/forte/simbot/definition/ChatGroup;
+	public synthetic fun getSource ()Llove/forte/simbot/definition/Organization;
+	public fun getSourceAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getSourceReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun source (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/event/ChatGroupMessageEvent : love/forte/simbot/event/ChatGroupEvent, love/forte/simbot/event/ChatRoomMessageEvent, love/forte/simbot/event/MemberAuthorAwareMessageEvent {
+}
+
+public abstract interface class love/forte/simbot/event/ChatRoomEvent : love/forte/simbot/event/ActorEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContent ()Llove/forte/simbot/definition/ChatRoom;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/event/ChatRoomMessageEvent : love/forte/simbot/event/ChatRoomEvent, love/forte/simbot/event/MessageEvent {
+}
+
+public abstract interface class love/forte/simbot/event/ComponentEvent : love/forte/simbot/event/Event {
+	public abstract fun getComponent ()Llove/forte/simbot/component/Component;
+}
+
+public abstract interface class love/forte/simbot/event/ContactEvent : love/forte/simbot/event/ActorEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContent ()Llove/forte/simbot/definition/Contact;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/event/ContactMessageEvent : love/forte/simbot/event/ContactEvent, love/forte/simbot/event/MessageEvent {
+}
+
+public abstract interface class love/forte/simbot/event/ContentEvent : love/forte/simbot/event/Event {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getContent ()Ljava/lang/Object;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/event/Event : love/forte/simbot/common/id/IDContainer {
+	public abstract fun getId ()Llove/forte/simbot/common/id/ID;
+	public abstract fun getTime ()Llove/forte/simbot/common/time/Timestamp;
+}
+
+public abstract interface class love/forte/simbot/event/EventContext : kotlinx/coroutines/CoroutineScope {
+	public abstract fun getAttributes ()Llove/forte/simbot/common/attribute/MutableAttributeMap;
+	public abstract fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	public abstract fun getEvent ()Llove/forte/simbot/event/Event;
+}
+
+public abstract interface class love/forte/simbot/event/EventDispatchInterceptor {
+	public abstract fun intercept (Llove/forte/simbot/event/EventDispatchInterceptor$Context;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class love/forte/simbot/event/EventDispatchInterceptor$Context {
+	public abstract fun getEventContext ()Llove/forte/simbot/event/EventContext;
+	public abstract fun invoke ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun invoke (Llove/forte/simbot/event/EventContext;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class love/forte/simbot/event/EventDispatchInterceptorRegistrationProperties {
+	public abstract fun getPriority ()I
+	public abstract fun setPriority (I)V
+}
+
+public abstract interface class love/forte/simbot/event/EventDispatcher : love/forte/simbot/event/EventListenerContainer, love/forte/simbot/event/EventListenerRegistrar, love/forte/simbot/event/EventProcessor {
+}
+
+public abstract interface class love/forte/simbot/event/EventDispatcherConfiguration {
+	public abstract fun addDispatchInterceptor (Llove/forte/simbot/common/function/ConfigurerFunction;Llove/forte/simbot/event/EventDispatchInterceptor;)V
+	public fun addDispatchInterceptor (Llove/forte/simbot/event/EventDispatchInterceptor;)V
+	public abstract fun addInterceptor (Llove/forte/simbot/common/function/ConfigurerFunction;Llove/forte/simbot/event/EventInterceptor;)V
+	public fun addInterceptor (Llove/forte/simbot/event/EventInterceptor;)V
+	public abstract fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	public abstract fun setCoroutineContext (Lkotlin/coroutines/CoroutineContext;)V
+}
+
+public abstract interface annotation class love/forte/simbot/event/EventDispatcherConfigurationDSL : java/lang/annotation/Annotation {
+}
+
+public abstract interface class love/forte/simbot/event/EventInterceptor {
+	public abstract synthetic fun intercept (Llove/forte/simbot/event/EventInterceptor$Context;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/event/EventInterceptor$Context {
+	public abstract fun getEventListenerContext ()Llove/forte/simbot/event/EventListenerContext;
+	public abstract synthetic fun invoke (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun invoke (Llove/forte/simbot/event/EventListenerContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/event/EventInterceptorRegistrationProperties {
+	public abstract fun getPriority ()I
+	public abstract fun setPriority (I)V
+}
+
+public final class love/forte/simbot/event/EventInterceptors {
+	public static final fun async (Llove/forte/simbot/event/JAsyncEventInterceptor;)Llove/forte/simbot/event/JAsyncEventInterceptor;
+	public static final fun block (Llove/forte/simbot/event/JBlockEventInterceptor;)Llove/forte/simbot/event/JBlockEventInterceptor;
+}
+
+public abstract interface class love/forte/simbot/event/EventListener {
+	public abstract synthetic fun handle (Llove/forte/simbot/event/EventListenerContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/event/EventListenerContainer {
+	public abstract fun getListeners ()Lkotlin/sequences/Sequence;
+}
+
+public abstract interface class love/forte/simbot/event/EventListenerContext {
+	public abstract fun getContext ()Llove/forte/simbot/event/EventContext;
+	public fun getEvent ()Llove/forte/simbot/event/Event;
+	public abstract fun getListener ()Llove/forte/simbot/event/EventListener;
+	public abstract fun getPlainText ()Ljava/lang/String;
+	public abstract fun setPlainText (Ljava/lang/String;)V
+}
+
+public abstract interface class love/forte/simbot/event/EventListenerRegistrar {
+	public abstract fun dispose (Llove/forte/simbot/event/EventListener;)V
+	public abstract fun register (Llove/forte/simbot/common/function/ConfigurerFunction;Llove/forte/simbot/event/EventListener;)Llove/forte/simbot/event/EventListenerRegistrationHandle;
+	public fun register (Llove/forte/simbot/event/EventListener;)Llove/forte/simbot/event/EventListenerRegistrationHandle;
+}
+
+public final class love/forte/simbot/event/EventListenerRegistrarKt {
+	public static final fun process (Llove/forte/simbot/event/EventListenerRegistrar;Lkotlin/jvm/functions/Function0;Llove/forte/simbot/common/function/ConfigurerFunction;Lkotlin/jvm/functions/Function2;)Llove/forte/simbot/event/EventListenerRegistrationHandle;
+	public static synthetic fun process$default (Llove/forte/simbot/event/EventListenerRegistrar;Lkotlin/jvm/functions/Function0;Llove/forte/simbot/common/function/ConfigurerFunction;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Llove/forte/simbot/event/EventListenerRegistrationHandle;
+}
+
+public abstract interface class love/forte/simbot/event/EventListenerRegistrationHandle {
+	public abstract fun dispose ()V
+}
+
+public abstract interface class love/forte/simbot/event/EventListenerRegistrationProperties {
+	public abstract fun addInterceptor (Llove/forte/simbot/common/function/ConfigurerFunction;Llove/forte/simbot/event/EventInterceptor;)V
+	public fun addInterceptor (Llove/forte/simbot/event/EventInterceptor;)V
+	public abstract fun getPriority ()I
+	public abstract fun setPriority (I)V
+}
+
+public final class love/forte/simbot/event/EventListeners {
+	public static final fun async (Ljava/lang/Class;Llove/forte/simbot/event/TypedJAsyncEventListener;)Llove/forte/simbot/event/EventListener;
+	public static final fun async (Llove/forte/simbot/event/JAsyncEventListener;)Llove/forte/simbot/event/EventListener;
+	public static final fun block (Ljava/lang/Class;Llove/forte/simbot/event/TypedJBlockEventListener;)Llove/forte/simbot/event/EventListener;
+	public static final fun block (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Class;Llove/forte/simbot/event/TypedJBlockEventListener;)Llove/forte/simbot/event/EventListener;
+	public static final fun block (Lkotlin/coroutines/CoroutineContext;Llove/forte/simbot/event/JBlockEventListener;)Llove/forte/simbot/event/EventListener;
+	public static final fun block (Llove/forte/simbot/event/JBlockEventListener;)Llove/forte/simbot/event/EventListener;
+	public static synthetic fun block$default (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Class;Llove/forte/simbot/event/TypedJBlockEventListener;ILjava/lang/Object;)Llove/forte/simbot/event/EventListener;
+	public static synthetic fun block$default (Lkotlin/coroutines/CoroutineContext;Llove/forte/simbot/event/JBlockEventListener;ILjava/lang/Object;)Llove/forte/simbot/event/EventListener;
+	public static final fun handleWith (Llove/forte/simbot/event/EventListener;Llove/forte/simbot/event/EventListenerContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/event/EventProcessor {
+	public abstract fun push (Llove/forte/simbot/event/Event;)Lkotlinx/coroutines/flow/Flow;
+	public fun pushAndLaunch (Lkotlinx/coroutines/CoroutineScope;Llove/forte/simbot/event/Event;)Lkotlinx/coroutines/Job;
+}
+
+public final class love/forte/simbot/event/EventProcessors {
+	public static final fun filterNotEmpty (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun filterNotEmptyResult (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun filterNotError (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun filterNotInvalid (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun filterOnlyValid (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun onEachError (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun pushAndAsFlux (Llove/forte/simbot/event/EventProcessor;Llove/forte/simbot/event/Event;)Lreactor/core/publisher/Flux;
+	public static final fun pushAndAsStream (Llove/forte/simbot/event/EventProcessor;Llove/forte/simbot/event/Event;Lkotlinx/coroutines/CoroutineScope;)Ljava/util/stream/Stream;
+	public static final synthetic fun pushAndCollect (Llove/forte/simbot/event/EventProcessor;Llove/forte/simbot/event/Event;Lkotlinx/coroutines/flow/FlowCollector;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun pushAndCollect$default (Llove/forte/simbot/event/EventProcessor;Llove/forte/simbot/event/Event;Lkotlinx/coroutines/flow/FlowCollector;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun pushAndCollectToAsync (Llove/forte/simbot/event/EventProcessor;Llove/forte/simbot/event/Event;Lkotlinx/coroutines/CoroutineScope;Ljava/util/Collection;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun pushAndCollectToAsync (Llove/forte/simbot/event/EventProcessor;Llove/forte/simbot/event/Event;Lkotlinx/coroutines/CoroutineScope;Ljava/util/stream/Collector;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun pushAndCollectToBlocking (Llove/forte/simbot/event/EventProcessor;Llove/forte/simbot/event/Event;Ljava/util/Collection;)Ljava/util/Collection;
+	public static final fun pushAndCollectToBlocking (Llove/forte/simbot/event/EventProcessor;Llove/forte/simbot/event/Event;Ljava/util/stream/Collector;)Ljava/lang/Object;
+	public static final fun pushAndCollectToListAsync (Llove/forte/simbot/event/EventProcessor;Llove/forte/simbot/event/Event;Lkotlinx/coroutines/CoroutineScope;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun pushAndCollectToListBlocking (Llove/forte/simbot/event/EventProcessor;Llove/forte/simbot/event/Event;)Ljava/util/List;
+	public static final synthetic fun pushAndLaunch (Llove/forte/simbot/event/EventProcessor;Lkotlinx/coroutines/CoroutineScope;Llove/forte/simbot/event/Event;Lkotlinx/coroutines/flow/FlowCollector;)Lkotlinx/coroutines/Job;
+	public static synthetic fun pushAndLaunch$default (Llove/forte/simbot/event/EventProcessor;Lkotlinx/coroutines/CoroutineScope;Llove/forte/simbot/event/Event;Lkotlinx/coroutines/flow/FlowCollector;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
+	public static final synthetic fun pushAndLaunchThen (Llove/forte/simbot/event/EventProcessor;Lkotlinx/coroutines/CoroutineScope;Llove/forte/simbot/event/Event;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/Job;
+	public static final fun takeWhileNotEmpty (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun takeWhileNotEmptyResult (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun takeWhileNotError (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun takeWhileNotInvalid (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun throwIfError (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class love/forte/simbot/event/EventResult {
+	public static final field Companion Llove/forte/simbot/event/EventResult$Companion;
+	public static fun empty ()Llove/forte/simbot/event/EventResult;
+	public static fun empty (Z)Llove/forte/simbot/event/EventResult;
+	public static fun error (Ljava/lang/Throwable;)Llove/forte/simbot/event/StandardEventResult$Error;
+	public static fun error (Ljava/lang/Throwable;Z)Llove/forte/simbot/event/StandardEventResult$Error;
+	public abstract fun getContent ()Ljava/lang/Object;
+	public static fun invalid ()Llove/forte/simbot/event/EventResult;
+	public abstract fun isTruncated ()Z
+	public static fun of ()Llove/forte/simbot/event/EventResult;
+	public static fun of (Ljava/lang/Object;)Llove/forte/simbot/event/EventResult;
+	public static fun of (Ljava/lang/Object;Z)Llove/forte/simbot/event/EventResult;
+}
+
+public final class love/forte/simbot/event/EventResult$Companion {
+	public final fun empty ()Llove/forte/simbot/event/EventResult;
+	public final fun empty (Z)Llove/forte/simbot/event/EventResult;
+	public static synthetic fun empty$default (Llove/forte/simbot/event/EventResult$Companion;ZILjava/lang/Object;)Llove/forte/simbot/event/EventResult;
+	public final fun error (Ljava/lang/Throwable;)Llove/forte/simbot/event/StandardEventResult$Error;
+	public final fun error (Ljava/lang/Throwable;Z)Llove/forte/simbot/event/StandardEventResult$Error;
+	public static synthetic fun error$default (Llove/forte/simbot/event/EventResult$Companion;Ljava/lang/Throwable;ZILjava/lang/Object;)Llove/forte/simbot/event/StandardEventResult$Error;
+	public final synthetic fun getInvalid ()Llove/forte/simbot/event/EventResult;
+	public final fun invalid ()Llove/forte/simbot/event/EventResult;
+	public final fun of ()Llove/forte/simbot/event/EventResult;
+	public final fun of (Ljava/lang/Object;)Llove/forte/simbot/event/EventResult;
+	public final fun of (Ljava/lang/Object;Z)Llove/forte/simbot/event/EventResult;
+	public static synthetic fun of$default (Llove/forte/simbot/event/EventResult$Companion;Ljava/lang/Object;ZILjava/lang/Object;)Llove/forte/simbot/event/EventResult;
+}
+
+public final class love/forte/simbot/event/EventResultKt {
+	public static final fun collectCollectableReactivelyToResult (Llove/forte/simbot/event/StandardEventResult$CollectableReactivelyResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun collected (Llove/forte/simbot/event/EventResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun isEmpty (Llove/forte/simbot/event/EventResult;)Z
+}
+
+public final class love/forte/simbot/event/EventResult_jvmKt {
+	public static final fun collectCollectableReactively (Llove/forte/simbot/event/StandardEventResult$CollectableReactivelyResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/event/GroupMemberChangeEvent : love/forte/simbot/event/ChangeEvent, love/forte/simbot/event/ChatGroupMemberEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContent ()Llove/forte/simbot/definition/Member;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun getSource ()Ljava/lang/Object;
+	public fun getSource ()Llove/forte/simbot/definition/ChatGroup;
+	public synthetic fun getSource ()Llove/forte/simbot/definition/Organization;
+	public fun getSourceAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getSourceReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun source (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/event/GuildEvent : love/forte/simbot/event/OrganizationEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContent ()Llove/forte/simbot/definition/Guild;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/event/GuildJoinRequestEvent : love/forte/simbot/event/GuildEvent, love/forte/simbot/event/OrganizationJoinRequestEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContent ()Llove/forte/simbot/definition/Guild;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/event/GuildMemberChangeEvent : love/forte/simbot/event/ChangeEvent, love/forte/simbot/event/GuildMemberEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContent ()Llove/forte/simbot/definition/Member;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun getSource ()Ljava/lang/Object;
+	public fun getSource ()Llove/forte/simbot/definition/Guild;
+	public synthetic fun getSource ()Llove/forte/simbot/definition/Organization;
+	public fun getSourceAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getSourceReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun source (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/event/GuildMemberDecreaseEvent : love/forte/simbot/event/GuildMemberIncreaseOrDecreaseEvent, love/forte/simbot/event/MemberDecreaseEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContent ()Llove/forte/simbot/definition/Guild;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/event/GuildMemberEvent : love/forte/simbot/event/MemberEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContent ()Llove/forte/simbot/definition/Member;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun getSource ()Ljava/lang/Object;
+	public fun getSource ()Llove/forte/simbot/definition/Guild;
+	public synthetic fun getSource ()Llove/forte/simbot/definition/Organization;
+	public fun getSourceAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getSourceReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun source (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/event/GuildMemberIncreaseEvent : love/forte/simbot/event/GuildMemberIncreaseOrDecreaseEvent, love/forte/simbot/event/MemberIncreaseEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContent ()Llove/forte/simbot/definition/Guild;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/event/GuildMemberIncreaseOrDecreaseEvent : love/forte/simbot/event/GuildEvent, love/forte/simbot/event/MemberIncreaseOrDecreaseEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContent ()Llove/forte/simbot/definition/Guild;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/event/GuildMemberMessageEvent : love/forte/simbot/event/MemberEvent, love/forte/simbot/event/MessageEvent {
+	public synthetic fun getSource ()Ljava/lang/Object;
+	public fun getSource ()Llove/forte/simbot/definition/Guild;
+	public synthetic fun getSource ()Llove/forte/simbot/definition/Organization;
+	public fun getSourceAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getSourceReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun source (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/event/JAsyncEventInterceptor : love/forte/simbot/event/EventInterceptor {
+	public fun createContext (Llove/forte/simbot/event/EventInterceptor$Context;)Llove/forte/simbot/event/JAsyncEventInterceptor$Context;
+	public synthetic fun intercept (Llove/forte/simbot/event/EventInterceptor$Context;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun intercept (Llove/forte/simbot/event/JAsyncEventInterceptor$Context;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun intercept$suspendImpl (Llove/forte/simbot/event/JAsyncEventInterceptor;Llove/forte/simbot/event/EventInterceptor$Context;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/event/JAsyncEventInterceptor$Context {
+	public fun <init> (Llove/forte/simbot/event/EventInterceptor$Context;Lkotlinx/coroutines/CoroutineScope;)V
+	public final fun component1 ()Llove/forte/simbot/event/EventInterceptor$Context;
+	public final fun component2 ()Lkotlinx/coroutines/CoroutineScope;
+	public final fun copy (Llove/forte/simbot/event/EventInterceptor$Context;Lkotlinx/coroutines/CoroutineScope;)Llove/forte/simbot/event/JAsyncEventInterceptor$Context;
+	public static synthetic fun copy$default (Llove/forte/simbot/event/JAsyncEventInterceptor$Context;Llove/forte/simbot/event/EventInterceptor$Context;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Llove/forte/simbot/event/JAsyncEventInterceptor$Context;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getScope ()Lkotlinx/coroutines/CoroutineScope;
+	public final fun getSource ()Llove/forte/simbot/event/EventInterceptor$Context;
+	public fun hashCode ()I
+	public final fun invoke ()Ljava/util/concurrent/CompletableFuture;
+	public final fun invoke (Llove/forte/simbot/event/EventListenerContext;)Ljava/util/concurrent/CompletableFuture;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/event/JAsyncEventListener {
+	public static final field Companion Llove/forte/simbot/event/JAsyncEventListener$Companion;
+	public fun emptyResult ()Ljava/util/concurrent/CompletionStage;
+	public abstract fun handle (Llove/forte/simbot/event/EventListenerContext;)Ljava/util/concurrent/CompletionStage;
+	public fun invalidResult ()Ljava/util/concurrent/CompletionStage;
+	public fun result (Llove/forte/simbot/event/EventResult;)Ljava/util/concurrent/CompletionStage;
+	public static fun toListener (Llove/forte/simbot/event/JAsyncEventListener;)Llove/forte/simbot/event/EventListener;
+}
+
+public final class love/forte/simbot/event/JAsyncEventListener$Companion {
+	public final fun toListener (Llove/forte/simbot/event/JAsyncEventListener;)Llove/forte/simbot/event/EventListener;
+}
+
+public abstract interface class love/forte/simbot/event/JBlockEventInterceptor : love/forte/simbot/event/EventInterceptor {
+	public synthetic fun intercept (Llove/forte/simbot/event/EventInterceptor$Context;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun intercept (Llove/forte/simbot/event/JBlockEventInterceptor$Context;)Llove/forte/simbot/event/EventResult;
+	public static synthetic fun intercept$suspendImpl (Llove/forte/simbot/event/JBlockEventInterceptor;Llove/forte/simbot/event/EventInterceptor$Context;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/event/JBlockEventInterceptor$Context {
+	public fun <init> (Llove/forte/simbot/event/EventInterceptor$Context;)V
+	public final fun component1 ()Llove/forte/simbot/event/EventInterceptor$Context;
+	public final fun copy (Llove/forte/simbot/event/EventInterceptor$Context;)Llove/forte/simbot/event/JBlockEventInterceptor$Context;
+	public static synthetic fun copy$default (Llove/forte/simbot/event/JBlockEventInterceptor$Context;Llove/forte/simbot/event/EventInterceptor$Context;ILjava/lang/Object;)Llove/forte/simbot/event/JBlockEventInterceptor$Context;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSource ()Llove/forte/simbot/event/EventInterceptor$Context;
+	public fun hashCode ()I
+	public final fun invoke ()Llove/forte/simbot/event/EventResult;
+	public final fun invoke (Llove/forte/simbot/event/EventListenerContext;)Llove/forte/simbot/event/EventResult;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/event/JBlockEventListener {
+	public static final field Companion Llove/forte/simbot/event/JBlockEventListener$Companion;
+	public abstract fun handle (Llove/forte/simbot/event/EventListenerContext;)Llove/forte/simbot/event/EventResult;
+	public static fun toListener (Lkotlin/coroutines/CoroutineContext;Llove/forte/simbot/event/JBlockEventListener;)Llove/forte/simbot/event/EventListener;
+	public static fun toListener (Llove/forte/simbot/event/JBlockEventListener;)Llove/forte/simbot/event/EventListener;
+}
+
+public final class love/forte/simbot/event/JBlockEventListener$Companion {
+	public final fun toListener (Lkotlin/coroutines/CoroutineContext;Llove/forte/simbot/event/JBlockEventListener;)Llove/forte/simbot/event/EventListener;
+	public final fun toListener (Llove/forte/simbot/event/JBlockEventListener;)Llove/forte/simbot/event/EventListener;
+	public static synthetic fun toListener$default (Llove/forte/simbot/event/JBlockEventListener$Companion;Lkotlin/coroutines/CoroutineContext;Llove/forte/simbot/event/JBlockEventListener;ILjava/lang/Object;)Llove/forte/simbot/event/EventListener;
+}
+
+public abstract interface class love/forte/simbot/event/MemberAuthorAwareMessageEvent : love/forte/simbot/event/ActorAuthorAwareMessageEvent {
+	public abstract synthetic fun author (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getAuthor ()Llove/forte/simbot/common/id/IDContainer;
+	public synthetic fun getAuthor ()Llove/forte/simbot/definition/Actor;
+	public fun getAuthor ()Llove/forte/simbot/definition/Member;
+	public fun getAuthorAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getAuthorReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/event/MemberChangeEvent : love/forte/simbot/event/ChangeEvent, love/forte/simbot/event/MemberEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContent ()Llove/forte/simbot/definition/Member;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/event/MemberDecreaseEvent : love/forte/simbot/event/MemberIncreaseOrDecreaseEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun getMember ()Llove/forte/simbot/definition/Member;
+	public fun getMemberAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getMemberReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun member (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/event/MemberEvent : love/forte/simbot/event/ActorEvent, love/forte/simbot/event/OrganizationSourceEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContent ()Llove/forte/simbot/definition/Member;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun getSource ()Ljava/lang/Object;
+	public fun getSource ()Llove/forte/simbot/definition/Organization;
+	public fun getSourceAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getSourceReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun source (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/event/MemberIncreaseEvent : love/forte/simbot/event/MemberIncreaseOrDecreaseEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun getMember ()Llove/forte/simbot/definition/Member;
+	public fun getMemberAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getMemberReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun member (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/event/MemberIncreaseOrDecreaseEvent : love/forte/simbot/event/OrganizationChangeEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun getMember ()Llove/forte/simbot/definition/Member;
+	public fun getMemberAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getMemberReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun member (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/event/MemberMessageEvent : love/forte/simbot/event/MemberEvent, love/forte/simbot/event/MessageEvent {
+}
+
+public abstract interface class love/forte/simbot/event/MessageContentAwareEvent : love/forte/simbot/event/Event {
+	public abstract fun getMessageContent ()Llove/forte/simbot/message/MessageContent;
+}
+
+public abstract interface class love/forte/simbot/event/MessageEvent : love/forte/simbot/ability/ReplySupport, love/forte/simbot/event/BotEvent, love/forte/simbot/event/MessageContentAwareEvent {
+	public abstract fun getAuthorId ()Llove/forte/simbot/common/id/ID;
+	public abstract fun getMessageContent ()Llove/forte/simbot/message/MessageContent;
+}
+
+public abstract interface class love/forte/simbot/event/OrganizationChangeEvent : love/forte/simbot/event/ChangeEvent, love/forte/simbot/event/OrganizationEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/event/OrganizationEvent : love/forte/simbot/event/ActorEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/event/OrganizationJoinRequestEvent : love/forte/simbot/event/OrganizationEvent {
+	public fun getRequester ()Llove/forte/simbot/definition/User;
+	public fun getRequesterAsync ()Ljava/util/concurrent/CompletableFuture;
+	public abstract fun getRequesterId ()Llove/forte/simbot/common/id/ID;
+	public fun getRequesterReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun requester (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/event/OrganizationRequestEvent : love/forte/simbot/event/OrganizationEvent, love/forte/simbot/event/RequestEvent {
+}
+
+public abstract interface class love/forte/simbot/event/OrganizationSourceEvent : love/forte/simbot/event/BotEvent, love/forte/simbot/event/SourceEvent {
+	public synthetic fun getSource ()Ljava/lang/Object;
+	public fun getSource ()Llove/forte/simbot/definition/Organization;
+	public fun getSourceAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getSourceReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun source (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/event/RequestEvent : love/forte/simbot/event/BotEvent {
+	public abstract synthetic fun accept (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun acceptAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun acceptBlocking ()V
+	public fun acceptReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getMessage ()Ljava/lang/String;
+	public abstract fun getType ()Llove/forte/simbot/event/RequestEvent$Type;
+	public abstract synthetic fun reject (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun rejectAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun rejectBlocking ()V
+	public fun rejectReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public final class love/forte/simbot/event/RequestEvent$Type : java/lang/Enum {
+	public static final field PASSIVE Llove/forte/simbot/event/RequestEvent$Type;
+	public static final field PROACTIVE Llove/forte/simbot/event/RequestEvent$Type;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Llove/forte/simbot/event/RequestEvent$Type;
+	public static fun values ()[Llove/forte/simbot/event/RequestEvent$Type;
+}
+
+public abstract interface class love/forte/simbot/event/SourceEvent : love/forte/simbot/event/Event {
+	public fun getSource ()Ljava/lang/Object;
+	public fun getSourceAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getSourceReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun source (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract class love/forte/simbot/event/StandardEventResult : love/forte/simbot/event/EventResult {
+}
+
+public abstract class love/forte/simbot/event/StandardEventResult$CollectableReactivelyResult : love/forte/simbot/event/StandardEventResult {
+	public fun <init> ()V
+	public abstract fun collected (Ljava/lang/Object;)Llove/forte/simbot/event/EventResult;
+	public abstract fun getContent ()Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/event/StandardEventResult$Empty : love/forte/simbot/event/StandardEventResult$EmptyResult {
+	public static final field Companion Llove/forte/simbot/event/StandardEventResult$Empty$Companion;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getContent ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public static final fun instance ()Llove/forte/simbot/event/StandardEventResult$Empty;
+	public static final fun instance (Z)Llove/forte/simbot/event/StandardEventResult$Empty;
+	public fun isTruncated ()Z
+	public fun toString ()Ljava/lang/String;
+	public static final fun truncated ()Llove/forte/simbot/event/StandardEventResult$Empty;
+}
+
+public final class love/forte/simbot/event/StandardEventResult$Empty$Companion {
+	public final fun instance ()Llove/forte/simbot/event/StandardEventResult$Empty;
+	public final fun instance (Z)Llove/forte/simbot/event/StandardEventResult$Empty;
+	public static synthetic fun instance$default (Llove/forte/simbot/event/StandardEventResult$Empty$Companion;ZILjava/lang/Object;)Llove/forte/simbot/event/StandardEventResult$Empty;
+	public final fun truncated ()Llove/forte/simbot/event/StandardEventResult$Empty;
+}
+
+public abstract class love/forte/simbot/event/StandardEventResult$EmptyResult : love/forte/simbot/event/StandardEventResult {
+}
+
+public final class love/forte/simbot/event/StandardEventResult$Error : love/forte/simbot/event/StandardEventResult {
+	public static final field Companion Llove/forte/simbot/event/StandardEventResult$Error$Companion;
+	public synthetic fun <init> (Ljava/lang/Throwable;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public fun getContent ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun isTruncated ()Z
+	public static final fun of (Ljava/lang/Throwable;)Llove/forte/simbot/event/StandardEventResult$Error;
+	public static final fun of (Ljava/lang/Throwable;Z)Llove/forte/simbot/event/StandardEventResult$Error;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/event/StandardEventResult$Error$Companion {
+	public final fun of (Ljava/lang/Throwable;)Llove/forte/simbot/event/StandardEventResult$Error;
+	public final fun of (Ljava/lang/Throwable;Z)Llove/forte/simbot/event/StandardEventResult$Error;
+	public static synthetic fun of$default (Llove/forte/simbot/event/StandardEventResult$Error$Companion;Ljava/lang/Throwable;ZILjava/lang/Object;)Llove/forte/simbot/event/StandardEventResult$Error;
+}
+
+public final class love/forte/simbot/event/StandardEventResult$Invalid : love/forte/simbot/event/StandardEventResult$EmptyResult {
+	public static final field INSTANCE Llove/forte/simbot/event/StandardEventResult$Invalid;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getContent ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun isTruncated ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/event/StandardEventResult$Simple : love/forte/simbot/event/StandardEventResult$CollectableReactivelyResult {
+	public fun <init> (Ljava/lang/Object;Z)V
+	public fun collected (Ljava/lang/Object;)Llove/forte/simbot/event/EventResult;
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Z
+	public final fun copy (Ljava/lang/Object;Z)Llove/forte/simbot/event/StandardEventResult$Simple;
+	public static synthetic fun copy$default (Llove/forte/simbot/event/StandardEventResult$Simple;Ljava/lang/Object;ZILjava/lang/Object;)Llove/forte/simbot/event/StandardEventResult$Simple;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getContent ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun isTruncated ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/event/TypedJAsyncEventListener {
+	public static final field Companion Llove/forte/simbot/event/TypedJAsyncEventListener$Companion;
+	public fun emptyResult ()Ljava/util/concurrent/CompletionStage;
+	public abstract fun handle (Llove/forte/simbot/event/EventListenerContext;Llove/forte/simbot/event/Event;)Ljava/util/concurrent/CompletionStage;
+	public fun invalidResult ()Ljava/util/concurrent/CompletionStage;
+	public fun result (Llove/forte/simbot/event/EventResult;)Ljava/util/concurrent/CompletionStage;
+	public static fun toListener (Ljava/lang/Class;Llove/forte/simbot/event/TypedJAsyncEventListener;)Llove/forte/simbot/event/EventListener;
+}
+
+public final class love/forte/simbot/event/TypedJAsyncEventListener$Companion {
+	public final fun toListener (Ljava/lang/Class;Llove/forte/simbot/event/TypedJAsyncEventListener;)Llove/forte/simbot/event/EventListener;
+}
+
+public abstract interface class love/forte/simbot/event/TypedJBlockEventListener {
+	public static final field Companion Llove/forte/simbot/event/TypedJBlockEventListener$Companion;
+	public abstract fun handle (Llove/forte/simbot/event/EventListenerContext;Llove/forte/simbot/event/Event;)Llove/forte/simbot/event/EventResult;
+	public static fun toListener (Ljava/lang/Class;Llove/forte/simbot/event/TypedJBlockEventListener;)Llove/forte/simbot/event/EventListener;
+	public static fun toListener (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Class;Llove/forte/simbot/event/TypedJBlockEventListener;)Llove/forte/simbot/event/EventListener;
+}
+
+public final class love/forte/simbot/event/TypedJBlockEventListener$Companion {
+	public final fun toListener (Ljava/lang/Class;Llove/forte/simbot/event/TypedJBlockEventListener;)Llove/forte/simbot/event/EventListener;
+	public final fun toListener (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Class;Llove/forte/simbot/event/TypedJBlockEventListener;)Llove/forte/simbot/event/EventListener;
+	public static synthetic fun toListener$default (Llove/forte/simbot/event/TypedJBlockEventListener$Companion;Lkotlin/coroutines/CoroutineContext;Ljava/lang/Class;Llove/forte/simbot/event/TypedJBlockEventListener;ILjava/lang/Object;)Llove/forte/simbot/event/EventListener;
+}
+
+public abstract class love/forte/simbot/message/AggregatedMessageReceipt : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker, love/forte/simbot/message/StandardMessageReceipt {
+	public fun <init> ()V
+	public fun delete ([Llove/forte/simbot/ability/DeleteOption;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun deleteAll ([Llove/forte/simbot/ability/DeleteOption;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun get (I)Llove/forte/simbot/message/SingleMessageReceipt;
+	public abstract fun getSize ()I
+	public fun iterator ()Ljava/util/Iterator;
+}
+
+public final class love/forte/simbot/message/At : love/forte/simbot/message/MentionMessage {
+	public static final field Companion Llove/forte/simbot/message/At$Companion;
+	public static final field DEFAULT_AT_TYPE Ljava/lang/String;
+	public fun <init> (Llove/forte/simbot/common/id/ID;)V
+	public fun <init> (Llove/forte/simbot/common/id/ID;Ljava/lang/String;)V
+	public fun <init> (Llove/forte/simbot/common/id/ID;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Llove/forte/simbot/common/id/ID;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Llove/forte/simbot/common/id/ID;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Llove/forte/simbot/common/id/ID;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/message/At;
+	public static synthetic fun copy$default (Llove/forte/simbot/message/At;Llove/forte/simbot/common/id/ID;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/message/At;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOriginContent ()Ljava/lang/String;
+	public final fun getTarget ()Llove/forte/simbot/common/id/ID;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static final fun of (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/message/At;
+	public static final fun of (Llove/forte/simbot/common/id/ID;Ljava/lang/String;)Llove/forte/simbot/message/At;
+	public static final fun of (Llove/forte/simbot/common/id/ID;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/message/At;
+	public static final fun of (Llove/forte/simbot/common/id/IDContainer;)Llove/forte/simbot/message/At;
+	public static final fun of (Llove/forte/simbot/common/id/IDContainer;Ljava/lang/String;)Llove/forte/simbot/message/At;
+	public static final fun of (Llove/forte/simbot/common/id/IDContainer;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/message/At;
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/message/At$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/message/At$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/message/At;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/message/At;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/message/At$Companion {
+	public final fun of (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/message/At;
+	public final fun of (Llove/forte/simbot/common/id/ID;Ljava/lang/String;)Llove/forte/simbot/message/At;
+	public final fun of (Llove/forte/simbot/common/id/ID;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/message/At;
+	public final fun of (Llove/forte/simbot/common/id/IDContainer;)Llove/forte/simbot/message/At;
+	public final fun of (Llove/forte/simbot/common/id/IDContainer;Ljava/lang/String;)Llove/forte/simbot/message/At;
+	public final fun of (Llove/forte/simbot/common/id/IDContainer;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/message/At;
+	public static synthetic fun of$default (Llove/forte/simbot/message/At$Companion;Llove/forte/simbot/common/id/ID;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/message/At;
+	public static synthetic fun of$default (Llove/forte/simbot/message/At$Companion;Llove/forte/simbot/common/id/IDContainer;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/message/At;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/message/AtAll : love/forte/simbot/message/MentionMessage {
+	public static final field INSTANCE Llove/forte/simbot/message/AtAll;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/message/Emoji : love/forte/simbot/message/EmoticonMessage {
+	public static final field Companion Llove/forte/simbot/message/Emoji$Companion;
+	public fun <init> (Llove/forte/simbot/common/id/ID;)V
+	public final fun component1 ()Llove/forte/simbot/common/id/ID;
+	public final fun copy (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/message/Emoji;
+	public static synthetic fun copy$default (Llove/forte/simbot/message/Emoji;Llove/forte/simbot/common/id/ID;ILjava/lang/Object;)Llove/forte/simbot/message/Emoji;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Llove/forte/simbot/common/id/ID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/message/Emoji$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/message/Emoji$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/message/Emoji;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/message/Emoji;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/message/Emoji$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class love/forte/simbot/message/EmoticonMessage : love/forte/simbot/message/StandardMessage {
+}
+
+public final class love/forte/simbot/message/Face : love/forte/simbot/message/EmoticonMessage {
+	public static final field Companion Llove/forte/simbot/message/Face$Companion;
+	public fun <init> (Llove/forte/simbot/common/id/ID;)V
+	public final fun component1 ()Llove/forte/simbot/common/id/ID;
+	public final fun copy (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/message/Face;
+	public static synthetic fun copy$default (Llove/forte/simbot/message/Face;Llove/forte/simbot/common/id/ID;ILjava/lang/Object;)Llove/forte/simbot/message/Face;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Llove/forte/simbot/common/id/ID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/message/Face$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/message/Face$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/message/Face;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/message/Face;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/message/Face$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class love/forte/simbot/message/IDAwareImage : love/forte/simbot/message/Image {
+	public abstract fun getId ()Llove/forte/simbot/common/id/ID;
+}
+
+public abstract interface class love/forte/simbot/message/Image : love/forte/simbot/message/StandardMessage {
+}
+
+public abstract interface class love/forte/simbot/message/JvmOfflineImageResolver : love/forte/simbot/message/OfflineImageResolver {
+	public abstract fun resolveFile (Llove/forte/simbot/message/OfflineFileImage;Ljava/lang/Object;)V
+	public abstract fun resolvePath (Llove/forte/simbot/message/OfflinePathImage;Ljava/lang/Object;)V
+	public abstract fun resolveURI (Llove/forte/simbot/message/OfflineURIImage;Ljava/lang/Object;)V
+	public fun resolveUnknown (Llove/forte/simbot/message/OfflineImage;Ljava/lang/Object;)V
+	public abstract fun resolveUnknownInternal (Llove/forte/simbot/message/OfflineImage;Ljava/lang/Object;)V
+}
+
+public abstract class love/forte/simbot/message/JvmOfflineImageValueResolver : love/forte/simbot/message/JvmOfflineImageResolver, love/forte/simbot/message/OfflineImageValueResolver, love/forte/simbot/resource/JvmResourceResolver {
+	public fun <init> ()V
+	public final fun resolveByteArray (Llove/forte/simbot/message/OfflineByteArrayImage;Ljava/lang/Object;)V
+	public final fun resolveByteArray (Llove/forte/simbot/resource/ByteArrayResource;Ljava/lang/Object;)V
+	public abstract fun resolveByteArray ([BLjava/lang/Object;)V
+	public abstract fun resolveFile (Ljava/io/File;Ljava/lang/Object;)V
+	public final fun resolveFile (Llove/forte/simbot/message/OfflineFileImage;Ljava/lang/Object;)V
+	public final fun resolveFile (Llove/forte/simbot/resource/FileResource;Ljava/lang/Object;)V
+	public abstract fun resolvePath (Ljava/nio/file/Path;Ljava/lang/Object;)V
+	public final fun resolvePath (Llove/forte/simbot/message/OfflinePathImage;Ljava/lang/Object;)V
+	public final fun resolvePath (Llove/forte/simbot/resource/PathResource;Ljava/lang/Object;)V
+	public final fun resolveResource (Llove/forte/simbot/message/OfflineResourceImage;Ljava/lang/Object;)V
+	public abstract fun resolveString (Ljava/lang/String;Ljava/lang/Object;)V
+	public final fun resolveString (Llove/forte/simbot/resource/StringResource;Ljava/lang/Object;)V
+	public fun resolveURI (Ljava/net/URI;Ljava/lang/Object;)V
+	public final fun resolveURI (Llove/forte/simbot/message/OfflineURIImage;Ljava/lang/Object;)V
+	public final fun resolveURI (Llove/forte/simbot/resource/URIResource;Ljava/lang/Object;)V
+	public abstract fun resolveURINotFileScheme (Ljava/net/URI;Ljava/lang/Object;)V
+}
+
+public abstract interface class love/forte/simbot/message/MentionMessage : love/forte/simbot/message/StandardMessage {
+}
+
+public abstract interface class love/forte/simbot/message/Message {
+}
+
+public abstract interface class love/forte/simbot/message/Message$Element : love/forte/simbot/message/Message {
+}
+
+public abstract interface class love/forte/simbot/message/MessageContent : love/forte/simbot/ability/DeleteSupport {
+	public abstract fun delete ([Llove/forte/simbot/ability/DeleteOption;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getId ()Llove/forte/simbot/common/id/ID;
+	public abstract fun getMessages ()Llove/forte/simbot/message/Messages;
+	public abstract fun getPlainText ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/message/MessageContentKt {
+	public static final fun getSafePlainText (Llove/forte/simbot/message/MessageContent;)Ljava/lang/String;
+}
+
+public final class love/forte/simbot/message/MessageKt {
+	public static final fun messageElementPolymorphic (Lkotlinx/serialization/modules/SerializersModuleBuilder;Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface class love/forte/simbot/message/MessageReceipt : love/forte/simbot/ability/DeleteSupport {
+	public abstract synthetic fun delete ([Llove/forte/simbot/ability/DeleteOption;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/message/MessageReceiptKt {
+	public static final fun deleteAllSafely (Llove/forte/simbot/message/AggregatedMessageReceipt;[Llove/forte/simbot/ability/DeleteOption;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteAllSafely$default (Llove/forte/simbot/message/AggregatedMessageReceipt;[Llove/forte/simbot/ability/DeleteOption;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/message/MessageReceipts {
+	public static final fun aggregation (Ljava/lang/Iterable;)Llove/forte/simbot/message/AggregatedMessageReceipt;
+	public static final fun aggregation (Ljava/util/Collection;)Llove/forte/simbot/message/AggregatedMessageReceipt;
+	public static final fun aggregation (Ljava/util/List;)Llove/forte/simbot/message/AggregatedMessageReceipt;
+}
+
+public abstract interface class love/forte/simbot/message/Messages : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker, love/forte/simbot/message/Message {
+	public static final field Companion Llove/forte/simbot/message/Messages$Companion;
+	public static fun builder ()Llove/forte/simbot/message/MessagesBuilder;
+	public static fun builder (Ljava/util/List;)Llove/forte/simbot/message/MessagesBuilder;
+	public abstract fun contains (Llove/forte/simbot/message/Message$Element;)Z
+	public static fun empty ()Llove/forte/simbot/message/Messages;
+	public abstract fun getSize ()I
+	public abstract fun isEmpty ()Z
+	public abstract fun iterator ()Ljava/util/Iterator;
+	public static fun of (Ljava/lang/Iterable;)Llove/forte/simbot/message/Messages;
+	public static fun of (Llove/forte/simbot/message/Message$Element;)Llove/forte/simbot/message/Messages;
+	public static fun of ([Llove/forte/simbot/message/Message$Element;)Llove/forte/simbot/message/Messages;
+	public abstract fun plus (Ljava/lang/Iterable;)Llove/forte/simbot/message/Messages;
+	public abstract fun plus (Llove/forte/simbot/message/Message$Element;)Llove/forte/simbot/message/Messages;
+	public static fun serializer ()Lkotlinx/serialization/KSerializer;
+	public static fun standardSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
+	public abstract fun toList ()Ljava/util/List;
+}
+
+public final class love/forte/simbot/message/Messages$Companion {
+	public final fun builder ()Llove/forte/simbot/message/MessagesBuilder;
+	public final fun builder (Ljava/util/List;)Llove/forte/simbot/message/MessagesBuilder;
+	public static synthetic fun builder$default (Llove/forte/simbot/message/Messages$Companion;Ljava/util/List;ILjava/lang/Object;)Llove/forte/simbot/message/MessagesBuilder;
+	public final fun empty ()Llove/forte/simbot/message/Messages;
+	public final fun of (Ljava/lang/Iterable;)Llove/forte/simbot/message/Messages;
+	public final fun of (Llove/forte/simbot/message/Message$Element;)Llove/forte/simbot/message/Messages;
+	public final fun of ([Llove/forte/simbot/message/Message$Element;)Llove/forte/simbot/message/Messages;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public final fun standardSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
+}
+
+public final class love/forte/simbot/message/MessagesBuilder {
+	public static final field Companion Llove/forte/simbot/message/MessagesBuilder$Companion;
+	public synthetic fun <init> (Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun add (Ljava/lang/String;)Llove/forte/simbot/message/MessagesBuilder;
+	public final fun add (Llove/forte/simbot/message/Message$Element;)Llove/forte/simbot/message/MessagesBuilder;
+	public final fun addAll (Ljava/lang/Iterable;)Llove/forte/simbot/message/MessagesBuilder;
+	public final fun build ()Llove/forte/simbot/message/Messages;
+	public static final fun create ()Llove/forte/simbot/message/MessagesBuilder;
+	public static final fun create (Ljava/util/List;)Llove/forte/simbot/message/MessagesBuilder;
+	public final fun unaryPlus (Ljava/lang/Iterable;)Llove/forte/simbot/message/MessagesBuilder;
+	public final fun unaryPlus (Ljava/lang/String;)Llove/forte/simbot/message/MessagesBuilder;
+	public final fun unaryPlus (Llove/forte/simbot/message/Message$Element;)Llove/forte/simbot/message/MessagesBuilder;
+}
+
+public final class love/forte/simbot/message/MessagesBuilder$Companion {
+	public final fun create ()Llove/forte/simbot/message/MessagesBuilder;
+	public final fun create (Ljava/util/List;)Llove/forte/simbot/message/MessagesBuilder;
+	public static synthetic fun create$default (Llove/forte/simbot/message/MessagesBuilder$Companion;Ljava/util/List;ILjava/lang/Object;)Llove/forte/simbot/message/MessagesBuilder;
+}
+
+public abstract interface annotation class love/forte/simbot/message/MessagesBuilderDsl : java/lang/annotation/Annotation {
+}
+
+public final class love/forte/simbot/message/MessagesBuilders {
+	public static final fun buildMessages (Ljava/util/List;Lkotlin/jvm/functions/Function1;)Llove/forte/simbot/message/Messages;
+	public static synthetic fun buildMessages$default (Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Llove/forte/simbot/message/Messages;
+	public static final fun plusAssign (Llove/forte/simbot/message/MessagesBuilder;Ljava/lang/Iterable;)V
+	public static final fun plusAssign (Llove/forte/simbot/message/MessagesBuilder;Ljava/lang/String;)V
+	public static final fun plusAssign (Llove/forte/simbot/message/MessagesBuilder;Llove/forte/simbot/message/Message$Element;)V
+}
+
+public final class love/forte/simbot/message/MessagesKt {
+	public static final field INSTANCE Llove/forte/simbot/message/MessagesKt;
+	public static final fun decodeMessagesFromString (Lkotlinx/serialization/StringFormat;Ljava/lang/String;)Llove/forte/simbot/message/Messages;
+	public static final fun emptyMessages ()Llove/forte/simbot/message/Messages;
+	public static final fun encodeMessagesToString (Lkotlinx/serialization/StringFormat;Llove/forte/simbot/message/Messages;)Ljava/lang/String;
+	public static final fun isNotEmpty (Llove/forte/simbot/message/Messages;)Z
+	public static final fun messagesOf (Llove/forte/simbot/message/Message$Element;)Llove/forte/simbot/message/Messages;
+	public static final fun messagesOf ([Llove/forte/simbot/message/Message$Element;)Llove/forte/simbot/message/Messages;
+	public static final fun plus (Llove/forte/simbot/message/Message;Llove/forte/simbot/message/Message;)Llove/forte/simbot/message/Messages;
+	public static final fun toMessages (Ljava/lang/Iterable;)Llove/forte/simbot/message/Messages;
+}
+
+public final class love/forte/simbot/message/MessagesUtil {
+	public static final fun decodeMessagesFromString (Lkotlinx/serialization/StringFormat;Ljava/lang/String;)Llove/forte/simbot/message/Messages;
+	public static final fun emptyMessages ()Llove/forte/simbot/message/Messages;
+	public static final fun encodeMessagesToString (Lkotlinx/serialization/StringFormat;Llove/forte/simbot/message/Messages;)Ljava/lang/String;
+	public static final fun isNotEmpty (Llove/forte/simbot/message/Messages;)Z
+	public static final fun messagesOf (Llove/forte/simbot/message/Message$Element;)Llove/forte/simbot/message/Messages;
+	public static final fun messagesOf ([Llove/forte/simbot/message/Message$Element;)Llove/forte/simbot/message/Messages;
+	public static final fun plus (Llove/forte/simbot/message/Message;Llove/forte/simbot/message/Message;)Llove/forte/simbot/message/Messages;
+	public static final fun toMessages (Ljava/lang/Iterable;)Llove/forte/simbot/message/Messages;
+}
+
+public final class love/forte/simbot/message/OfflineByteArrayImage : love/forte/simbot/message/OfflineImage {
+	public static final field Companion Llove/forte/simbot/message/OfflineByteArrayImage$Companion;
+	public fun <init> ([B)V
+	public final fun copy ([B)Llove/forte/simbot/message/OfflineByteArrayImage;
+	public static synthetic fun copy$default (Llove/forte/simbot/message/OfflineByteArrayImage;[BILjava/lang/Object;)Llove/forte/simbot/message/OfflineByteArrayImage;
+	public fun data ()[B
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/message/OfflineByteArrayImage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/message/OfflineByteArrayImage$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/message/OfflineByteArrayImage;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/message/OfflineByteArrayImage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/message/OfflineByteArrayImage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/message/OfflineFileImage : love/forte/simbot/message/OfflineResourceImage {
+	public static final field Companion Llove/forte/simbot/message/OfflineFileImage$Companion;
+	public synthetic fun <init> (Ljava/io/File;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun data ()[B
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFile ()Ljava/io/File;
+	public fun getResource ()Llove/forte/simbot/resource/FileResource;
+	public synthetic fun getResource ()Llove/forte/simbot/resource/Resource;
+	public fun hashCode ()I
+	public static final fun of (Ljava/io/File;)Llove/forte/simbot/message/OfflineFileImage;
+	public static final fun of (Llove/forte/simbot/resource/FileResource;)Llove/forte/simbot/message/OfflineFileImage;
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/message/OfflineFileImage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/message/OfflineFileImage$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/message/OfflineFileImage;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/message/OfflineFileImage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/message/OfflineFileImage$Companion {
+	public final fun of (Ljava/io/File;)Llove/forte/simbot/message/OfflineFileImage;
+	public final fun of (Llove/forte/simbot/resource/FileResource;)Llove/forte/simbot/message/OfflineFileImage;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class love/forte/simbot/message/OfflineImage : love/forte/simbot/message/Image {
+	public static final field Companion Llove/forte/simbot/message/OfflineImage$Companion;
+	public abstract fun data ()[B
+	public static fun ofBytes ([B)Llove/forte/simbot/message/OfflineImage;
+	public static fun ofResource (Llove/forte/simbot/resource/Resource;)Llove/forte/simbot/message/OfflineImage;
+}
+
+public final class love/forte/simbot/message/OfflineImage$Companion {
+	public final fun ofBytes ([B)Llove/forte/simbot/message/OfflineImage;
+	public final fun ofResource (Llove/forte/simbot/resource/Resource;)Llove/forte/simbot/message/OfflineImage;
+}
+
+public abstract interface class love/forte/simbot/message/OfflineImageResolver {
+	public static final field Companion Llove/forte/simbot/message/OfflineImageResolver$Companion;
+	public static fun resolve (Llove/forte/simbot/message/OfflineImageResolver;Llove/forte/simbot/message/OfflineImage;Ljava/lang/Object;)V
+	public abstract fun resolveByteArray (Llove/forte/simbot/message/OfflineByteArrayImage;Ljava/lang/Object;)V
+	public abstract fun resolveResource (Llove/forte/simbot/message/OfflineResourceImage;Ljava/lang/Object;)V
+	public abstract fun resolveUnknown (Llove/forte/simbot/message/OfflineImage;Ljava/lang/Object;)V
+}
+
+public final class love/forte/simbot/message/OfflineImageResolver$Companion {
+	public final fun resolve (Llove/forte/simbot/message/OfflineImageResolver;Llove/forte/simbot/message/OfflineImage;Ljava/lang/Object;)V
+}
+
+public abstract interface class love/forte/simbot/message/OfflineImageValueResolver : love/forte/simbot/message/OfflineImageResolver, love/forte/simbot/resource/ResourceResolver {
+	public fun resolveByteArray (Llove/forte/simbot/message/OfflineByteArrayImage;Ljava/lang/Object;)V
+	public fun resolveByteArray (Llove/forte/simbot/resource/ByteArrayResource;Ljava/lang/Object;)V
+	public abstract fun resolveByteArray ([BLjava/lang/Object;)V
+	public fun resolveResource (Llove/forte/simbot/message/OfflineResourceImage;Ljava/lang/Object;)V
+	public abstract fun resolveString (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun resolveString (Llove/forte/simbot/resource/StringResource;Ljava/lang/Object;)V
+}
+
+public final class love/forte/simbot/message/OfflinePathImage : love/forte/simbot/message/OfflineResourceImage {
+	public static final field Companion Llove/forte/simbot/message/OfflinePathImage$Companion;
+	public fun <init> (Ljava/nio/file/Path;)V
+	public final fun component1 ()Ljava/nio/file/Path;
+	public final fun copy (Ljava/nio/file/Path;)Llove/forte/simbot/message/OfflinePathImage;
+	public static synthetic fun copy$default (Llove/forte/simbot/message/OfflinePathImage;Ljava/nio/file/Path;ILjava/lang/Object;)Llove/forte/simbot/message/OfflinePathImage;
+	public fun data ()[B
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPath ()Ljava/nio/file/Path;
+	public fun getResource ()Llove/forte/simbot/resource/PathResource;
+	public synthetic fun getResource ()Llove/forte/simbot/resource/Resource;
+	public fun hashCode ()I
+	public static final fun of (Ljava/nio/file/Path;)Llove/forte/simbot/message/OfflinePathImage;
+	public static final fun of (Llove/forte/simbot/resource/PathResource;)Llove/forte/simbot/message/OfflinePathImage;
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/message/OfflinePathImage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/message/OfflinePathImage$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/message/OfflinePathImage;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/message/OfflinePathImage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/message/OfflinePathImage$Companion {
+	public final fun of (Ljava/nio/file/Path;)Llove/forte/simbot/message/OfflinePathImage;
+	public final fun of (Llove/forte/simbot/resource/PathResource;)Llove/forte/simbot/message/OfflinePathImage;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class love/forte/simbot/message/OfflineResourceImage : love/forte/simbot/message/OfflineImage {
+	public fun data ()[B
+	public abstract fun getResource ()Llove/forte/simbot/resource/Resource;
+}
+
+public final class love/forte/simbot/message/OfflineURIImage : love/forte/simbot/message/OfflineResourceImage {
+	public static final field Companion Llove/forte/simbot/message/OfflineURIImage$Companion;
+	public fun <init> (Ljava/net/URI;)V
+	public final fun component1 ()Ljava/net/URI;
+	public final fun copy (Ljava/net/URI;)Llove/forte/simbot/message/OfflineURIImage;
+	public static synthetic fun copy$default (Llove/forte/simbot/message/OfflineURIImage;Ljava/net/URI;ILjava/lang/Object;)Llove/forte/simbot/message/OfflineURIImage;
+	public fun data ()[B
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getResource ()Llove/forte/simbot/resource/Resource;
+	public fun getResource ()Llove/forte/simbot/resource/URIResource;
+	public final fun getUri ()Ljava/net/URI;
+	public fun hashCode ()I
+	public static final fun of (Ljava/net/URI;)Llove/forte/simbot/message/OfflineURIImage;
+	public static final fun of (Llove/forte/simbot/resource/URIResource;)Llove/forte/simbot/message/OfflineURIImage;
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/message/OfflineURIImage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/message/OfflineURIImage$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/message/OfflineURIImage;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/message/OfflineURIImage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/message/OfflineURIImage$Companion {
+	public final fun of (Ljava/net/URI;)Llove/forte/simbot/message/OfflineURIImage;
+	public final fun of (Llove/forte/simbot/resource/URIResource;)Llove/forte/simbot/message/OfflineURIImage;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class love/forte/simbot/message/PlainText : love/forte/simbot/message/StandardMessage {
+	public abstract fun getText ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/message/RemoteIDImage : love/forte/simbot/message/RemoteImage {
+	public static final field Companion Llove/forte/simbot/message/RemoteIDImage$Companion;
+	public fun <init> (Llove/forte/simbot/common/id/ID;)V
+	public final fun component1 ()Llove/forte/simbot/common/id/ID;
+	public final fun copy (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/message/RemoteIDImage;
+	public static synthetic fun copy$default (Llove/forte/simbot/message/RemoteIDImage;Llove/forte/simbot/common/id/ID;ILjava/lang/Object;)Llove/forte/simbot/message/RemoteIDImage;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getId ()Llove/forte/simbot/common/id/ID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/message/RemoteIDImage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/message/RemoteIDImage$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/message/RemoteIDImage;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/message/RemoteIDImage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/message/RemoteIDImage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class love/forte/simbot/message/RemoteImage : love/forte/simbot/message/IDAwareImage, love/forte/simbot/message/Image {
+	public abstract fun getId ()Llove/forte/simbot/common/id/ID;
+}
+
+public abstract interface class love/forte/simbot/message/RemoteUrlAwareImage : love/forte/simbot/message/RemoteImage, love/forte/simbot/message/UrlAwareImage {
+	public abstract synthetic fun url (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/message/SimpleOfflineResourceImage : love/forte/simbot/message/OfflineResourceImage {
+	public static final field Companion Llove/forte/simbot/message/SimpleOfflineResourceImage$Companion;
+	public fun <init> (Llove/forte/simbot/resource/Resource;)V
+	public final fun component1 ()Llove/forte/simbot/resource/Resource;
+	public final fun copy (Llove/forte/simbot/resource/Resource;)Llove/forte/simbot/message/SimpleOfflineResourceImage;
+	public static synthetic fun copy$default (Llove/forte/simbot/message/SimpleOfflineResourceImage;Llove/forte/simbot/resource/Resource;ILjava/lang/Object;)Llove/forte/simbot/message/SimpleOfflineResourceImage;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getResource ()Llove/forte/simbot/resource/Resource;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/message/SimpleOfflineResourceImage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/message/SimpleOfflineResourceImage$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/message/SimpleOfflineResourceImage;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/message/SimpleOfflineResourceImage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/message/SimpleOfflineResourceImage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class love/forte/simbot/message/SingleMessageReceipt : love/forte/simbot/message/StandardMessageReceipt {
+	public fun <init> ()V
+	public abstract fun getId ()Llove/forte/simbot/common/id/ID;
+}
+
+public abstract interface class love/forte/simbot/message/StandardMessage : love/forte/simbot/message/Message$Element {
+}
+
+public abstract interface class love/forte/simbot/message/StandardMessageReceipt : love/forte/simbot/message/MessageReceipt {
+}
+
+public final class love/forte/simbot/message/StandardMessages {
+	public static final fun Text ()Llove/forte/simbot/message/Text;
+	public static final fun Text (Lkotlin/jvm/functions/Function0;)Llove/forte/simbot/message/Text;
+	public static final fun toOfflineResourceImage (Llove/forte/simbot/resource/Resource;)Llove/forte/simbot/message/OfflineResourceImage;
+	public static final fun toText (Ljava/lang/String;)Llove/forte/simbot/message/Text;
+}
+
+public final class love/forte/simbot/message/Text : love/forte/simbot/message/PlainText {
+	public static final field Companion Llove/forte/simbot/message/Text$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static final fun of (Ljava/lang/String;)Llove/forte/simbot/message/Text;
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/message/Text$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/message/Text$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/message/Text;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/message/Text;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/message/Text$Companion {
+	public final fun of (Ljava/lang/String;)Llove/forte/simbot/message/Text;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class love/forte/simbot/message/UrlAwareImage : love/forte/simbot/message/Image {
+	public fun getUrl ()Ljava/lang/String;
+	public fun getUrlAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getUrlReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun url (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract class love/forte/simbot/plugin/AbstractJPlugin : love/forte/simbot/plugin/SimplePlugin {
+	public static final field Companion Llove/forte/simbot/plugin/AbstractJPlugin$Companion;
+	public fun <init> (Llove/forte/simbot/plugin/AbstractJPlugin$Key;)V
+	public static final fun createKey (Ljava/lang/String;)Llove/forte/simbot/plugin/AbstractJPlugin$Key;
+	public fun getKey ()Llove/forte/simbot/plugin/AbstractJPlugin$Key;
+	public synthetic fun getKey ()Llove/forte/simbot/plugin/SimplePlugin$Key;
+}
+
+public final class love/forte/simbot/plugin/AbstractJPlugin$Companion {
+	public final fun createKey (Ljava/lang/String;)Llove/forte/simbot/plugin/AbstractJPlugin$Key;
+}
+
+public abstract class love/forte/simbot/plugin/AbstractJPlugin$Factory : love/forte/simbot/plugin/PluginFactory {
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun create (Ljava/lang/Object;Llove/forte/simbot/common/function/ConfigurerFunction;)Ljava/lang/Object;
+	protected abstract fun create (Llove/forte/simbot/plugin/PluginConfigureContext;Ljava/lang/Object;)Llove/forte/simbot/plugin/AbstractJPlugin;
+	public final fun create (Llove/forte/simbot/plugin/PluginConfigureContext;Llove/forte/simbot/common/function/ConfigurerFunction;)Llove/forte/simbot/plugin/AbstractJPlugin;
+	protected abstract fun createConfig ()Ljava/lang/Object;
+	public synthetic fun getKey ()Llove/forte/simbot/common/function/MergeableFactory$Key;
+	public fun getKey ()Llove/forte/simbot/plugin/PluginFactory$Key;
+}
+
+public abstract interface class love/forte/simbot/plugin/AbstractJPlugin$Key : love/forte/simbot/plugin/SimplePlugin$Key {
+	public abstract fun getName ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/plugin/Plugin {
+}
+
+public abstract interface class love/forte/simbot/plugin/PluginConfigureContext {
+	public abstract fun getApplicationConfiguration ()Llove/forte/simbot/application/ApplicationConfiguration;
+	public abstract fun getApplicationEventRegistrar ()Llove/forte/simbot/application/ApplicationEventRegistrar;
+	public abstract fun getComponents ()Llove/forte/simbot/component/Components;
+	public abstract fun getEventDispatcher ()Llove/forte/simbot/event/EventDispatcher;
+}
+
+public final class love/forte/simbot/plugin/PluginCreatorKt {
+	public static final fun nameBasedPluginKey (Ljava/lang/String;)Llove/forte/simbot/plugin/SimplePlugin$Key;
+	public static final fun simplePlugin (Llove/forte/simbot/plugin/SimplePlugin$Key;Ljava/lang/Object;)Llove/forte/simbot/plugin/SimplePlugin;
+}
+
+public final class love/forte/simbot/plugin/PluginFactoriesConfigurator : love/forte/simbot/common/function/MergeableFactoriesConfigurator {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public abstract interface class love/forte/simbot/plugin/PluginFactory : love/forte/simbot/common/function/MergeableFactory {
+}
+
+public abstract interface class love/forte/simbot/plugin/PluginFactory$Key : love/forte/simbot/common/function/MergeableFactory$Key {
+}
+
+public abstract interface class love/forte/simbot/plugin/PluginFactoryConfigurerProvider {
+	public abstract fun configure (Ljava/lang/Object;)V
+}
+
+public abstract interface class love/forte/simbot/plugin/PluginFactoryProvider {
+	public fun configurersLoader ()Lkotlin/sequences/Sequence;
+	public fun loadConfigures ()Lkotlin/sequences/Sequence;
+	public abstract fun provide ()Llove/forte/simbot/plugin/PluginFactory;
+}
+
+public final class love/forte/simbot/plugin/PluginFactoryProviders {
+	public static final fun addPluginFactoryProvider (Lkotlin/jvm/functions/Function0;)V
+	public static final fun clearPluginFactoryProviders ()V
+	public static final fun findAndInstallAllPlugins (Llove/forte/simbot/plugin/PluginInstaller;Z)V
+	public static final fun loadPluginFactoriesFromProviders (Ljava/lang/ClassLoader;Z)Lkotlin/sequences/Sequence;
+	public static final fun loadPluginFactoriesFromProviders (Z)Lkotlin/sequences/Sequence;
+	public static final fun loadPluginProviders ()Lkotlin/sequences/Sequence;
+	public static final fun loadPluginProviders (Ljava/lang/ClassLoader;)Lkotlin/sequences/Sequence;
+}
+
+public abstract interface class love/forte/simbot/plugin/PluginInstaller {
+	public fun install (Llove/forte/simbot/plugin/PluginFactory;)V
+	public abstract fun install (Llove/forte/simbot/plugin/PluginFactory;Llove/forte/simbot/common/function/ConfigurerFunction;)V
+}
+
+public final class love/forte/simbot/plugin/PluginUtil {
+	public static final fun toPlugins (Ljava/util/Collection;)Llove/forte/simbot/plugin/Plugins;
+}
+
+public abstract interface class love/forte/simbot/plugin/Plugins : java/util/Collection, kotlin/jvm/internal/markers/KMappedMarker {
+}
+
+public abstract interface class love/forte/simbot/plugin/SimplePlugin : love/forte/simbot/plugin/Plugin {
+	public abstract fun getKey ()Llove/forte/simbot/plugin/SimplePlugin$Key;
+}
+
+public abstract interface class love/forte/simbot/plugin/SimplePlugin$Key : love/forte/simbot/plugin/PluginFactory$Key {
+	public abstract fun getName ()Ljava/lang/String;
+}
+
+public abstract class love/forte/simbot/resource/AbstractJvmResourceResolver : love/forte/simbot/resource/JvmResourceResolver {
+	public fun <init> ()V
+	public final fun resolveUnknown (Llove/forte/simbot/resource/Resource;Ljava/lang/Object;)V
+}
+
+public abstract class love/forte/simbot/resource/AbstractJvmResourceValueResolver : love/forte/simbot/resource/JvmResourceValueResolver {
+	public fun <init> ()V
+	public final fun resolveByteArray (Llove/forte/simbot/resource/ByteArrayResource;Ljava/lang/Object;)V
+	public final fun resolveFile (Llove/forte/simbot/resource/FileResource;Ljava/lang/Object;)V
+	public final fun resolvePath (Llove/forte/simbot/resource/PathResource;Ljava/lang/Object;)V
+	public final fun resolveString (Llove/forte/simbot/resource/StringResource;Ljava/lang/Object;)V
+	public final fun resolveURI (Llove/forte/simbot/resource/URIResource;Ljava/lang/Object;)V
+}
+
+public abstract interface class love/forte/simbot/resource/ByteArrayResource : love/forte/simbot/resource/Resource {
+	public abstract fun data ()[B
+}
+
+public abstract interface class love/forte/simbot/resource/FileResource : love/forte/simbot/resource/InputStreamResource, love/forte/simbot/resource/ReaderResource {
+	public fun data ()[B
+	public abstract fun getFile ()Ljava/io/File;
+	public fun inputStream ()Ljava/io/InputStream;
+	public fun reader ()Ljava/io/Reader;
+	public abstract fun reader (Ljava/nio/charset/Charset;)Ljava/io/Reader;
+	public fun string ()Ljava/lang/String;
+	public abstract fun string (Ljava/nio/charset/Charset;)Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/resource/InputStreamResource : love/forte/simbot/resource/Resource {
+	public fun data ()[B
+	public abstract fun inputStream ()Ljava/io/InputStream;
+}
+
+public abstract interface class love/forte/simbot/resource/JvmResourceResolver : love/forte/simbot/resource/ResourceResolver {
+	public abstract fun resolveFile (Llove/forte/simbot/resource/FileResource;Ljava/lang/Object;)V
+	public abstract fun resolvePath (Llove/forte/simbot/resource/PathResource;Ljava/lang/Object;)V
+	public abstract fun resolveURI (Llove/forte/simbot/resource/URIResource;Ljava/lang/Object;)V
+	public fun resolveUnknown (Llove/forte/simbot/resource/Resource;Ljava/lang/Object;)V
+	public abstract fun resolveUnknownInternal (Llove/forte/simbot/resource/Resource;Ljava/lang/Object;)V
+}
+
+public abstract interface class love/forte/simbot/resource/JvmResourceValueResolver : love/forte/simbot/resource/JvmResourceResolver {
+	public fun resolveByteArray (Llove/forte/simbot/resource/ByteArrayResource;Ljava/lang/Object;)V
+	public abstract fun resolveByteArray ([BLjava/lang/Object;)V
+	public abstract fun resolveFile (Ljava/io/File;Ljava/lang/Object;)V
+	public fun resolveFile (Llove/forte/simbot/resource/FileResource;Ljava/lang/Object;)V
+	public abstract fun resolvePath (Ljava/nio/file/Path;Ljava/lang/Object;)V
+	public fun resolvePath (Llove/forte/simbot/resource/PathResource;Ljava/lang/Object;)V
+	public abstract fun resolveString (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun resolveString (Llove/forte/simbot/resource/StringResource;Ljava/lang/Object;)V
+	public fun resolveURI (Ljava/net/URI;Ljava/lang/Object;)V
+	public fun resolveURI (Llove/forte/simbot/resource/URIResource;Ljava/lang/Object;)V
+	public abstract fun resolveURINotFileScheme (Ljava/net/URI;Ljava/lang/Object;)V
+}
+
+public abstract interface class love/forte/simbot/resource/JvmStringReadableResource : love/forte/simbot/resource/StringReadableResource {
+	public static final field Companion Llove/forte/simbot/resource/JvmStringReadableResource$Companion;
+	public static final field DEFAULT_CHARSET Ljava/nio/charset/Charset;
+	public fun string ()Ljava/lang/String;
+	public abstract fun string (Ljava/nio/charset/Charset;)Ljava/lang/String;
+}
+
+public final class love/forte/simbot/resource/JvmStringReadableResource$Companion {
+}
+
+public abstract interface class love/forte/simbot/resource/PathResource : love/forte/simbot/resource/InputStreamResource, love/forte/simbot/resource/ReaderResource {
+	public fun data ()[B
+	public abstract fun getPath ()Ljava/nio/file/Path;
+	public abstract fun inputStream ()Ljava/io/InputStream;
+	public abstract fun reader (Ljava/nio/charset/Charset;)Ljava/io/Reader;
+	public abstract fun string (Ljava/nio/charset/Charset;)Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/resource/ReaderResource : love/forte/simbot/resource/JvmStringReadableResource {
+	public fun reader ()Ljava/io/Reader;
+	public abstract fun reader (Ljava/nio/charset/Charset;)Ljava/io/Reader;
+	public fun string (Ljava/nio/charset/Charset;)Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/resource/Resource {
+	public abstract fun data ()[B
+}
+
+public final class love/forte/simbot/resource/ResourceBase64Serializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Llove/forte/simbot/resource/ResourceBase64Serializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/resource/Resource;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/resource/Resource;)V
+}
+
+public abstract interface class love/forte/simbot/resource/ResourceResolver {
+	public static final field Companion Llove/forte/simbot/resource/ResourceResolver$Companion;
+	public static fun resolve (Llove/forte/simbot/resource/ResourceResolver;Llove/forte/simbot/resource/Resource;Ljava/lang/Object;)V
+	public abstract fun resolveByteArray (Llove/forte/simbot/resource/ByteArrayResource;Ljava/lang/Object;)V
+	public abstract fun resolveString (Llove/forte/simbot/resource/StringResource;Ljava/lang/Object;)V
+	public abstract fun resolveUnknown (Llove/forte/simbot/resource/Resource;Ljava/lang/Object;)V
+}
+
+public final class love/forte/simbot/resource/ResourceResolver$Companion {
+	public final fun resolve (Llove/forte/simbot/resource/ResourceResolver;Llove/forte/simbot/resource/Resource;Ljava/lang/Object;)V
+}
+
+public final class love/forte/simbot/resource/Resources {
+	public static final fun valueOf (Ljava/io/File;)Llove/forte/simbot/resource/FileResource;
+	public static final fun valueOf (Ljava/io/File;Ljava/nio/charset/Charset;)Llove/forte/simbot/resource/FileResource;
+	public static final fun valueOf (Ljava/lang/String;)Llove/forte/simbot/resource/StringResource;
+	public static final fun valueOf (Ljava/net/URI;)Llove/forte/simbot/resource/URIResource;
+	public static final fun valueOf (Ljava/net/URI;Ljava/nio/charset/Charset;)Llove/forte/simbot/resource/URIResource;
+	public static final fun valueOf (Ljava/net/URL;)Llove/forte/simbot/resource/URIResource;
+	public static final fun valueOf (Ljava/net/URL;Ljava/nio/charset/Charset;)Llove/forte/simbot/resource/URIResource;
+	public static final fun valueOf (Ljava/nio/file/Path;Ljava/nio/charset/Charset;[Ljava/nio/file/OpenOption;)Llove/forte/simbot/resource/PathResource;
+	public static final fun valueOf (Ljava/nio/file/Path;[Ljava/nio/file/OpenOption;)Llove/forte/simbot/resource/PathResource;
+	public static final fun valueOf ([B)Llove/forte/simbot/resource/ByteArrayResource;
+	public static synthetic fun valueOf$default (Ljava/io/File;Ljava/nio/charset/Charset;ILjava/lang/Object;)Llove/forte/simbot/resource/FileResource;
+	public static synthetic fun valueOf$default (Ljava/net/URI;Ljava/nio/charset/Charset;ILjava/lang/Object;)Llove/forte/simbot/resource/URIResource;
+	public static synthetic fun valueOf$default (Ljava/net/URL;Ljava/nio/charset/Charset;ILjava/lang/Object;)Llove/forte/simbot/resource/URIResource;
+	public static synthetic fun valueOf$default (Ljava/nio/file/Path;Ljava/nio/charset/Charset;[Ljava/nio/file/OpenOption;ILjava/lang/Object;)Llove/forte/simbot/resource/PathResource;
+}
+
+public abstract interface class love/forte/simbot/resource/StringReadableResource : love/forte/simbot/resource/Resource {
+	public abstract fun string ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/resource/StringResource : love/forte/simbot/resource/StringReadableResource {
+	public abstract fun string ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/resource/URIResource : love/forte/simbot/resource/InputStreamResource, love/forte/simbot/resource/JvmStringReadableResource {
+	public abstract fun getUri ()Ljava/net/URI;
+	public abstract fun inputStream ()Ljava/io/InputStream;
+	public fun string ()Ljava/lang/String;
+	public abstract fun string (Ljava/nio/charset/Charset;)Ljava/lang/String;
+}
+

--- a/simbot-api/build.gradle.kts
+++ b/simbot-api/build.gradle.kts
@@ -4,7 +4,7 @@
  *     Project    https://github.com/simple-robot/simpler-robot
  *     Email      ForteScarlet@163.com
  *
- *     This file is part of the Simple Robot Library.
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Lesser General Public License as published by
@@ -25,7 +25,7 @@ import love.forte.gradle.common.core.project.setup
 import love.forte.gradle.common.kotlin.multiplatform.applyTier1
 import love.forte.gradle.common.kotlin.multiplatform.applyTier2
 import love.forte.gradle.common.kotlin.multiplatform.applyTier3
-import love.forte.plugin.suspendtrans.gradle.withKotlinTargets
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 
 plugins {
     kotlin("multiplatform")
@@ -42,6 +42,7 @@ setup(P.Simbot)
 configJavaCompileWithModule("simbot.api")
 apply(plugin = "simbot-multiplatform-maven-publish")
 
+@OptIn(ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     explicitApi()
     applyDefaultHierarchyTemplate()
@@ -62,12 +63,18 @@ kotlin {
 //    @Suppress("OPT_IN_USAGE")
 //    wasmWasi()
 
-    withKotlinTargets { target ->
-        targets.findByName(target.name)?.compilations?.all {
-            // 'expect'/'actual' classes (including interfaces, objects, annotations, enums, and 'actual' typealiases) are in Beta. You can use -Xexpect-actual-classes flag to suppress this warning. Also see: https://youtrack.jetbrains.com/issue/KT-61573
-            kotlinOptions.freeCompilerArgs += "-Xexpect-actual-classes"
-        }
+    compilerOptions {
+        freeCompilerArgs.addAll(
+            "-Xexpect-actual-classes"
+        )
     }
+
+    // withKotlinTargets { target ->
+    // targets.findByName(target.name)?.compilations?.all {
+    //     // 'expect'/'actual' classes (including interfaces, objects, annotations, enums, and 'actual' typealiases) are in Beta. You can use -Xexpect-actual-classes flag to suppress this warning. Also see: https://youtrack.jetbrains.com/issue/KT-61573
+    //     kotlinOptions.freeCompilerArgs += "-Xexpect-actual-classes"
+    // }
+    // }
 
     sourceSets {
         commonMain {
@@ -82,7 +89,7 @@ kotlin {
                 api(libs.kotlinx.coroutines.core)
                 api(libs.kotlinx.serialization.core)
                 // suspend reversal annotations
-                compileOnly(libs.suspend.reversal.annotations)
+
             }
         }
         commonTest {
@@ -123,14 +130,14 @@ kotlin {
             api(libs.kotlinx.serialization.json)
             api(libs.jetbrains.annotations)
             api(project(":simbot-commons:simbot-common-annotations"))
-            api(libs.suspend.reversal.annotations)
+
         }
 
         jsMain.dependencies {
             api(libs.kotlinx.serialization.json)
             api(project(":simbot-commons:simbot-common-annotations"))
             api(libs.jetbrains.annotations)
-            api(libs.suspend.reversal.annotations)
+
         }
 
         jsTest.dependencies {
@@ -163,7 +170,7 @@ kotlin {
 }
 
 dependencies {
-    add("kspJvm", libs.suspend.reversal.processor)
+    // add("kspJvm", libs.suspend.reversal.processor)
     add("kspJvm", project(":internal-processors:interface-uml-processor"))
 }
 

--- a/simbot-commons/simbot-common-annotations/api/simbot-common-annotations.api
+++ b/simbot-commons/simbot-common-annotations/api/simbot-common-annotations.api
@@ -1,0 +1,15 @@
+public abstract interface annotation class love/forte/simbot/annotations/Api4J : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class love/forte/simbot/annotations/Api4Js : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class love/forte/simbot/annotations/ExperimentalSimbotAPI : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class love/forte/simbot/annotations/FragileSimbotAPI : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class love/forte/simbot/annotations/InternalSimbotAPI : java/lang/annotation/Annotation {
+}
+

--- a/simbot-commons/simbot-common-apidefinition/api/simbot-common-apidefinition.api
+++ b/simbot-commons/simbot-common-apidefinition/api/simbot-common-apidefinition.api
@@ -1,0 +1,40 @@
+public abstract interface class love/forte/simbot/common/apidefinition/ApiDefinition {
+	public abstract fun getBody ()Ljava/lang/Object;
+	public fun getHeaders ()Lio/ktor/http/Headers;
+	public abstract fun getMethod ()Lio/ktor/http/HttpMethod;
+	public abstract fun getResultDeserializationStrategy ()Lkotlinx/serialization/DeserializationStrategy;
+	public abstract fun getUrl ()Lio/ktor/http/Url;
+}
+
+public abstract class love/forte/simbot/common/apidefinition/BodyComputableApiDefinition : love/forte/simbot/common/apidefinition/RestApiDefinition {
+	public fun <init> ()V
+	protected abstract fun createBody ()Ljava/lang/Object;
+	public fun getBody ()Ljava/lang/Object;
+}
+
+public abstract class love/forte/simbot/common/apidefinition/DeleteApiDefinition : love/forte/simbot/common/apidefinition/RestApiDefinition {
+	public fun <init> ()V
+	public fun getBody ()Ljava/lang/Object;
+	public fun getMethod ()Lio/ktor/http/HttpMethod;
+}
+
+public abstract class love/forte/simbot/common/apidefinition/GetApiDefinition : love/forte/simbot/common/apidefinition/RestApiDefinition {
+	public fun <init> ()V
+	public fun getBody ()Ljava/lang/Object;
+	public fun getMethod ()Lio/ktor/http/HttpMethod;
+}
+
+public abstract class love/forte/simbot/common/apidefinition/PostApiDefinition : love/forte/simbot/common/apidefinition/BodyComputableApiDefinition {
+	public fun <init> ()V
+	public fun getMethod ()Lio/ktor/http/HttpMethod;
+}
+
+public abstract class love/forte/simbot/common/apidefinition/PutApiDefinition : love/forte/simbot/common/apidefinition/BodyComputableApiDefinition {
+	public fun <init> ()V
+	public fun getMethod ()Lio/ktor/http/HttpMethod;
+}
+
+public abstract class love/forte/simbot/common/apidefinition/RestApiDefinition : love/forte/simbot/common/apidefinition/ApiDefinition {
+	public fun <init> ()V
+}
+

--- a/simbot-commons/simbot-common-atomic/api/simbot-common-atomic.api
+++ b/simbot-commons/simbot-common-atomic/api/simbot-common-atomic.api
@@ -1,0 +1,108 @@
+public abstract interface class love/forte/simbot/common/atomic/AtomicBoolean {
+	public abstract fun compareAndExchange (ZZ)Z
+	public abstract fun compareAndSet (ZZ)Z
+	public abstract fun getAndSet (Z)Z
+	public abstract fun getValue ()Z
+	public abstract fun setValue (Z)V
+}
+
+public abstract interface class love/forte/simbot/common/atomic/AtomicInt {
+	public abstract fun compareAndExchange (II)I
+	public abstract fun compareAndSet (II)Z
+	public abstract fun decrementAndGet (I)I
+	public static synthetic fun decrementAndGet$default (Llove/forte/simbot/common/atomic/AtomicInt;IILjava/lang/Object;)I
+	public abstract fun getAndDecrement (I)I
+	public static synthetic fun getAndDecrement$default (Llove/forte/simbot/common/atomic/AtomicInt;IILjava/lang/Object;)I
+	public abstract fun getAndIncrement (I)I
+	public static synthetic fun getAndIncrement$default (Llove/forte/simbot/common/atomic/AtomicInt;IILjava/lang/Object;)I
+	public abstract fun getAndSet (I)I
+	public abstract fun getValue ()I
+	public abstract fun incrementAndGet (I)I
+	public static synthetic fun incrementAndGet$default (Llove/forte/simbot/common/atomic/AtomicInt;IILjava/lang/Object;)I
+	public abstract fun setValue (I)V
+}
+
+public abstract interface class love/forte/simbot/common/atomic/AtomicLong {
+	public abstract fun compareAndExchange (JJ)J
+	public abstract fun compareAndSet (JJ)Z
+	public abstract fun decrementAndGet (J)J
+	public static synthetic fun decrementAndGet$default (Llove/forte/simbot/common/atomic/AtomicLong;JILjava/lang/Object;)J
+	public abstract fun getAndDecrement (J)J
+	public static synthetic fun getAndDecrement$default (Llove/forte/simbot/common/atomic/AtomicLong;JILjava/lang/Object;)J
+	public abstract fun getAndIncrement (J)J
+	public static synthetic fun getAndIncrement$default (Llove/forte/simbot/common/atomic/AtomicLong;JILjava/lang/Object;)J
+	public abstract fun getAndSet (J)J
+	public abstract fun getValue ()J
+	public abstract fun incrementAndGet (J)J
+	public static synthetic fun incrementAndGet$default (Llove/forte/simbot/common/atomic/AtomicLong;JILjava/lang/Object;)J
+	public abstract fun setValue (J)V
+}
+
+public abstract interface class love/forte/simbot/common/atomic/AtomicRef {
+	public abstract fun compareAndExchange (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun compareAndSet (Ljava/lang/Object;Ljava/lang/Object;)Z
+	public abstract fun getAndSet (Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getValue ()Ljava/lang/Object;
+	public abstract fun setValue (Ljava/lang/Object;)V
+}
+
+public abstract interface class love/forte/simbot/common/atomic/AtomicUInt {
+	public abstract fun compareAndExchange-YcLip9I (II)I
+	public abstract fun compareAndSet-feOb9K0 (II)Z
+	public abstract fun decrementAndGet-IKrLr70 (I)I
+	public static synthetic fun decrementAndGet-IKrLr70$default (Llove/forte/simbot/common/atomic/AtomicUInt;IILjava/lang/Object;)I
+	public abstract fun getAndDecrement-IKrLr70 (I)I
+	public static synthetic fun getAndDecrement-IKrLr70$default (Llove/forte/simbot/common/atomic/AtomicUInt;IILjava/lang/Object;)I
+	public abstract fun getAndIncrement-IKrLr70 (I)I
+	public static synthetic fun getAndIncrement-IKrLr70$default (Llove/forte/simbot/common/atomic/AtomicUInt;IILjava/lang/Object;)I
+	public abstract fun getAndSet-IKrLr70 (I)I
+	public abstract fun getValue-pVg5ArA ()I
+	public abstract fun incrementAndGet-IKrLr70 (I)I
+	public static synthetic fun incrementAndGet-IKrLr70$default (Llove/forte/simbot/common/atomic/AtomicUInt;IILjava/lang/Object;)I
+	public abstract fun setValue-WZ4Q5Ns (I)V
+}
+
+public abstract interface class love/forte/simbot/common/atomic/AtomicULong {
+	public abstract fun compareAndExchange-oku0oEs (JJ)J
+	public abstract fun compareAndSet-PWzV0Is (JJ)Z
+	public abstract fun decrementAndGet-PUiSbYQ (J)J
+	public static synthetic fun decrementAndGet-PUiSbYQ$default (Llove/forte/simbot/common/atomic/AtomicULong;JILjava/lang/Object;)J
+	public abstract fun getAndDecrement-PUiSbYQ (J)J
+	public static synthetic fun getAndDecrement-PUiSbYQ$default (Llove/forte/simbot/common/atomic/AtomicULong;JILjava/lang/Object;)J
+	public abstract fun getAndIncrement-PUiSbYQ (J)J
+	public static synthetic fun getAndIncrement-PUiSbYQ$default (Llove/forte/simbot/common/atomic/AtomicULong;JILjava/lang/Object;)J
+	public abstract fun getAndSet-PUiSbYQ (J)J
+	public abstract fun getValue-s-VKNKU ()J
+	public abstract fun incrementAndGet-PUiSbYQ (J)J
+	public static synthetic fun incrementAndGet-PUiSbYQ$default (Llove/forte/simbot/common/atomic/AtomicULong;JILjava/lang/Object;)J
+	public abstract fun setValue-VKZWuLQ (J)V
+}
+
+public final class love/forte/simbot/common/atomic/Atomics {
+	public static final fun atomic (I)Llove/forte/simbot/common/atomic/AtomicInt;
+	public static final fun atomic (J)Llove/forte/simbot/common/atomic/AtomicLong;
+	public static final fun atomic (Z)Llove/forte/simbot/common/atomic/AtomicBoolean;
+	public static final fun atomic-VKZWuLQ (J)Llove/forte/simbot/common/atomic/AtomicULong;
+	public static final fun atomic-WZ4Q5Ns (I)Llove/forte/simbot/common/atomic/AtomicUInt;
+	public static final fun atomicRef (Ljava/lang/Object;)Llove/forte/simbot/common/atomic/AtomicRef;
+	public static final fun atomicUL-VKZWuLQ (J)Llove/forte/simbot/common/atomic/AtomicULong;
+	public static final fun minusAssign (Llove/forte/simbot/common/atomic/AtomicInt;I)V
+	public static final fun minusAssign (Llove/forte/simbot/common/atomic/AtomicLong;J)V
+	public static final fun minusAssign-2TYgG_w (Llove/forte/simbot/common/atomic/AtomicULong;J)V
+	public static final fun minusAssign-Qn1smSk (Llove/forte/simbot/common/atomic/AtomicUInt;I)V
+	public static final fun plusAssign (Llove/forte/simbot/common/atomic/AtomicInt;I)V
+	public static final fun plusAssign (Llove/forte/simbot/common/atomic/AtomicLong;J)V
+	public static final fun plusAssign-2TYgG_w (Llove/forte/simbot/common/atomic/AtomicULong;J)V
+	public static final fun plusAssign-Qn1smSk (Llove/forte/simbot/common/atomic/AtomicUInt;I)V
+	public static final fun update (Llove/forte/simbot/common/atomic/AtomicInt;Lkotlin/jvm/functions/Function1;)I
+	public static final fun update (Llove/forte/simbot/common/atomic/AtomicLong;Lkotlin/jvm/functions/Function1;)J
+	public static final fun update (Llove/forte/simbot/common/atomic/AtomicRef;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun update (Llove/forte/simbot/common/atomic/AtomicUInt;Lkotlin/jvm/functions/Function1;)I
+	public static final fun update (Llove/forte/simbot/common/atomic/AtomicULong;Lkotlin/jvm/functions/Function1;)J
+	public static final fun updateAndGet (Llove/forte/simbot/common/atomic/AtomicInt;Lkotlin/jvm/functions/Function1;)I
+	public static final fun updateAndGet (Llove/forte/simbot/common/atomic/AtomicLong;Lkotlin/jvm/functions/Function1;)J
+	public static final fun updateAndGet (Llove/forte/simbot/common/atomic/AtomicRef;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun updateAndGet (Llove/forte/simbot/common/atomic/AtomicUInt;Lkotlin/jvm/functions/Function1;)I
+	public static final fun updateAndGet (Llove/forte/simbot/common/atomic/AtomicULong;Lkotlin/jvm/functions/Function1;)J
+}
+

--- a/simbot-commons/simbot-common-atomic/build.gradle.kts
+++ b/simbot-commons/simbot-common-atomic/build.gradle.kts
@@ -25,7 +25,7 @@ import love.forte.gradle.common.core.project.setup
 import love.forte.gradle.common.kotlin.multiplatform.applyTier1
 import love.forte.gradle.common.kotlin.multiplatform.applyTier2
 import love.forte.gradle.common.kotlin.multiplatform.applyTier3
-import love.forte.plugin.suspendtrans.gradle.withKotlinTargets
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 plugins {
@@ -59,11 +59,11 @@ kotlin {
         configWasmJs()
     }
 
-    withKotlinTargets { target ->
-        targets.findByName(target.name)?.compilations?.all {
-            // 'expect'/'actual' classes (including interfaces, objects, annotations, enums, and 'actual' typealiases) are in Beta. You can use -Xexpect-actual-classes flag to suppress this warning. Also see: https://youtrack.jetbrains.com/issue/KT-61573
-            kotlinOptions.freeCompilerArgs += "-Xexpect-actual-classes"
-        }
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
+    compilerOptions {
+        freeCompilerArgs.addAll(
+            "-Xexpect-actual-classes"
+        )
     }
 
     sourceSets {

--- a/simbot-commons/simbot-common-collection/api/simbot-common-collection.api
+++ b/simbot-commons/simbot-common-collection/api/simbot-common-collection.api
@@ -1,0 +1,63 @@
+public final class love/forte/simbot/common/collection/Collections_jvmKt {
+	public static final fun createConcurrentQueue ()Llove/forte/simbot/common/collection/ConcurrentQueue;
+	public static final fun createPriorityConcurrentQueue ()Llove/forte/simbot/common/collection/PriorityConcurrentQueue;
+	public static final fun toImmutable (Ljava/util/Collection;)Ljava/util/Collection;
+}
+
+public abstract interface class love/forte/simbot/common/collection/ConcurrentQueue : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker {
+	public abstract fun add (Ljava/lang/Object;)V
+	public abstract fun clear ()V
+	public abstract fun getSize ()I
+	public abstract fun isEmpty ()Z
+	public abstract fun iterator ()Ljava/util/Iterator;
+	public abstract fun remove (Ljava/lang/Object;)V
+	public abstract fun removeIf (Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface annotation class love/forte/simbot/common/collection/ExperimentalSimbotCollectionApi : java/lang/annotation/Annotation {
+}
+
+public final class love/forte/simbot/common/collection/FlowsKt {
+	public static final fun asIterator (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/util/Iterator;
+}
+
+public final class love/forte/simbot/common/collection/MapsKt {
+	public static final fun internalComputeIfAbsentImpl (Ljava/util/Map;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun internalComputeIfPresentImpl (Ljava/util/Map;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public static final fun internalComputeImpl (Ljava/util/Map;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public static final fun internalMergeImpl (Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public static final fun internalRemoveValueImpl (Ljava/util/Map;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Z
+}
+
+public final class love/forte/simbot/common/collection/Maps_jvmKt {
+	public static final fun computeValue (Ljava/util/Map;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public static final fun computeValueIfAbsent (Ljava/util/Map;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun computeValueIfPresent (Ljava/util/Map;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public static final fun concurrentMutableMap ()Ljava/util/Map;
+	public static final fun mergeValue (Ljava/util/Map;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public static final fun removeValue (Ljava/util/Map;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Z
+}
+
+public final class love/forte/simbot/common/collection/Maps_jvmKt$sam$i$java_util_function_BiFunction$0 : java/util/function/BiFunction {
+	public fun <init> (Lkotlin/jvm/functions/Function2;)V
+	public final synthetic fun apply (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/common/collection/Maps_jvmKt$sam$i$java_util_function_Function$0 : java/util/function/Function {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public final synthetic fun apply (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/common/collection/PriorityConcurrentQueue : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker {
+	public abstract fun add (ILjava/lang/Object;)V
+	public abstract fun clear ()V
+	public abstract fun getSize ()I
+	public abstract fun isEmpty ()Z
+	public abstract fun isEmpty (I)Z
+	public abstract fun iterator ()Ljava/util/Iterator;
+	public abstract fun remove (ILjava/lang/Object;)V
+	public abstract fun remove (Ljava/lang/Object;)V
+	public abstract fun removeIf (ILkotlin/jvm/functions/Function1;)V
+	public abstract fun removeIf (Lkotlin/jvm/functions/Function1;)V
+}
+

--- a/simbot-commons/simbot-common-collection/build.gradle.kts
+++ b/simbot-commons/simbot-common-collection/build.gradle.kts
@@ -25,7 +25,7 @@ import love.forte.gradle.common.core.project.setup
 import love.forte.gradle.common.kotlin.multiplatform.applyTier1
 import love.forte.gradle.common.kotlin.multiplatform.applyTier2
 import love.forte.gradle.common.kotlin.multiplatform.applyTier3
-import love.forte.plugin.suspendtrans.gradle.withKotlinTargets
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 plugins {
@@ -66,11 +66,11 @@ kotlin {
         configWasmJs()
     }
 
-    withKotlinTargets { target ->
-        targets.findByName(target.name)?.compilations?.all {
-            // 'expect'/'actual' classes (including interfaces, objects, annotations, enums, and 'actual' typealiases) are in Beta. You can use -Xexpect-actual-classes flag to suppress this warning. Also see: https://youtrack.jetbrains.com/issue/KT-61573
-            kotlinOptions.freeCompilerArgs += "-Xexpect-actual-classes"
-        }
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
+    compilerOptions {
+        freeCompilerArgs.addAll(
+            "-Xexpect-actual-classes"
+        )
     }
 
     sourceSets {

--- a/simbot-commons/simbot-common-collection/src/nativeTest/kotlin/AtomicTest.kt
+++ b/simbot-commons/simbot-common-collection/src/nativeTest/kotlin/AtomicTest.kt
@@ -1,0 +1,107 @@
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.test.runTest
+import kotlin.concurrent.AtomicReference
+import kotlin.coroutines.resume
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ *
+ * @author ForteScarlet
+ */
+class AtomicTest {
+    private data class Data<T, R>(val value: T, val continuation: CancellableContinuation<R>)
+    private class Session<T, R>(val channel: Channel<Data<T, R>>)
+    class MapBox<K, V>(val map: Map<K, V>)
+
+    private fun <K, V> Map<K, V>.box(): MapBox<K, V> = MapBox(this)
+
+    @Test
+    fun a() = runTest {
+        val pJob = Job()
+        val key = Any()
+        val mapRef = AtomicReference(emptyMap<Any, Session<Int, String>>().box())
+        withContext(Dispatchers.Default) {
+            val channel = Channel<Data<Int, String>>()
+            val scope = CoroutineScope(Dispatchers.Default + pJob)
+            val sJob = Job(pJob)
+            val session = Session(channel)
+
+            sJob.invokeOnCompletion {
+                channel.cancel(it?.let { e -> CancellationException(e.message, e) })
+                // remove session
+                do {
+                    val oldMapBox = mapRef.value
+                    val newMap = oldMapBox.map.toMutableMap().apply {
+                        removeValue(key) { session }
+                    }
+                } while (!mapRef.compareAndSet(expected = oldMapBox, newValue = newMap.box()))
+            }
+
+            scope.launch {
+                withContext(Dispatchers.Default) {
+                    withTimeoutOrNull(50.milliseconds) {
+                        session.channel.receive()
+                    }
+                }
+
+                session.channel.receive().also { (value, continuation) ->
+                    continuation.resume(value.toString())
+                }
+                session.channel.receive().also { (value, continuation) ->
+                    continuation.resume(value.toString())
+                }
+                session.channel.receive().also { (value, continuation) ->
+                    continuation.resume(value.toString())
+                }
+                sJob.complete()
+            }
+
+            withContext(Dispatchers.Default) {
+                delay(100.milliseconds)
+            }
+
+            coroutineScope {
+                val v1 = suspendCancellableCoroutine { c ->
+                    launch { channel.send(Data(1, c)) }
+                }
+                val v2 = suspendCancellableCoroutine { c ->
+                    launch { channel.send(Data(2, c)) }
+                }
+                val v3 = suspendCancellableCoroutine { c ->
+                    launch { channel.send(Data(3, c)) }
+                }
+
+                assertEquals("1", v1)
+                assertEquals("2", v2)
+                assertEquals("3", v3)
+
+                sJob.join()
+
+                assertNull(mapRef.value.map[key])
+            }
+        }
+
+    }
+
+}
+
+private inline fun <K, V> MutableMap<K, V>.removeValue(
+    key: K,
+    crossinline target: () -> V
+): Boolean {
+    val targetValue = target()
+    val iter = iterator()
+    while (iter.hasNext()) {
+        val entry = iter.next()
+        if (entry.key == key && entry.value == targetValue) {
+            iter.remove()
+            return true
+        }
+    }
+
+    return false
+}

--- a/simbot-commons/simbot-common-core/api/simbot-common-core.api
+++ b/simbot-commons/simbot-common-core/api/simbot-common-core.api
@@ -1,0 +1,688 @@
+public final class love/forte/simbot/common/PriorityConstant {
+	public static final field DEFAULT I
+	public static final field DE_PRIORITIZE_1 I
+	public static final field DE_PRIORITIZE_2 I
+	public static final field DE_PRIORITIZE_3 I
+	public static final field DE_PRIORITIZE_4 I
+	public static final field DE_PRIORITIZE_5 I
+	public static final field DE_PRIORITIZE_6 I
+	public static final field DE_PRIORITIZE_7 I
+	public static final field DE_PRIORITIZE_8 I
+	public static final field DE_PRIORITIZE_9 I
+	public static final field INSTANCE Llove/forte/simbot/common/PriorityConstant;
+	public static final field PRIORITIZE_1 I
+	public static final field PRIORITIZE_2 I
+	public static final field PRIORITIZE_3 I
+	public static final field PRIORITIZE_4 I
+	public static final field PRIORITIZE_5 I
+	public static final field PRIORITIZE_6 I
+	public static final field PRIORITIZE_7 I
+	public static final field PRIORITIZE_8 I
+	public static final field PRIORITIZE_9 I
+}
+
+public final class love/forte/simbot/common/async/Async {
+	public fun <init> (Lkotlinx/coroutines/Deferred;)V
+	public final fun asFuture ()Ljava/util/concurrent/CompletableFuture;
+	public final fun cancel ()V
+	public final fun cancelBy (Ljava/util/concurrent/CancellationException;)V
+	public final fun getDeferred ()Lkotlinx/coroutines/Deferred;
+	public final fun handle (Llove/forte/simbot/common/function/Action;)Lkotlinx/coroutines/DisposableHandle;
+	public final fun isActive ()Z
+	public final fun isCancelled ()Z
+	public final fun isCompleted ()Z
+	public final fun onCancellation (Llove/forte/simbot/common/function/Action;)Lkotlinx/coroutines/DisposableHandle;
+	public final fun onCompletion (Llove/forte/simbot/common/function/Action;)Lkotlinx/coroutines/DisposableHandle;
+	public final fun onError (Llove/forte/simbot/common/function/Action;)Lkotlinx/coroutines/DisposableHandle;
+}
+
+public abstract interface class love/forte/simbot/common/async/AsyncHandler {
+	public abstract fun invoke (Ljava/lang/Throwable;)V
+}
+
+public final class love/forte/simbot/common/async/AsyncUtil {
+	public static final fun asAsync (Ljava/util/concurrent/CompletableFuture;)Llove/forte/simbot/common/async/Async;
+	public static final fun asAsync (Lkotlinx/coroutines/Deferred;)Llove/forte/simbot/common/async/Async;
+	public static final synthetic fun await (Llove/forte/simbot/common/async/Async;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun cancelBy (Llove/forte/simbot/common/async/Async;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public static synthetic fun cancelBy$default (Llove/forte/simbot/common/async/Async;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public static final fun completedAsync (Ljava/lang/Object;)Llove/forte/simbot/common/async/Async;
+	public static final fun getOnAwait (Llove/forte/simbot/common/async/Async;)Lkotlinx/coroutines/selects/SelectClause1;
+	public static final fun getOnJoin (Llove/forte/simbot/common/async/Async;)Lkotlinx/coroutines/selects/SelectClause0;
+	public static final synthetic fun join (Llove/forte/simbot/common/async/Async;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun toAsync (Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)Llove/forte/simbot/common/async/Async;
+}
+
+public abstract interface class love/forte/simbot/common/async/CancellationHandler {
+	public abstract fun invoke (Ljava/util/concurrent/CancellationException;)V
+}
+
+public abstract interface class love/forte/simbot/common/async/CompletionHandler {
+	public abstract fun invoke (Ljava/lang/Object;)V
+}
+
+public abstract interface class love/forte/simbot/common/async/ErrorHandler {
+	public abstract fun invoke (Ljava/lang/Throwable;)V
+}
+
+public final class love/forte/simbot/common/attribute/Attribute {
+	public static final field Companion Llove/forte/simbot/common/attribute/Attribute$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static final fun of (Ljava/lang/String;)Llove/forte/simbot/common/attribute/Attribute;
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/common/attribute/Attribute$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public fun <init> (Lkotlinx/serialization/KSerializer;)V
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/common/attribute/Attribute;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/common/attribute/Attribute;)V
+	public final fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/common/attribute/Attribute$Companion {
+	public final fun of (Ljava/lang/String;)Llove/forte/simbot/common/attribute/Attribute;
+	public final fun serializer (Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class love/forte/simbot/common/attribute/AttributeMap {
+	public static final field Companion Llove/forte/simbot/common/attribute/AttributeMap$Companion;
+	public abstract fun contains (Llove/forte/simbot/common/attribute/Attribute;)Z
+	public static fun create ()Llove/forte/simbot/common/attribute/AttributeMap;
+	public static fun create (Ljava/util/Map;)Llove/forte/simbot/common/attribute/AttributeMap;
+	public abstract fun get (Llove/forte/simbot/common/attribute/Attribute;)Ljava/lang/Object;
+	public abstract fun getEntries ()Ljava/util/Set;
+	public abstract fun safeGet (Llove/forte/simbot/common/attribute/Attribute;)Ljava/lang/Object;
+	public abstract fun size ()I
+}
+
+public final class love/forte/simbot/common/attribute/AttributeMap$Companion {
+	public final fun create ()Llove/forte/simbot/common/attribute/AttributeMap;
+	public final fun create (Ljava/util/Map;)Llove/forte/simbot/common/attribute/AttributeMap;
+	public static synthetic fun create$default (Llove/forte/simbot/common/attribute/AttributeMap$Companion;Ljava/util/Map;ILjava/lang/Object;)Llove/forte/simbot/common/attribute/AttributeMap;
+}
+
+public abstract interface class love/forte/simbot/common/attribute/AttributeMapContainer {
+	public abstract fun getAttributeMap ()Llove/forte/simbot/common/attribute/AttributeMap;
+}
+
+public final class love/forte/simbot/common/attribute/Attributes {
+	public static final fun attributeMapOf (Ljava/util/Map;)Llove/forte/simbot/common/attribute/AttributeMap;
+	public static synthetic fun attributeMapOf$default (Ljava/util/Map;ILjava/lang/Object;)Llove/forte/simbot/common/attribute/AttributeMap;
+	public static final fun mutableAttributeMapOf (Ljava/util/Map;)Llove/forte/simbot/common/attribute/MutableAttributeMap;
+	public static synthetic fun mutableAttributeMapOf$default (Ljava/util/Map;ILjava/lang/Object;)Llove/forte/simbot/common/attribute/MutableAttributeMap;
+	public static final fun set (Llove/forte/simbot/common/attribute/MutableAttributeMap;Llove/forte/simbot/common/attribute/Attribute;Ljava/lang/Object;)V
+}
+
+public abstract interface class love/forte/simbot/common/attribute/MutableAttributeMap : love/forte/simbot/common/attribute/AttributeMap {
+	public static final field Companion Llove/forte/simbot/common/attribute/MutableAttributeMap$Companion;
+	public abstract fun computeIfAbsent (Llove/forte/simbot/common/attribute/Attribute;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public abstract fun computeIfPresent (Llove/forte/simbot/common/attribute/Attribute;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public static fun create (Ljava/util/Map;)Llove/forte/simbot/common/attribute/MutableAttributeMap;
+	public abstract fun getEntries ()Ljava/util/Set;
+	public abstract fun merge (Llove/forte/simbot/common/attribute/Attribute;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public abstract fun put (Llove/forte/simbot/common/attribute/Attribute;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun remove (Llove/forte/simbot/common/attribute/Attribute;)Ljava/lang/Object;
+	public abstract fun safeComputeIfAbsent (Llove/forte/simbot/common/attribute/Attribute;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public abstract fun safeComputeIfPresent (Llove/forte/simbot/common/attribute/Attribute;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public abstract fun safeMerge (Llove/forte/simbot/common/attribute/Attribute;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public abstract fun safePut (Llove/forte/simbot/common/attribute/Attribute;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun safeRemove (Llove/forte/simbot/common/attribute/Attribute;)Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/common/attribute/MutableAttributeMap$Companion {
+	public final fun create (Ljava/util/Map;)Llove/forte/simbot/common/attribute/MutableAttributeMap;
+	public static synthetic fun create$default (Llove/forte/simbot/common/attribute/MutableAttributeMap$Companion;Ljava/util/Map;ILjava/lang/Object;)Llove/forte/simbot/common/attribute/MutableAttributeMap;
+}
+
+public final class love/forte/simbot/common/attribute/MutableAttributeMapImpl$inlined$sam$i$java_util_function_BiFunction$0 : java/util/function/BiFunction {
+	public fun <init> (Lkotlin/jvm/functions/Function2;)V
+	public final synthetic fun apply (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/common/attribute/MutableAttributeMapImpl$inlined$sam$i$java_util_function_Function$0 : java/util/function/Function {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public final synthetic fun apply (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/common/collectable/Collectable {
+	public abstract fun asFlow ()Lkotlinx/coroutines/flow/Flow;
+	public abstract synthetic fun collect (Llove/forte/simbot/common/function/Action;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun collectAsync (Lkotlinx/coroutines/CoroutineScope;Llove/forte/simbot/common/function/Action;)Llove/forte/simbot/common/async/Async;
+	public fun transform (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;Llove/forte/simbot/suspendrunner/reserve/SuspendReserve$Transformer;)Ljava/lang/Object;
+	public fun transform (Llove/forte/simbot/suspendrunner/reserve/SuspendReserve$Transformer;)Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/common/collectable/Collectables {
+	public static final fun asFlowSynchronouslyIterateCollectable (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/CoroutineScope;)Llove/forte/simbot/common/collectable/FlowSynchronouslyIterateCollectable;
+	public static final fun asFlux (Llove/forte/simbot/common/collectable/Collectable;)Lreactor/core/publisher/Flux;
+	public static final fun asStream (Llove/forte/simbot/common/collectable/Collectable;)Ljava/util/stream/Stream;
+	public static final fun asStream (Llove/forte/simbot/common/collectable/Collectable;Lkotlinx/coroutines/CoroutineScope;)Ljava/util/stream/Stream;
+	public static final fun asStream (Llove/forte/simbot/common/collectable/IterableCollectable;)Ljava/util/stream/Stream;
+	public static final fun asStream (Llove/forte/simbot/common/collectable/SequenceCollectable;)Ljava/util/stream/Stream;
+	public static synthetic fun asStream$default (Llove/forte/simbot/common/collectable/Collectable;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Ljava/util/stream/Stream;
+	public static final fun asSynchronouslyIterateCollectable (Llove/forte/simbot/common/collectable/Collectable;Lkotlinx/coroutines/CoroutineScope;)Llove/forte/simbot/common/collectable/SynchronouslyIterateCollectable;
+	public static final fun collect (Llove/forte/simbot/common/collectable/Collectable;Ljava/util/stream/Collector;)Ljava/lang/Object;
+	public static final fun collectAsync (Llove/forte/simbot/common/collectable/Collectable;Ljava/util/stream/Collector;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun collectAsync (Llove/forte/simbot/common/collectable/Collectable;Lkotlinx/coroutines/CoroutineScope;Ljava/util/stream/Collector;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun collectAsync$default (Llove/forte/simbot/common/collectable/Collectable;Lkotlinx/coroutines/CoroutineScope;Ljava/util/stream/Collector;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public static final synthetic fun collectBy (Lkotlinx/coroutines/flow/Flow;Ljava/util/stream/Collector;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final synthetic fun collectBy (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;Ljava/util/stream/Collector;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun collectBy$default (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;Ljava/util/stream/Collector;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun emptyCollectable ()Llove/forte/simbot/common/collectable/Collectable;
+	public static final fun flowCollectable (Lkotlin/jvm/functions/Function2;)Llove/forte/simbot/common/collectable/Collectable;
+	public static final fun toList (Llove/forte/simbot/common/collectable/Collectable;)Ljava/util/List;
+	public static final fun toListAsync (Llove/forte/simbot/common/collectable/Collectable;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun toListAsync (Llove/forte/simbot/common/collectable/Collectable;Lkotlinx/coroutines/CoroutineScope;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun toListAsync$default (Llove/forte/simbot/common/collectable/Collectable;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun transform (Llove/forte/simbot/common/collectable/Collectable;Lkotlinx/coroutines/CoroutineScope;Llove/forte/simbot/suspendrunner/reserve/SuspendReserve$Transformer;)Ljava/lang/Object;
+	public static final fun transform (Llove/forte/simbot/common/collectable/Collectable;Llove/forte/simbot/suspendrunner/reserve/SuspendReserve$Transformer;)Ljava/lang/Object;
+	public static synthetic fun transform$default (Llove/forte/simbot/common/collectable/Collectable;Lkotlinx/coroutines/CoroutineScope;Llove/forte/simbot/suspendrunner/reserve/SuspendReserve$Transformer;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun valueOf (Ljava/lang/Iterable;)Llove/forte/simbot/common/collectable/IterableCollectable;
+	public static final fun valueOf (Ljava/util/stream/Stream;)Llove/forte/simbot/common/collectable/SequenceCollectable;
+	public static final fun valueOf (Lkotlin/sequences/Sequence;)Llove/forte/simbot/common/collectable/SequenceCollectable;
+	public static final fun valueOf (Lkotlinx/coroutines/flow/Flow;)Llove/forte/simbot/common/collectable/Collectable;
+}
+
+public abstract interface class love/forte/simbot/common/collectable/FlowSynchronouslyIterateCollectable : love/forte/simbot/common/collectable/SynchronouslyIterateCollectable {
+	public abstract fun asFlow ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun collect (Llove/forte/simbot/common/function/Action;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun collectAsync (Lkotlinx/coroutines/CoroutineScope;Llove/forte/simbot/common/function/Action;)Llove/forte/simbot/common/async/Async;
+	public abstract fun forEach (Llove/forte/simbot/common/function/Action;)V
+	public abstract fun iterator ()Ljava/util/Iterator;
+	public abstract fun iterator (Lkotlinx/coroutines/CoroutineScope;)Ljava/util/Iterator;
+}
+
+public abstract interface class love/forte/simbot/common/collectable/IterableCollectable : love/forte/simbot/common/collectable/SynchronouslyIterateCollectable {
+	public fun asFlow ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun iterator ()Ljava/util/Iterator;
+}
+
+public abstract interface class love/forte/simbot/common/collectable/SequenceCollectable : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker, love/forte/simbot/common/collectable/SynchronouslyIterateCollectable {
+	public fun asFlow ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun asSequence ()Lkotlin/sequences/Sequence;
+	public fun iterator ()Ljava/util/Iterator;
+}
+
+public abstract interface class love/forte/simbot/common/collectable/SynchronouslyIterateCollectable : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker, love/forte/simbot/common/collectable/Collectable {
+	public synthetic fun collect (Llove/forte/simbot/common/function/Action;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun collect$suspendImpl (Llove/forte/simbot/common/collectable/SynchronouslyIterateCollectable;Llove/forte/simbot/common/function/Action;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun collectAsync (Lkotlinx/coroutines/CoroutineScope;Llove/forte/simbot/common/function/Action;)Llove/forte/simbot/common/async/Async;
+	public abstract fun forEach (Llove/forte/simbot/common/function/Action;)V
+	public abstract fun toList ()Ljava/util/List;
+}
+
+public final class love/forte/simbot/common/coroutines/CoroutineContexts {
+	public static final fun mergeWith (Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;)Lkotlin/coroutines/CoroutineContext;
+}
+
+public final class love/forte/simbot/common/coroutines/DispatchersUtil {
+	public static final fun getIOOrDefault (Lkotlinx/coroutines/Dispatchers;)Lkotlinx/coroutines/CoroutineDispatcher;
+	public static final fun getVirtual (Lkotlinx/coroutines/Dispatchers;)Lkotlinx/coroutines/CoroutineDispatcher;
+	public static final fun getVirtualDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public static final fun getVirtualOrIO (Lkotlinx/coroutines/Dispatchers;)Lkotlinx/coroutines/CoroutineDispatcher;
+	public static final fun getVirtualOrIODispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+}
+
+public final class love/forte/simbot/common/coroutines/Jobs {
+	public static final fun linkTo (Lkotlinx/coroutines/Job;Lkotlinx/coroutines/Job;)Lkotlinx/coroutines/DisposableHandle;
+	public static final fun linkTo (Lkotlinx/coroutines/Job;Lkotlinx/coroutines/Job;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/DisposableHandle;
+	public static synthetic fun linkTo$default (Lkotlinx/coroutines/Job;Lkotlinx/coroutines/Job;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/DisposableHandle;
+}
+
+public final class love/forte/simbot/common/coroutines/LinkedParentJobCancellationException : java/util/concurrent/CancellationException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun getCause ()Ljava/lang/Throwable;
+	public fun getMessage ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/common/exception/Exceptions_jvmKt {
+	public static final fun initExceptionCause (Ljava/lang/Throwable;Ljava/lang/Throwable;)V
+}
+
+public abstract interface class love/forte/simbot/common/function/Action {
+	public abstract fun invoke (Ljava/lang/Object;)V
+}
+
+public abstract interface class love/forte/simbot/common/function/Condition {
+	public abstract fun invoke (Ljava/lang/Object;)Z
+}
+
+public abstract interface class love/forte/simbot/common/function/ConfigurerFunction {
+	public abstract fun invoke (Ljava/lang/Object;)V
+}
+
+public final class love/forte/simbot/common/function/FunctionsKt {
+	public static final fun invokeBy (Ljava/lang/Object;Llove/forte/simbot/common/function/ConfigurerFunction;)Ljava/lang/Object;
+	public static final fun invokeWith (Llove/forte/simbot/common/function/ConfigurerFunction;Ljava/lang/Object;)V
+	public static final fun plus (Llove/forte/simbot/common/function/ConfigurerFunction;Llove/forte/simbot/common/function/ConfigurerFunction;)Llove/forte/simbot/common/function/ConfigurerFunction;
+	public static final fun toConfigurerFunction (Lkotlin/jvm/functions/Function1;)Llove/forte/simbot/common/function/ConfigurerFunction;
+}
+
+public class love/forte/simbot/common/function/MergeableFactoriesConfigurator {
+	public fun <init> (Ljava/util/Map;Ljava/util/Map;)V
+	public final fun add (Llove/forte/simbot/common/function/MergeableFactory;Llove/forte/simbot/common/function/ConfigurerFunction;)V
+	public final fun create (Ljava/lang/Object;Llove/forte/simbot/common/function/MergeableFactory;)Ljava/lang/Object;
+	public final fun createAll (Ljava/lang/Object;)Ljava/util/List;
+	public final fun createOrNull (Llove/forte/simbot/common/function/MergeableFactory;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/common/function/MergeableFactoriesConfigurator$Configurer {
+	public abstract fun invoke (Ljava/lang/Object;Ljava/lang/Object;)V
+}
+
+public abstract interface class love/forte/simbot/common/function/MergeableFactory {
+	public fun create (Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun create (Ljava/lang/Object;Llove/forte/simbot/common/function/ConfigurerFunction;)Ljava/lang/Object;
+	public abstract fun getKey ()Llove/forte/simbot/common/function/MergeableFactory$Key;
+}
+
+public abstract interface class love/forte/simbot/common/function/MergeableFactory$Key {
+}
+
+public final class love/forte/simbot/common/id/AsStringIDSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Llove/forte/simbot/common/id/AsStringIDSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/common/id/StringID;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/common/id/ID;)V
+}
+
+public abstract class love/forte/simbot/common/id/ID : java/lang/Comparable {
+	public static final field Companion Llove/forte/simbot/common/id/ID$Companion;
+	public abstract fun copy ()Llove/forte/simbot/common/id/ID;
+	public abstract fun equals (Ljava/lang/Object;)Z
+	public abstract fun equalsExact (Ljava/lang/Object;)Z
+	public abstract fun hashCode ()I
+	public abstract fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/common/id/ID$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface annotation class love/forte/simbot/common/id/ID4J : java/lang/annotation/Annotation {
+}
+
+public abstract interface class love/forte/simbot/common/id/IDContainer {
+	public abstract fun getId ()Llove/forte/simbot/common/id/ID;
+}
+
+public final class love/forte/simbot/common/id/Identifies {
+	public static final fun getLiteral (Llove/forte/simbot/common/id/ID;)Ljava/lang/String;
+	public static final fun of (I)Llove/forte/simbot/common/id/IntID;
+	public static final fun of (J)Llove/forte/simbot/common/id/LongID;
+	public static final fun of (Ljava/lang/CharSequence;)Llove/forte/simbot/common/id/StringID;
+	public static final fun of (Ljava/lang/String;)Llove/forte/simbot/common/id/StringID;
+	public static final fun ofUInt (I)Llove/forte/simbot/common/id/UIntID;
+	public static final fun ofUInt (Ljava/lang/String;)Llove/forte/simbot/common/id/UIntID;
+	public static final fun ofULong (J)Llove/forte/simbot/common/id/ULongID;
+	public static final fun ofULong (Ljava/lang/String;)Llove/forte/simbot/common/id/ULongID;
+	public static final fun toInt (Llove/forte/simbot/common/id/ID;)I
+	public static final fun toInt (Llove/forte/simbot/common/id/ID;Lkotlin/jvm/functions/Function1;)I
+	public static synthetic fun toInt$default (Llove/forte/simbot/common/id/ID;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)I
+	public static final fun toIntID (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/common/id/IntID;
+	public static final fun toIntID (Llove/forte/simbot/common/id/ID;Lkotlin/jvm/functions/Function1;)Llove/forte/simbot/common/id/IntID;
+	public static synthetic fun toIntID$default (Llove/forte/simbot/common/id/ID;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Llove/forte/simbot/common/id/IntID;
+	public static final fun toIntOrNull (Llove/forte/simbot/common/id/ID;)Ljava/lang/Integer;
+	public static final fun toIntOrNull (Llove/forte/simbot/common/id/ID;Lkotlin/jvm/functions/Function1;)Ljava/lang/Integer;
+	public static synthetic fun toIntOrNull$default (Llove/forte/simbot/common/id/ID;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Integer;
+	public static final fun toLong (Llove/forte/simbot/common/id/ID;)J
+	public static final fun toLong (Llove/forte/simbot/common/id/ID;Lkotlin/jvm/functions/Function1;)J
+	public static synthetic fun toLong$default (Llove/forte/simbot/common/id/ID;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)J
+	public static final fun toLongID (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/common/id/LongID;
+	public static final fun toLongID (Llove/forte/simbot/common/id/ID;Lkotlin/jvm/functions/Function1;)Llove/forte/simbot/common/id/LongID;
+	public static synthetic fun toLongID$default (Llove/forte/simbot/common/id/ID;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Llove/forte/simbot/common/id/LongID;
+	public static final fun toLongOrNull (Llove/forte/simbot/common/id/ID;)Ljava/lang/Long;
+	public static final fun toLongOrNull (Llove/forte/simbot/common/id/ID;Lkotlin/jvm/functions/Function1;)Ljava/lang/Long;
+	public static synthetic fun toLongOrNull$default (Llove/forte/simbot/common/id/ID;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Long;
+	public static final fun toUInt (Llove/forte/simbot/common/id/ID;)I
+	public static final fun toUInt (Llove/forte/simbot/common/id/ID;Lkotlin/jvm/functions/Function1;)I
+	public static synthetic fun toUInt$default (Llove/forte/simbot/common/id/ID;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)I
+	public static final fun toUIntID (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/common/id/UIntID;
+	public static final fun toUIntID (Llove/forte/simbot/common/id/ID;Lkotlin/jvm/functions/Function1;)Llove/forte/simbot/common/id/UIntID;
+	public static synthetic fun toUIntID$default (Llove/forte/simbot/common/id/ID;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Llove/forte/simbot/common/id/UIntID;
+	public static final fun toUIntOrNull (Llove/forte/simbot/common/id/ID;)Lkotlin/UInt;
+	public static final fun toUIntOrNull (Llove/forte/simbot/common/id/ID;Lkotlin/jvm/functions/Function1;)Lkotlin/UInt;
+	public static synthetic fun toUIntOrNull$default (Llove/forte/simbot/common/id/ID;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlin/UInt;
+	public static final fun toULong (Llove/forte/simbot/common/id/ID;)J
+	public static final fun toULong (Llove/forte/simbot/common/id/ID;Lkotlin/jvm/functions/Function1;)J
+	public static synthetic fun toULong$default (Llove/forte/simbot/common/id/ID;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)J
+	public static final fun toULongID (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/common/id/ULongID;
+	public static final fun toULongID (Llove/forte/simbot/common/id/ID;Lkotlin/jvm/functions/Function1;)Llove/forte/simbot/common/id/ULongID;
+	public static synthetic fun toULongID$default (Llove/forte/simbot/common/id/ID;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Llove/forte/simbot/common/id/ULongID;
+	public static final fun toULongOrNull (Llove/forte/simbot/common/id/ID;)Lkotlin/ULong;
+	public static final fun toULongOrNull (Llove/forte/simbot/common/id/ID;Lkotlin/jvm/functions/Function1;)Lkotlin/ULong;
+	public static synthetic fun toULongOrNull$default (Llove/forte/simbot/common/id/ID;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlin/ULong;
+	public static final fun uuid ()Llove/forte/simbot/common/id/UUID;
+	public static final fun uuid (Ljava/util/Random;)Llove/forte/simbot/common/id/UUID;
+	public static final fun uuid (Ljava/util/UUID;)Llove/forte/simbot/common/id/UUID;
+	public static final fun uuid (Lkotlin/random/Random;)Llove/forte/simbot/common/id/UUID;
+	public static synthetic fun uuid$default (Lkotlin/random/Random;ILjava/lang/Object;)Llove/forte/simbot/common/id/UUID;
+}
+
+public final class love/forte/simbot/common/id/IntID : love/forte/simbot/common/id/SignedNumericID {
+	public static final field Companion Llove/forte/simbot/common/id/IntID$Companion;
+	public synthetic fun <init> (ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun copy ()Llove/forte/simbot/common/id/ID;
+	public fun copy ()Llove/forte/simbot/common/id/IntID;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun equalsExact (Ljava/lang/Object;)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public fun toByte ()B
+	public fun toDouble ()D
+	public fun toFloat ()F
+	public fun toInt ()I
+	public fun toLong ()J
+	public fun toShort ()S
+	public fun toString ()Ljava/lang/String;
+	public static final fun valueOf (I)Llove/forte/simbot/common/id/IntID;
+}
+
+public final class love/forte/simbot/common/id/IntID$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public final fun valueOf (I)Llove/forte/simbot/common/id/IntID;
+}
+
+public final class love/forte/simbot/common/id/LongID : love/forte/simbot/common/id/SignedNumericID {
+	public static final field Companion Llove/forte/simbot/common/id/LongID$Companion;
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun copy ()Llove/forte/simbot/common/id/ID;
+	public fun copy ()Llove/forte/simbot/common/id/LongID;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun equalsExact (Ljava/lang/Object;)Z
+	public final fun getValue ()J
+	public fun hashCode ()I
+	public fun toByte ()B
+	public fun toDouble ()D
+	public fun toFloat ()F
+	public fun toInt ()I
+	public fun toLong ()J
+	public fun toShort ()S
+	public fun toString ()Ljava/lang/String;
+	public static final fun valueOf (J)Llove/forte/simbot/common/id/LongID;
+}
+
+public final class love/forte/simbot/common/id/LongID$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public final fun valueOf (J)Llove/forte/simbot/common/id/LongID;
+}
+
+public final class love/forte/simbot/common/id/LongID$Serializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Llove/forte/simbot/common/id/LongID$Serializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/common/id/LongID;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/common/id/LongID;)V
+}
+
+public abstract class love/forte/simbot/common/id/NumericalID : love/forte/simbot/common/id/ID {
+	public static final field Companion Llove/forte/simbot/common/id/NumericalID$Companion;
+	protected abstract fun compareNumber (Llove/forte/simbot/common/id/NumericalID;)I
+	public synthetic fun compareTo (Ljava/lang/Object;)I
+	public final fun compareTo (Llove/forte/simbot/common/id/ID;)I
+	public abstract fun toByte ()B
+	public abstract fun toDouble ()D
+	public abstract fun toFloat ()F
+	public abstract fun toInt ()I
+	public abstract fun toLong ()J
+	public abstract fun toShort ()S
+	public fun toUInt-pVg5ArA ()I
+	public fun toULong-s-VKNKU ()J
+}
+
+public final class love/forte/simbot/common/id/NumericalID$Companion {
+}
+
+public abstract class love/forte/simbot/common/id/SignedNumericID : love/forte/simbot/common/id/NumericalID {
+}
+
+public final class love/forte/simbot/common/id/StringID : love/forte/simbot/common/id/ID {
+	public static final field Companion Llove/forte/simbot/common/id/StringID$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun compareTo (Ljava/lang/Object;)I
+	public fun compareTo (Llove/forte/simbot/common/id/ID;)I
+	public synthetic fun copy ()Llove/forte/simbot/common/id/ID;
+	public fun copy ()Llove/forte/simbot/common/id/StringID;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun equalsExact (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun valueOf (Ljava/lang/CharSequence;)Llove/forte/simbot/common/id/StringID;
+	public static final fun valueOf (Ljava/lang/String;)Llove/forte/simbot/common/id/StringID;
+}
+
+public final class love/forte/simbot/common/id/StringID$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public final fun valueOf (Ljava/lang/CharSequence;)Llove/forte/simbot/common/id/StringID;
+	public final fun valueOf (Ljava/lang/String;)Llove/forte/simbot/common/id/StringID;
+}
+
+public final class love/forte/simbot/common/id/StringID$Serializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Llove/forte/simbot/common/id/StringID$Serializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/common/id/StringID;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/common/id/StringID;)V
+}
+
+public final class love/forte/simbot/common/id/UIntID : love/forte/simbot/common/id/UnsignedNumericID {
+	public static final field Companion Llove/forte/simbot/common/id/UIntID$Companion;
+	public synthetic fun <init> (ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun copy ()Llove/forte/simbot/common/id/ID;
+	public fun copy ()Llove/forte/simbot/common/id/UIntID;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun equalsExact (Ljava/lang/Object;)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public fun toByte ()B
+	public fun toDouble ()D
+	public fun toFloat ()F
+	public fun toInt ()I
+	public fun toLong ()J
+	public fun toShort ()S
+	public fun toString ()Ljava/lang/String;
+	public fun toUInt-pVg5ArA ()I
+	public static final fun valueOf (I)Llove/forte/simbot/common/id/UIntID;
+}
+
+public final class love/forte/simbot/common/id/UIntID$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public final fun valueOf (I)Llove/forte/simbot/common/id/UIntID;
+}
+
+public final class love/forte/simbot/common/id/ULongID : love/forte/simbot/common/id/UnsignedNumericID {
+	public static final field Companion Llove/forte/simbot/common/id/ULongID$Companion;
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun copy ()Llove/forte/simbot/common/id/ID;
+	public fun copy ()Llove/forte/simbot/common/id/ULongID;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun equalsExact (Ljava/lang/Object;)Z
+	public final fun getValue ()J
+	public fun hashCode ()I
+	public fun toByte ()B
+	public fun toDouble ()D
+	public fun toFloat ()F
+	public fun toInt ()I
+	public fun toLong ()J
+	public fun toShort ()S
+	public fun toString ()Ljava/lang/String;
+	public fun toULong-s-VKNKU ()J
+	public static final fun valueOf (J)Llove/forte/simbot/common/id/ULongID;
+}
+
+public final class love/forte/simbot/common/id/ULongID$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public final fun valueOf (J)Llove/forte/simbot/common/id/ULongID;
+}
+
+public final class love/forte/simbot/common/id/UUID : love/forte/simbot/common/id/ID {
+	public static final field Companion Llove/forte/simbot/common/id/UUID$Companion;
+	public synthetic fun compareTo (Ljava/lang/Object;)I
+	public fun compareTo (Llove/forte/simbot/common/id/ID;)I
+	public fun copy ()Llove/forte/simbot/common/id/ID;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun equalsExact (Ljava/lang/Object;)Z
+	public final fun getLeastSignificantBits ()J
+	public final fun getMostSignificantBits ()J
+	public fun hashCode ()I
+	public static final fun random ()Llove/forte/simbot/common/id/UUID;
+	public static final fun random (Lkotlin/random/Random;)Llove/forte/simbot/common/id/UUID;
+	public fun toString ()Ljava/lang/String;
+	public static final fun valueOf (JJ)Llove/forte/simbot/common/id/UUID;
+	public static final fun valueOf (Ljava/lang/String;)Llove/forte/simbot/common/id/UUID;
+	public static final fun valueOf ([B)Llove/forte/simbot/common/id/UUID;
+}
+
+public final class love/forte/simbot/common/id/UUID$Companion {
+	public final fun random ()Llove/forte/simbot/common/id/UUID;
+	public final fun random (Lkotlin/random/Random;)Llove/forte/simbot/common/id/UUID;
+	public static synthetic fun random$default (Llove/forte/simbot/common/id/UUID$Companion;Lkotlin/random/Random;ILjava/lang/Object;)Llove/forte/simbot/common/id/UUID;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public final fun valueOf (JJ)Llove/forte/simbot/common/id/UUID;
+	public final fun valueOf (Ljava/lang/String;)Llove/forte/simbot/common/id/UUID;
+	public final fun valueOf ([B)Llove/forte/simbot/common/id/UUID;
+}
+
+public final class love/forte/simbot/common/id/UUID$Serializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Llove/forte/simbot/common/id/UUID$Serializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/common/id/UUID;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/common/id/UUID;)V
+}
+
+public final class love/forte/simbot/common/id/UUID$StructureSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Llove/forte/simbot/common/id/UUID$StructureSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/common/id/UUID;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/common/id/UUID;)V
+}
+
+public final class love/forte/simbot/common/id/UUIDJvmKt {
+	public static final fun getJavaUUID (Llove/forte/simbot/common/id/UUID;)Ljava/util/UUID;
+	public static final fun getSimbotUUID (Ljava/util/UUID;)Llove/forte/simbot/common/id/UUID;
+	public static final fun randomUUID (Ljava/util/Random;)Llove/forte/simbot/common/id/UUID;
+}
+
+public final class love/forte/simbot/common/id/UUIDsKt {
+	public static final fun checkRadix (I)I
+	public static final fun toLong (Ljava/lang/String;III)J
+	public static final fun toUUIDSigs (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+}
+
+public abstract class love/forte/simbot/common/id/UnsignedNumericID : love/forte/simbot/common/id/NumericalID {
+}
+
+public final class love/forte/simbot/common/serialization/Base64BytesSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Llove/forte/simbot/common/serialization/Base64BytesSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)[B
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;[B)V
+}
+
+public final class love/forte/simbot/common/serialization/GuessSerializerKt {
+	public static final fun guessSerializer (Ljava/lang/Object;Lkotlinx/serialization/modules/SerializersModule;)Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/common/services/Services {
+	public static final field INSTANCE Llove/forte/simbot/common/services/Services;
+	public static final fun addProvider (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function0;)V
+	public static final fun clearProviders (Lkotlin/reflect/KClass;)V
+	public static final fun loadProviders (Lkotlin/reflect/KClass;)Lkotlin/sequences/Sequence;
+}
+
+public final class love/forte/simbot/common/services/ServicesKt {
+	public static final fun addProvider (Llove/forte/simbot/common/services/Services;ZLkotlin/reflect/KClass;Lkotlin/jvm/functions/Function0;)V
+	public static final fun addProviderExceptJvm (Llove/forte/simbot/common/services/Services;Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function0;)V
+}
+
+public final class love/forte/simbot/common/services/Services_jvmKt {
+	public static final fun isJvm ()Z
+}
+
+public final class love/forte/simbot/common/text/StringsKt {
+	public static final fun toHex ([B)Ljava/lang/String;
+}
+
+public final class love/forte/simbot/common/time/InstantTimestamp : java/io/Serializable, love/forte/simbot/common/time/Timestamp {
+	public static final field Companion Llove/forte/simbot/common/time/InstantTimestamp$Companion;
+	public synthetic fun <init> (Ljava/time/Instant;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInstant ()Ljava/time/Instant;
+	public fun getMilliseconds ()J
+	public fun hashCode ()I
+	public static final fun of (Ljava/time/Instant;)Llove/forte/simbot/common/time/InstantTimestamp;
+	public fun timeAs (Ljava/util/concurrent/TimeUnit;)J
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/common/time/InstantTimestamp$Companion {
+	public final fun of (Ljava/time/Instant;)Llove/forte/simbot/common/time/InstantTimestamp;
+}
+
+public final class love/forte/simbot/common/time/JavaDurationsKt {
+	public static final synthetic fun getJava-LRDsOJo (J)Ljava/time/Duration;
+	public static final synthetic fun getJavaOrNull-LRDsOJo (J)Ljava/time/Duration;
+	public static final synthetic fun getKotlin (Ljava/time/Duration;)J
+	public static final fun java-VtjQ1oo (JLkotlin/jvm/functions/Function1;)Ljava/time/Duration;
+	public static synthetic fun java-VtjQ1oo$default (JLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/time/Duration;
+}
+
+public final class love/forte/simbot/common/time/MillisecondTimestamp : love/forte/simbot/common/time/Timestamp {
+	public fun <init> (J)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMilliseconds ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/common/time/Timestamp : java/lang/Comparable {
+	public static final field Companion Llove/forte/simbot/common/time/Timestamp$Companion;
+	public synthetic fun compareTo (Ljava/lang/Object;)I
+	public fun compareTo (Llove/forte/simbot/common/time/Timestamp;)I
+	public abstract fun getMilliseconds ()J
+	public static fun ofMilliseconds (J)Llove/forte/simbot/common/time/Timestamp;
+	public fun timeAs (Ljava/util/concurrent/TimeUnit;)J
+}
+
+public final class love/forte/simbot/common/time/Timestamp$Companion {
+	public final fun ofMilliseconds (J)Llove/forte/simbot/common/time/Timestamp;
+}
+
+public final class love/forte/simbot/common/weak/NonWeakRefImpl : love/forte/simbot/common/weak/WeakRef {
+	public fun <init> (Ljava/lang/Object;)V
+	public fun clear ()V
+	public fun getValue ()Ljava/lang/Object;
+	public fun setValue (Ljava/lang/Object;)V
+}
+
+public abstract interface class love/forte/simbot/common/weak/WeakRef {
+	public abstract fun clear ()V
+	public abstract fun getValue ()Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/common/weak/WeakRefKt {
+	public static final fun getValue (Llove/forte/simbot/common/weak/WeakRef;Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/common/weak/WeakRef_jvmKt {
+	public static final fun weakRef (Ljava/lang/Object;)Llove/forte/simbot/common/weak/WeakRef;
+}
+

--- a/simbot-commons/simbot-common-core/build.gradle.kts
+++ b/simbot-commons/simbot-common-core/build.gradle.kts
@@ -4,7 +4,7 @@
  *     Project    https://github.com/simple-robot/simpler-robot
  *     Email      ForteScarlet@163.com
  *
- *     This file is part of the Simple Robot Library.
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Lesser General Public License as published by
@@ -25,7 +25,7 @@ import love.forte.gradle.common.core.project.setup
 import love.forte.gradle.common.kotlin.multiplatform.applyTier1
 import love.forte.gradle.common.kotlin.multiplatform.applyTier2
 import love.forte.gradle.common.kotlin.multiplatform.applyTier3
-import love.forte.plugin.suspendtrans.gradle.withKotlinTargets
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 plugins {
@@ -59,11 +59,11 @@ kotlin {
         configWasmJs()
     }
 
-    withKotlinTargets { target ->
-        targets.findByName(target.name)?.compilations?.all {
-            // 'expect'/'actual' classes (including interfaces, objects, annotations, enums, and 'actual' typealiases) are in Beta. You can use -Xexpect-actual-classes flag to suppress this warning. Also see: https://youtrack.jetbrains.com/issue/KT-61573
-            kotlinOptions.freeCompilerArgs += "-Xexpect-actual-classes"
-        }
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
+    compilerOptions {
+        freeCompilerArgs.addAll(
+            "-Xexpect-actual-classes"
+        )
     }
 
     sourceSets {

--- a/simbot-commons/simbot-common-core/src/commonTest/kotlin/love/forte/simbot/common/id/IDTests.kt
+++ b/simbot-commons/simbot-common-core/src/commonTest/kotlin/love/forte/simbot/common/id/IDTests.kt
@@ -116,7 +116,10 @@ class IDTests {
         val uuid = UUID.from(mv, lv)
         val jsonString = Json.encodeToString(UUID.StructureSerializer, uuid)
         assertEquals("""{"mostSignificantBits":$mv,"leastSignificantBits":$lv}""", jsonString)
-        val decodedUUID = Json.decodeFromString(UUID.StructureSerializer, """{"mostSignificantBits":$mv,"leastSignificantBits":$lv}""")
+        val decodedUUID = Json.decodeFromString(
+            UUID.StructureSerializer,
+            """{"mostSignificantBits":$mv,"leastSignificantBits":$lv}"""
+        )
         assertEquals(uuid, decodedUUID)
 
         val err = assertFails {

--- a/simbot-commons/simbot-common-ktor-inputfile/api/simbot-common-ktor-inputfile.api
+++ b/simbot-commons/simbot-common-ktor-inputfile/api/simbot-common-ktor-inputfile.api
@@ -1,0 +1,28 @@
+public abstract interface class love/forte/simbot/common/ktor/inputfile/InputFile {
+	public abstract fun includeTo (Ljava/lang/String;Lio/ktor/http/Headers;Lio/ktor/client/request/forms/FormBuilder;)V
+	public static synthetic fun includeTo$default (Llove/forte/simbot/common/ktor/inputfile/InputFile;Ljava/lang/String;Lio/ktor/http/Headers;Lio/ktor/client/request/forms/FormBuilder;ILjava/lang/Object;)V
+	public abstract fun toFormPart (Ljava/lang/String;Lio/ktor/http/Headers;)Lio/ktor/client/request/forms/FormPart;
+	public static synthetic fun toFormPart$default (Llove/forte/simbot/common/ktor/inputfile/InputFile;Ljava/lang/String;Lio/ktor/http/Headers;ILjava/lang/Object;)Lio/ktor/client/request/forms/FormPart;
+}
+
+public final class love/forte/simbot/common/ktor/inputfile/InputFiles {
+	public static final fun of (Lio/ktor/client/request/forms/ChannelProvider;)Llove/forte/simbot/common/ktor/inputfile/InputFile;
+	public static final fun of (Lio/ktor/client/request/forms/ChannelProvider;Lio/ktor/http/Headers;)Llove/forte/simbot/common/ktor/inputfile/InputFile;
+	public static final fun of (Lio/ktor/client/request/forms/InputProvider;)Llove/forte/simbot/common/ktor/inputfile/InputFile;
+	public static final fun of (Lio/ktor/client/request/forms/InputProvider;Lio/ktor/http/Headers;)Llove/forte/simbot/common/ktor/inputfile/InputFile;
+	public static final fun of (Lio/ktor/utils/io/core/ByteReadPacket;)Llove/forte/simbot/common/ktor/inputfile/InputFile;
+	public static final fun of (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/http/Headers;)Llove/forte/simbot/common/ktor/inputfile/InputFile;
+	public static final fun of (Ljava/io/File;)Llove/forte/simbot/common/ktor/inputfile/InputFile;
+	public static final fun of (Ljava/io/File;Lio/ktor/http/Headers;)Llove/forte/simbot/common/ktor/inputfile/InputFile;
+	public static final fun of (Ljava/nio/file/Path;)Llove/forte/simbot/common/ktor/inputfile/InputFile;
+	public static final fun of (Ljava/nio/file/Path;Lio/ktor/http/Headers;)Llove/forte/simbot/common/ktor/inputfile/InputFile;
+	public static final fun of ([B)Llove/forte/simbot/common/ktor/inputfile/InputFile;
+	public static final fun of ([BLio/ktor/http/Headers;)Llove/forte/simbot/common/ktor/inputfile/InputFile;
+	public static synthetic fun of$default (Lio/ktor/client/request/forms/ChannelProvider;Lio/ktor/http/Headers;ILjava/lang/Object;)Llove/forte/simbot/common/ktor/inputfile/InputFile;
+	public static synthetic fun of$default (Lio/ktor/client/request/forms/InputProvider;Lio/ktor/http/Headers;ILjava/lang/Object;)Llove/forte/simbot/common/ktor/inputfile/InputFile;
+	public static synthetic fun of$default (Lio/ktor/utils/io/core/ByteReadPacket;Lio/ktor/http/Headers;ILjava/lang/Object;)Llove/forte/simbot/common/ktor/inputfile/InputFile;
+	public static synthetic fun of$default (Ljava/io/File;Lio/ktor/http/Headers;ILjava/lang/Object;)Llove/forte/simbot/common/ktor/inputfile/InputFile;
+	public static synthetic fun of$default (Ljava/nio/file/Path;Lio/ktor/http/Headers;ILjava/lang/Object;)Llove/forte/simbot/common/ktor/inputfile/InputFile;
+	public static synthetic fun of$default ([BLio/ktor/http/Headers;ILjava/lang/Object;)Llove/forte/simbot/common/ktor/inputfile/InputFile;
+}
+

--- a/simbot-commons/simbot-common-stage-loop/api/simbot-common-stage-loop.api
+++ b/simbot-commons/simbot-common-stage-loop/api/simbot-common-stage-loop.api
@@ -1,0 +1,31 @@
+public abstract class love/forte/simbot/common/stageloop/Stage {
+	public fun <init> ()V
+	public abstract fun invoke (Llove/forte/simbot/common/stageloop/StageLoop;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/common/stageloop/StageLoop {
+	public abstract fun appendStage (Llove/forte/simbot/common/stageloop/Stage;)V
+	public abstract fun getCurrentStage ()Llove/forte/simbot/common/stageloop/Stage;
+	public abstract fun invoke (Llove/forte/simbot/common/stageloop/Stage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun poll ()Llove/forte/simbot/common/stageloop/Stage;
+}
+
+public final class love/forte/simbot/common/stageloop/StageLoop_jvmKt {
+	public static final fun DefaultStageLoop ()Llove/forte/simbot/common/stageloop/StageLoop;
+}
+
+public final class love/forte/simbot/common/stageloop/StageLoopsKt {
+	public static final fun loop (Llove/forte/simbot/common/stageloop/StageLoop;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun loop$default (Llove/forte/simbot/common/stageloop/StageLoop;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract class love/forte/simbot/common/stageloop/State {
+	public fun <init> ()V
+	public abstract fun invoke (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/common/stageloop/StatesKt {
+	public static final fun loop (Llove/forte/simbot/common/stageloop/State;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun loop$default (Llove/forte/simbot/common/stageloop/State;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+

--- a/simbot-commons/simbot-common-stage-loop/build.gradle.kts
+++ b/simbot-commons/simbot-common-stage-loop/build.gradle.kts
@@ -4,7 +4,7 @@
  *     Project    https://github.com/simple-robot/simpler-robot
  *     Email      ForteScarlet@163.com
  *
- *     This file is part of the Simple Robot Library.
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Lesser General Public License as published by
@@ -25,6 +25,7 @@ import love.forte.gradle.common.core.project.setup
 import love.forte.gradle.common.kotlin.multiplatform.applyTier1
 import love.forte.gradle.common.kotlin.multiplatform.applyTier2
 import love.forte.gradle.common.kotlin.multiplatform.applyTier3
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 /*
@@ -60,21 +61,12 @@ setup(P.SimbotCommon)
 configJavaCompileWithModule("simbot.common.stageloop")
 apply(plugin = "simbot-multiplatform-maven-publish")
 
+@OptIn(ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     explicitApi()
     applyDefaultHierarchyTemplate()
 
-    configKotlinJvm(JVMConstants.KT_JVM_TARGET_VALUE) {
-        compilations.all {
-            kotlinOptions {
-                freeCompilerArgs = freeCompilerArgs + listOf(
-                    // 'expect'/'actual' classes (including interfaces, objects, annotations, enums, and 'actual' typealiases) are in Beta. You can use -Xexpect-actual-classes flag to suppress this warning. Also see: https://youtrack.jetbrains.com/issue/KT-61573
-                    "-Xexpect-actual-classes"
-                )
-            }
-        }
-    }
-
+    configKotlinJvm()
 
     js(IR) {
         configJs()
@@ -87,6 +79,12 @@ kotlin {
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
         configWasmJs()
+    }
+
+    compilerOptions {
+        freeCompilerArgs.addAll(
+            "-Xexpect-actual-classes"
+        )
     }
 
     sourceSets {
@@ -103,6 +101,5 @@ kotlin {
         }
     }
 }
-
 
 configWasmJsTest()

--- a/simbot-commons/simbot-common-suspend-runner/api/simbot-common-suspend-runner.api
+++ b/simbot-commons/simbot-common-suspend-runner/api/simbot-common-suspend-runner.api
@@ -1,0 +1,89 @@
+public final class love/forte/simbot/suspendrunner/BlockingRunnerKt {
+	public static final fun runInBlocking (Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public static synthetic fun runInBlocking$default (Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun runInNoScopeBlocking (Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static synthetic fun runInNoScopeBlocking$default (Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun runInNoScopeTimeoutBlocking (JLkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static synthetic fun runInNoScopeTimeoutBlocking$default (JLkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun runInTimeoutBlocking (JLkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public static synthetic fun runInTimeoutBlocking$default (JLkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract class love/forte/simbot/suspendrunner/CustomBlockingDispatcherProvider {
+	public fun <init> ()V
+	public abstract fun blockingDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+}
+
+public abstract class love/forte/simbot/suspendrunner/CustomBlockingExecutorProvider : love/forte/simbot/suspendrunner/CustomBlockingDispatcherProvider {
+	public fun <init> ()V
+	public final fun blockingDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public abstract fun blockingExecutor ()Ljava/util/concurrent/Executor;
+}
+
+public final class love/forte/simbot/suspendrunner/DefaultBlockingDispatcherTaskRejectedExecutionException : java/util/concurrent/RejectedExecutionException {
+	public fun <init> (Ljava/lang/Runnable;Ljava/util/concurrent/Executor;)V
+	public final fun getExecutor ()Ljava/util/concurrent/Executor;
+	public final fun getRunnable ()Ljava/lang/Runnable;
+}
+
+public abstract interface class love/forte/simbot/suspendrunner/InvokeStrategy {
+	public abstract fun invoke (Lkotlin/jvm/functions/Function1;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;)Ljava/lang/Object;
+	public static synthetic fun invoke$default (Llove/forte/simbot/suspendrunner/InvokeStrategy;Lkotlin/jvm/functions/Function1;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/suspendrunner/Reserve {
+	public fun <init> (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)V
+	public final fun async ()Ljava/util/concurrent/CompletableFuture;
+	public final fun block ()Ljava/lang/Object;
+}
+
+public abstract class love/forte/simbot/suspendrunner/RunInBlockingException : java/lang/RuntimeException {
+	public synthetic fun <init> (Ljava/lang/Throwable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public abstract interface annotation class love/forte/simbot/suspendrunner/SuspendTrans : java/lang/annotation/Annotation {
+	public abstract fun asyncAsProperty ()Z
+	public abstract fun asyncBaseName ()Ljava/lang/String;
+	public abstract fun asyncSuffix ()Ljava/lang/String;
+	public abstract fun blockingAsProperty ()Z
+	public abstract fun blockingBaseName ()Ljava/lang/String;
+	public abstract fun blockingSuffix ()Ljava/lang/String;
+	public abstract fun reserveAsProperty ()Z
+	public abstract fun reserveBaseName ()Ljava/lang/String;
+	public abstract fun reserveSuffix ()Ljava/lang/String;
+}
+
+public abstract interface annotation class love/forte/simbot/suspendrunner/SuspendTransProperty : java/lang/annotation/Annotation {
+	public abstract fun asyncAsProperty ()Z
+	public abstract fun asyncBaseName ()Ljava/lang/String;
+	public abstract fun asyncSuffix ()Ljava/lang/String;
+	public abstract fun blockingAsProperty ()Z
+	public abstract fun blockingBaseName ()Ljava/lang/String;
+	public abstract fun blockingSuffix ()Ljava/lang/String;
+	public abstract fun jsPromiseAsProperty ()Z
+	public abstract fun jsPromiseBaseName ()Ljava/lang/String;
+	public abstract fun jsPromiseSuffix ()Ljava/lang/String;
+	public abstract fun reserveAsProperty ()Z
+	public abstract fun reserveBaseName ()Ljava/lang/String;
+	public abstract fun reserveSuffix ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/suspendrunner/reserve/SuspendReserve {
+	public abstract fun transform (Llove/forte/simbot/suspendrunner/reserve/SuspendReserve$Transformer;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/suspendrunner/reserve/SuspendReserve$Transformer {
+	public abstract fun invoke (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/suspendrunner/reserve/SuspendReserves {
+	public static final fun async ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve$Transformer;
+	public static final fun block ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve$Transformer;
+	public static final fun deferred ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve$Transformer;
+	public static final fun flux ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve$Transformer;
+	public static final fun list ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve$Transformer;
+	public static final fun mono ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve$Transformer;
+	public static final fun rx2Maybe ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve$Transformer;
+	public static final fun rx3Maybe ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve$Transformer;
+}
+

--- a/simbot-cores/simbot-core-spring-boot-starter-common/api/simbot-core-spring-boot-starter-common.api
+++ b/simbot-cores/simbot-core-spring-boot-starter-common/api/simbot-core-spring-boot-starter-common.api
@@ -1,0 +1,151 @@
+public class love/forte/simbot/spring/common/BotAutoStartOnFailureException : java/lang/IllegalStateException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public class love/forte/simbot/spring/common/BotConfigResourceLoadOnFailureException : java/lang/IllegalStateException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public class love/forte/simbot/spring/common/MismatchConfigurableBotManagerException : java/util/NoSuchElementException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public class love/forte/simbot/spring/common/MultipleIncompatibleTypesEventException : java/lang/IllegalArgumentException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public final class love/forte/simbot/spring/common/application/ApplicationLaunchMode : java/lang/Enum {
+	public static final field NONE Llove/forte/simbot/spring/common/application/ApplicationLaunchMode;
+	public static final field THREAD Llove/forte/simbot/spring/common/application/ApplicationLaunchMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Llove/forte/simbot/spring/common/application/ApplicationLaunchMode;
+	public static fun values ()[Llove/forte/simbot/spring/common/application/ApplicationLaunchMode;
+}
+
+public final class love/forte/simbot/spring/common/application/BotAutoStartMode : java/lang/Enum {
+	public static final field ASYNC Llove/forte/simbot/spring/common/application/BotAutoStartMode;
+	public static final field SYNC Llove/forte/simbot/spring/common/application/BotAutoStartMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Llove/forte/simbot/spring/common/application/BotAutoStartMode;
+	public static fun values ()[Llove/forte/simbot/spring/common/application/BotAutoStartMode;
+}
+
+public final class love/forte/simbot/spring/common/application/BotConfigResourceLoadFailurePolicy : java/lang/Enum {
+	public static final field ERROR Llove/forte/simbot/spring/common/application/BotConfigResourceLoadFailurePolicy;
+	public static final field ERROR_LOG Llove/forte/simbot/spring/common/application/BotConfigResourceLoadFailurePolicy;
+	public static final field IGNORE Llove/forte/simbot/spring/common/application/BotConfigResourceLoadFailurePolicy;
+	public static final field WARN Llove/forte/simbot/spring/common/application/BotConfigResourceLoadFailurePolicy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Llove/forte/simbot/spring/common/application/BotConfigResourceLoadFailurePolicy;
+	public static fun values ()[Llove/forte/simbot/spring/common/application/BotConfigResourceLoadFailurePolicy;
+}
+
+public final class love/forte/simbot/spring/common/application/BotRegistrationFailurePolicy : java/lang/Enum {
+	public static final field ERROR Llove/forte/simbot/spring/common/application/BotRegistrationFailurePolicy;
+	public static final field ERROR_LOG Llove/forte/simbot/spring/common/application/BotRegistrationFailurePolicy;
+	public static final field IGNORE Llove/forte/simbot/spring/common/application/BotRegistrationFailurePolicy;
+	public static final field WARN Llove/forte/simbot/spring/common/application/BotRegistrationFailurePolicy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Llove/forte/simbot/spring/common/application/BotRegistrationFailurePolicy;
+	public static fun values ()[Llove/forte/simbot/spring/common/application/BotRegistrationFailurePolicy;
+}
+
+public final class love/forte/simbot/spring/common/application/MismatchConfigurableBotManagerPolicy : java/lang/Enum {
+	public static final field ERROR Llove/forte/simbot/spring/common/application/MismatchConfigurableBotManagerPolicy;
+	public static final field ERROR_LOG Llove/forte/simbot/spring/common/application/MismatchConfigurableBotManagerPolicy;
+	public static final field IGNORE Llove/forte/simbot/spring/common/application/MismatchConfigurableBotManagerPolicy;
+	public static final field WARN Llove/forte/simbot/spring/common/application/MismatchConfigurableBotManagerPolicy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Llove/forte/simbot/spring/common/application/MismatchConfigurableBotManagerPolicy;
+	public static fun values ()[Llove/forte/simbot/spring/common/application/MismatchConfigurableBotManagerPolicy;
+}
+
+public abstract interface class love/forte/simbot/spring/common/application/SpringApplication : love/forte/simbot/application/Application {
+}
+
+public class love/forte/simbot/spring/common/application/SpringApplicationBuilder : love/forte/simbot/application/AbstractApplicationBuilder {
+	public fun <init> ()V
+	public fun getApplicationConfigurationProperties ()Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties;
+	public fun setApplicationConfigurationProperties (Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties;)V
+}
+
+public abstract interface class love/forte/simbot/spring/common/application/SpringApplicationConfiguration : love/forte/simbot/application/ApplicationConfiguration {
+	public abstract fun getApplicationConfigurationProperties ()Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties;
+}
+
+public final class love/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties {
+	public fun <init> ()V
+	public final fun getApplication ()Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties$ApplicationProperties;
+	public final fun getBots ()Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties$BotProperties;
+	public final fun getComponents ()Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties$ComponentProperties;
+	public final fun getPlugins ()Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties$PluginProperties;
+	public final fun setApplication (Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties$ApplicationProperties;)V
+	public final fun setBots (Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties$BotProperties;)V
+	public final fun setComponents (Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties$ComponentProperties;)V
+	public final fun setPlugins (Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties$PluginProperties;)V
+}
+
+public final class love/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties$ApplicationProperties {
+	public fun <init> ()V
+	public final fun getApplicationLaunchMode ()Llove/forte/simbot/spring/common/application/ApplicationLaunchMode;
+	public final fun setApplicationLaunchMode (Llove/forte/simbot/spring/common/application/ApplicationLaunchMode;)V
+}
+
+public final class love/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties$BotProperties {
+	public static final field Companion Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties$BotProperties$Companion;
+	public fun <init> ()V
+	public final fun getAutoRegistrationFailurePolicy ()Llove/forte/simbot/spring/common/application/BotRegistrationFailurePolicy;
+	public final fun getAutoRegistrationMismatchConfigurableBotManagerPolicy ()Llove/forte/simbot/spring/common/application/MismatchConfigurableBotManagerPolicy;
+	public final fun getAutoRegistrationResourceLoadFailurePolicy ()Llove/forte/simbot/spring/common/application/BotConfigResourceLoadFailurePolicy;
+	public final fun getAutoStartBots ()Z
+	public final fun getAutoStartMode ()Llove/forte/simbot/spring/common/application/BotAutoStartMode;
+	public final fun getConfigurationJsonResources ()Ljava/util/Set;
+	public final fun setAutoRegistrationFailurePolicy (Llove/forte/simbot/spring/common/application/BotRegistrationFailurePolicy;)V
+	public final fun setAutoRegistrationMismatchConfigurableBotManagerPolicy (Llove/forte/simbot/spring/common/application/MismatchConfigurableBotManagerPolicy;)V
+	public final fun setAutoRegistrationResourceLoadFailurePolicy (Llove/forte/simbot/spring/common/application/BotConfigResourceLoadFailurePolicy;)V
+	public final fun setAutoStartBots (Z)V
+	public final fun setAutoStartMode (Llove/forte/simbot/spring/common/application/BotAutoStartMode;)V
+	public final fun setConfigurationJsonResources (Ljava/util/Set;)V
+}
+
+public final class love/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties$BotProperties$Companion {
+}
+
+public final class love/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties$ComponentProperties {
+	public fun <init> ()V
+	public final fun getAutoInstallProviderConfigures ()Z
+	public final fun getAutoInstallProviders ()Z
+	public final fun setAutoInstallProviderConfigures (Z)V
+	public final fun setAutoInstallProviders (Z)V
+}
+
+public final class love/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties$PluginProperties {
+	public fun <init> ()V
+	public final fun getAutoInstallProviderConfigures ()Z
+	public final fun getAutoInstallProviders ()Z
+	public final fun setAutoInstallProviderConfigures (Z)V
+	public final fun setAutoInstallProviders (Z)V
+}
+
+public abstract interface class love/forte/simbot/spring/common/application/SpringApplicationEventRegistrar : love/forte/simbot/application/ApplicationEventRegistrar {
+}
+
+public abstract interface class love/forte/simbot/spring/common/application/SpringApplicationFactory : love/forte/simbot/application/ApplicationFactory {
+}
+
+public abstract interface class love/forte/simbot/spring/common/application/SpringApplicationLauncher : love/forte/simbot/application/ApplicationLauncher {
+}
+
+public abstract interface class love/forte/simbot/spring/common/application/SpringEventDispatcherConfiguration : love/forte/simbot/core/event/SimpleEventDispatcherConfiguration {
+	public fun setExecutorDispatcher (Ljava/util/concurrent/Executor;)V
+}
+

--- a/simbot-cores/simbot-core-spring-boot-starter-v2/api/simbot-core-spring-boot-starter-v2.api
+++ b/simbot-cores/simbot-core-spring-boot-starter-v2/api/simbot-core-spring-boot-starter-v2.api
@@ -1,0 +1,392 @@
+public abstract interface annotation class love/forte/simbot/spring2/EnableSimbot : java/lang/annotation/Annotation {
+}
+
+public final class love/forte/simbot/spring2/application/Spring : love/forte/simbot/spring/common/application/SpringApplicationFactory {
+	public static final field INSTANCE Llove/forte/simbot/spring2/application/Spring;
+	public synthetic fun create (Llove/forte/simbot/common/function/ConfigurerFunction;)Llove/forte/simbot/application/ApplicationLauncher;
+	public fun create (Llove/forte/simbot/common/function/ConfigurerFunction;)Llove/forte/simbot/spring/common/application/SpringApplicationLauncher;
+}
+
+public final class love/forte/simbot/spring2/configuration/DefaultSimbotComponentInstallProcessor : love/forte/simbot/spring2/configuration/SimbotComponentInstallProcessor {
+	public static final field Companion Llove/forte/simbot/spring2/configuration/DefaultSimbotComponentInstallProcessor$Companion;
+	public fun <init> (ZZLjava/util/List;Ljava/util/List;)V
+	public fun process (Llove/forte/simbot/component/ComponentInstaller;)V
+}
+
+public final class love/forte/simbot/spring2/configuration/DefaultSimbotComponentInstallProcessor$Companion {
+}
+
+public class love/forte/simbot/spring2/configuration/DefaultSimbotComponentInstallProcessorConfiguration {
+	public static final field Companion Llove/forte/simbot/spring2/configuration/DefaultSimbotComponentInstallProcessorConfiguration$Companion;
+	public static final field DEFAULT_SIMBOT_COMPONENT_INSTALL_PROCESSOR_BEAN_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun defaultSimbotComponentInstallProcessor (Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties;Ljava/util/List;Ljava/util/List;)Llove/forte/simbot/spring2/configuration/DefaultSimbotComponentInstallProcessor;
+	public static synthetic fun defaultSimbotComponentInstallProcessor$default (Llove/forte/simbot/spring2/configuration/DefaultSimbotComponentInstallProcessorConfiguration;Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Llove/forte/simbot/spring2/configuration/DefaultSimbotComponentInstallProcessor;
+}
+
+public final class love/forte/simbot/spring2/configuration/DefaultSimbotComponentInstallProcessorConfiguration$Companion {
+}
+
+public class love/forte/simbot/spring2/configuration/DefaultSimbotDispatcherProcessor : love/forte/simbot/spring2/configuration/SimbotDispatcherProcessor {
+	public static final field Companion Llove/forte/simbot/spring2/configuration/DefaultSimbotDispatcherProcessor$Companion;
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public fun process (Llove/forte/simbot/spring/common/application/SpringEventDispatcherConfiguration;)V
+}
+
+public final class love/forte/simbot/spring2/configuration/DefaultSimbotDispatcherProcessor$Companion {
+}
+
+public class love/forte/simbot/spring2/configuration/DefaultSimbotDispatcherProcessorConfiguration {
+	public static final field Companion Llove/forte/simbot/spring2/configuration/DefaultSimbotDispatcherProcessorConfiguration$Companion;
+	public static final field DEFAULT_SIMBOT_DISPATCHER_PROCESSOR_BEAN_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun defaultSimbotDispatcherProcessor (Ljava/util/List;Ljava/util/List;Ljava/util/List;)Llove/forte/simbot/spring2/configuration/DefaultSimbotDispatcherProcessor;
+	public static synthetic fun defaultSimbotDispatcherProcessor$default (Llove/forte/simbot/spring2/configuration/DefaultSimbotDispatcherProcessorConfiguration;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Llove/forte/simbot/spring2/configuration/DefaultSimbotDispatcherProcessor;
+}
+
+public final class love/forte/simbot/spring2/configuration/DefaultSimbotDispatcherProcessorConfiguration$Companion {
+}
+
+public class love/forte/simbot/spring2/configuration/DefaultSimbotEventDispatcherProcessor : love/forte/simbot/spring2/configuration/SimbotEventDispatcherProcessor {
+	public static final field Companion Llove/forte/simbot/spring2/configuration/DefaultSimbotEventDispatcherProcessor$Companion;
+	public fun <init> (Llove/forte/simbot/spring2/configuration/SimbotEventListenerRegistrarProcessor;Ljava/util/List;)V
+	public fun process (Llove/forte/simbot/event/EventDispatcher;)V
+}
+
+public final class love/forte/simbot/spring2/configuration/DefaultSimbotEventDispatcherProcessor$Companion {
+}
+
+public class love/forte/simbot/spring2/configuration/DefaultSimbotEventDispatcherProcessorConfiguration {
+	public static final field Companion Llove/forte/simbot/spring2/configuration/DefaultSimbotEventDispatcherProcessorConfiguration$Companion;
+	public static final field DEFAULT_SIMBOT_EVENT_DISPATCHER_PROCESSOR_BEAN_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun defaultSimbotEventDispatcherProcessor (Llove/forte/simbot/spring2/configuration/SimbotEventListenerRegistrarProcessor;Ljava/util/List;)Llove/forte/simbot/spring2/configuration/DefaultSimbotEventDispatcherProcessor;
+	public static synthetic fun defaultSimbotEventDispatcherProcessor$default (Llove/forte/simbot/spring2/configuration/DefaultSimbotEventDispatcherProcessorConfiguration;Llove/forte/simbot/spring2/configuration/SimbotEventListenerRegistrarProcessor;Ljava/util/List;ILjava/lang/Object;)Llove/forte/simbot/spring2/configuration/DefaultSimbotEventDispatcherProcessor;
+}
+
+public final class love/forte/simbot/spring2/configuration/DefaultSimbotEventDispatcherProcessorConfiguration$Companion {
+}
+
+public class love/forte/simbot/spring2/configuration/DefaultSimbotEventListenerRegistrarProcessor : love/forte/simbot/spring2/configuration/SimbotEventListenerRegistrarProcessor {
+	public static final field Companion Llove/forte/simbot/spring2/configuration/DefaultSimbotEventListenerRegistrarProcessor$Companion;
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public fun process (Llove/forte/simbot/event/EventListenerRegistrar;)V
+}
+
+public final class love/forte/simbot/spring2/configuration/DefaultSimbotEventListenerRegistrarProcessor$Companion {
+}
+
+public class love/forte/simbot/spring2/configuration/DefaultSimbotEventListenerRegistrarProcessorConfiguration {
+	public static final field Companion Llove/forte/simbot/spring2/configuration/DefaultSimbotEventListenerRegistrarProcessorConfiguration$Companion;
+	public static final field DEFAULT_SIMBOT_EVENT_LISTENER_REGISTRAR_PROCESSOR_BEAN_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun defaultSimbotEventListenerRegistrarProcessor (Ljava/util/List;Ljava/util/List;)Llove/forte/simbot/spring2/configuration/DefaultSimbotEventListenerRegistrarProcessor;
+	public static synthetic fun defaultSimbotEventListenerRegistrarProcessor$default (Llove/forte/simbot/spring2/configuration/DefaultSimbotEventListenerRegistrarProcessorConfiguration;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Llove/forte/simbot/spring2/configuration/DefaultSimbotEventListenerRegistrarProcessor;
+}
+
+public final class love/forte/simbot/spring2/configuration/DefaultSimbotEventListenerRegistrarProcessorConfiguration$Companion {
+}
+
+public final class love/forte/simbot/spring2/configuration/DefaultSimbotPluginInstallProcessor : love/forte/simbot/spring2/configuration/SimbotPluginInstallProcessor {
+	public static final field Companion Llove/forte/simbot/spring2/configuration/DefaultSimbotPluginInstallProcessor$Companion;
+	public fun <init> (ZZLjava/util/List;Ljava/util/List;)V
+	public fun process (Llove/forte/simbot/plugin/PluginInstaller;)V
+}
+
+public final class love/forte/simbot/spring2/configuration/DefaultSimbotPluginInstallProcessor$Companion {
+}
+
+public class love/forte/simbot/spring2/configuration/DefaultSimbotPluginInstallProcessorConfiguration {
+	public static final field Companion Llove/forte/simbot/spring2/configuration/DefaultSimbotPluginInstallProcessorConfiguration$Companion;
+	public static final field DEFAULT_SIMBOT_PLUGIN_INSTALL_PROCESSOR_BEAN_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun defaultSimbotPluginInstallProcessor (Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties;Ljava/util/List;Ljava/util/List;)Llove/forte/simbot/spring2/configuration/DefaultSimbotPluginInstallProcessor;
+	public static synthetic fun defaultSimbotPluginInstallProcessor$default (Llove/forte/simbot/spring2/configuration/DefaultSimbotPluginInstallProcessorConfiguration;Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Llove/forte/simbot/spring2/configuration/DefaultSimbotPluginInstallProcessor;
+}
+
+public final class love/forte/simbot/spring2/configuration/DefaultSimbotPluginInstallProcessorConfiguration$Companion {
+}
+
+public abstract interface class love/forte/simbot/spring2/configuration/SimbotComponentInstallProcessor {
+	public abstract fun process (Llove/forte/simbot/component/ComponentInstaller;)V
+}
+
+public abstract interface class love/forte/simbot/spring2/configuration/SimbotComponentInstaller {
+	public abstract fun install (Llove/forte/simbot/component/ComponentInstaller;)V
+}
+
+public abstract interface class love/forte/simbot/spring2/configuration/SimbotDispatcherConfigurer {
+	public abstract fun configure (Llove/forte/simbot/spring/common/application/SpringEventDispatcherConfiguration;)V
+}
+
+public abstract interface class love/forte/simbot/spring2/configuration/SimbotDispatcherProcessor {
+	public abstract fun process (Llove/forte/simbot/spring/common/application/SpringEventDispatcherConfiguration;)V
+}
+
+public abstract interface class love/forte/simbot/spring2/configuration/SimbotEventDispatcherPostConfigurer {
+	public abstract fun configure (Llove/forte/simbot/event/EventDispatcher;)V
+}
+
+public abstract interface class love/forte/simbot/spring2/configuration/SimbotEventDispatcherProcessor {
+	public abstract fun process (Llove/forte/simbot/event/EventDispatcher;)V
+}
+
+public abstract interface class love/forte/simbot/spring2/configuration/SimbotEventListenerRegistrarPostConfigurer {
+	public abstract fun configure (Llove/forte/simbot/event/EventListenerRegistrar;)V
+}
+
+public abstract interface class love/forte/simbot/spring2/configuration/SimbotEventListenerRegistrarProcessor {
+	public abstract fun process (Llove/forte/simbot/event/EventListenerRegistrar;)V
+}
+
+public abstract interface class love/forte/simbot/spring2/configuration/SimbotPluginInstallProcessor {
+	public abstract fun process (Llove/forte/simbot/plugin/PluginInstaller;)V
+}
+
+public abstract interface class love/forte/simbot/spring2/configuration/SimbotPluginInstaller {
+	public abstract fun install (Llove/forte/simbot/plugin/PluginInstaller;)V
+}
+
+public class love/forte/simbot/spring2/configuration/SimbotSpringPropertiesConfiguration {
+	public fun <init> ()V
+	public fun springApplicationConfigurationProperties ()Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties;
+}
+
+public final class love/forte/simbot/spring2/configuration/application/DefaultSimbotApplicationLauncherFactory : love/forte/simbot/spring2/configuration/application/SimbotApplicationLauncherFactory {
+	public fun <init> (Ljava/util/List;Ljava/util/List;Llove/forte/simbot/spring2/configuration/config/SimbotApplicationConfigurationProcessor;Llove/forte/simbot/spring2/configuration/SimbotDispatcherProcessor;Llove/forte/simbot/spring2/configuration/SimbotComponentInstallProcessor;Llove/forte/simbot/spring2/configuration/SimbotPluginInstallProcessor;)V
+	public fun process (Llove/forte/simbot/spring2/application/Spring;)Llove/forte/simbot/spring/common/application/SpringApplicationLauncher;
+}
+
+public final class love/forte/simbot/spring2/configuration/application/DefaultSimbotApplicationLauncherFactoryProcessor : love/forte/simbot/spring2/configuration/application/SimbotApplicationLauncherFactoryProcessor {
+	public static final field INSTANCE Llove/forte/simbot/spring2/configuration/application/DefaultSimbotApplicationLauncherFactoryProcessor;
+	public fun process (Llove/forte/simbot/spring2/configuration/application/SimbotApplicationLauncherFactory;)Llove/forte/simbot/spring/common/application/SpringApplicationLauncher;
+}
+
+public class love/forte/simbot/spring2/configuration/application/DefaultSimbotApplicationLauncherFactoryProcessorConfiguration {
+	public static final field Companion Llove/forte/simbot/spring2/configuration/application/DefaultSimbotApplicationLauncherFactoryProcessorConfiguration$Companion;
+	public static final field DEFAULT_SIMBOT_APPLICATION_LAUNCHER_FACTORY_PROCESSOR_BEAN_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun defaultSimbotApplicationLauncherFactoryProcessor ()Llove/forte/simbot/spring2/configuration/application/DefaultSimbotApplicationLauncherFactoryProcessor;
+}
+
+public final class love/forte/simbot/spring2/configuration/application/DefaultSimbotApplicationLauncherFactoryProcessorConfiguration$Companion {
+}
+
+public final class love/forte/simbot/spring2/configuration/application/DefaultSimbotApplicationProcessor : love/forte/simbot/spring2/configuration/application/SimbotApplicationProcessor {
+	public static final field Companion Llove/forte/simbot/spring2/configuration/application/DefaultSimbotApplicationProcessor$Companion;
+	public fun <init> (Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties;Ljava/util/List;Ljava/util/List;Ljava/util/List;Llove/forte/simbot/spring2/configuration/SimbotEventDispatcherProcessor;)V
+	public fun process (Llove/forte/simbot/spring/common/application/SpringApplication;)V
+}
+
+public final class love/forte/simbot/spring2/configuration/application/DefaultSimbotApplicationProcessor$Companion {
+}
+
+public class love/forte/simbot/spring2/configuration/application/DefaultSimbotSpringApplicationLauncherFactoryConfiguration {
+	public static final field Companion Llove/forte/simbot/spring2/configuration/application/DefaultSimbotSpringApplicationLauncherFactoryConfiguration$Companion;
+	public static final field DEFAULT_SPRING_APPLICATION_LAUNCHER_PROCESSOR_BEAN_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun defaultSpringApplicationLauncherProcessor (Ljava/util/List;Ljava/util/List;Llove/forte/simbot/spring2/configuration/config/SimbotApplicationConfigurationProcessor;Llove/forte/simbot/spring2/configuration/SimbotDispatcherProcessor;Llove/forte/simbot/spring2/configuration/SimbotComponentInstallProcessor;Llove/forte/simbot/spring2/configuration/SimbotPluginInstallProcessor;)Llove/forte/simbot/spring2/configuration/application/DefaultSimbotApplicationLauncherFactory;
+	public static synthetic fun defaultSpringApplicationLauncherProcessor$default (Llove/forte/simbot/spring2/configuration/application/DefaultSimbotSpringApplicationLauncherFactoryConfiguration;Ljava/util/List;Ljava/util/List;Llove/forte/simbot/spring2/configuration/config/SimbotApplicationConfigurationProcessor;Llove/forte/simbot/spring2/configuration/SimbotDispatcherProcessor;Llove/forte/simbot/spring2/configuration/SimbotComponentInstallProcessor;Llove/forte/simbot/spring2/configuration/SimbotPluginInstallProcessor;ILjava/lang/Object;)Llove/forte/simbot/spring2/configuration/application/DefaultSimbotApplicationLauncherFactory;
+}
+
+public final class love/forte/simbot/spring2/configuration/application/DefaultSimbotSpringApplicationLauncherFactoryConfiguration$Companion {
+}
+
+public class love/forte/simbot/spring2/configuration/application/DefaultSimbotSpringApplicationProcessorConfiguration {
+	public static final field Companion Llove/forte/simbot/spring2/configuration/application/DefaultSimbotSpringApplicationProcessorConfiguration$Companion;
+	public static final field DEFAULT_SIMBOT_APPLICATION_PROCESSOR_BEAN_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun defaultSimbotApplicationProcessor (Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties;Ljava/util/List;Ljava/util/List;Ljava/util/List;Llove/forte/simbot/spring2/configuration/SimbotEventDispatcherProcessor;)Llove/forte/simbot/spring2/configuration/application/DefaultSimbotApplicationProcessor;
+	public static synthetic fun defaultSimbotApplicationProcessor$default (Llove/forte/simbot/spring2/configuration/application/DefaultSimbotSpringApplicationProcessorConfiguration;Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties;Ljava/util/List;Ljava/util/List;Ljava/util/List;Llove/forte/simbot/spring2/configuration/SimbotEventDispatcherProcessor;ILjava/lang/Object;)Llove/forte/simbot/spring2/configuration/application/DefaultSimbotApplicationProcessor;
+}
+
+public final class love/forte/simbot/spring2/configuration/application/DefaultSimbotSpringApplicationProcessorConfiguration$Companion {
+}
+
+public class love/forte/simbot/spring2/configuration/application/SimbotApplicationConfiguration {
+	public static final field Companion Llove/forte/simbot/spring2/configuration/application/SimbotApplicationConfiguration$Companion;
+	public static final field SPRING_APPLICATION_BEAN_NAME Ljava/lang/String;
+	public static final field SPRING_APPLICATION_LAUNCHER_BEAN_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun springApplication (Llove/forte/simbot/spring/common/application/SpringApplicationLauncher;)Llove/forte/simbot/spring/common/application/SpringApplication;
+	public fun springApplicationLauncher (Llove/forte/simbot/spring2/configuration/application/SimbotApplicationLauncherFactory;Llove/forte/simbot/spring2/configuration/application/SimbotApplicationLauncherFactoryProcessor;)Llove/forte/simbot/spring/common/application/SpringApplicationLauncher;
+}
+
+public final class love/forte/simbot/spring2/configuration/application/SimbotApplicationConfiguration$Companion {
+}
+
+public abstract interface class love/forte/simbot/spring2/configuration/application/SimbotApplicationConfigurer {
+	public abstract fun configure (Llove/forte/simbot/spring/common/application/SpringApplication;)V
+}
+
+public abstract interface class love/forte/simbot/spring2/configuration/application/SimbotApplicationLauncherConfigurer {
+	public abstract fun configure (Llove/forte/simbot/application/ApplicationFactoryConfigurer;)V
+}
+
+public abstract interface class love/forte/simbot/spring2/configuration/application/SimbotApplicationLauncherFactory {
+	public abstract fun process (Llove/forte/simbot/spring2/application/Spring;)Llove/forte/simbot/spring/common/application/SpringApplicationLauncher;
+}
+
+public abstract interface class love/forte/simbot/spring2/configuration/application/SimbotApplicationLauncherFactoryProcessor {
+	public abstract fun process (Llove/forte/simbot/spring2/configuration/application/SimbotApplicationLauncherFactory;)Llove/forte/simbot/spring/common/application/SpringApplicationLauncher;
+}
+
+public abstract interface class love/forte/simbot/spring2/configuration/application/SimbotApplicationLauncherPostConfigurer : love/forte/simbot/spring2/configuration/application/SimbotApplicationLauncherConfigurer {
+}
+
+public abstract interface class love/forte/simbot/spring2/configuration/application/SimbotApplicationLauncherPreConfigurer : love/forte/simbot/spring2/configuration/application/SimbotApplicationLauncherConfigurer {
+}
+
+public abstract interface class love/forte/simbot/spring2/configuration/application/SimbotApplicationPostConfigurer : love/forte/simbot/spring2/configuration/application/SimbotApplicationConfigurer {
+}
+
+public abstract interface class love/forte/simbot/spring2/configuration/application/SimbotApplicationPreConfigurer : love/forte/simbot/spring2/configuration/application/SimbotApplicationConfigurer {
+}
+
+public abstract interface class love/forte/simbot/spring2/configuration/application/SimbotApplicationProcessor {
+	public abstract fun process (Llove/forte/simbot/spring/common/application/SpringApplication;)V
+}
+
+public class love/forte/simbot/spring2/configuration/application/SimbotApplicationRunner : org/springframework/boot/ApplicationRunner, org/springframework/context/ApplicationContextAware {
+	public static final field Companion Llove/forte/simbot/spring2/configuration/application/SimbotApplicationRunner$Companion;
+	public fun <init> (Llove/forte/simbot/spring/common/application/SpringApplication;Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties;Llove/forte/simbot/spring2/configuration/application/SimbotApplicationProcessor;)V
+	public fun run (Lorg/springframework/boot/ApplicationArguments;)V
+	public fun setApplicationContext (Lorg/springframework/context/ApplicationContext;)V
+}
+
+public final class love/forte/simbot/spring2/configuration/application/SimbotApplicationRunner$Companion {
+}
+
+public class love/forte/simbot/spring2/configuration/binder/DefaultBinderManagerProvidersConfiguration {
+	public fun <init> ()V
+	public fun eventParameterBinderFactory ()Llove/forte/simbot/quantcat/common/binder/impl/EventParameterBinderFactory;
+	public fun keywordBinderFactory ()Llove/forte/simbot/quantcat/common/binder/impl/KeywordBinderFactory;
+}
+
+public class love/forte/simbot/spring2/configuration/binder/DuplicateBinderIdException : java/lang/IllegalArgumentException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public abstract interface class love/forte/simbot/spring2/configuration/binder/ParameterBinderManagerBuilder {
+	public abstract fun addBinderFactory (Ljava/lang/String;Llove/forte/simbot/quantcat/common/binder/ParameterBinderFactory;)V
+	public abstract fun addBinderFactory (Llove/forte/simbot/quantcat/common/binder/ParameterBinderFactory;)V
+}
+
+public abstract interface class love/forte/simbot/spring2/configuration/binder/ParameterBinderManagerBuilderConfigurer {
+	public abstract fun configure (Llove/forte/simbot/spring2/configuration/binder/ParameterBinderManagerBuilder;)V
+}
+
+public class love/forte/simbot/spring2/configuration/binder/ResolveBinderManagerProcessor : org/springframework/context/annotation/ConfigurationClassPostProcessor {
+	public static final field BINDER_MANAGER_BEAN_NAME Ljava/lang/String;
+	public static final field Companion Llove/forte/simbot/spring2/configuration/binder/ResolveBinderManagerProcessor$Companion;
+	protected field registry Lorg/springframework/beans/factory/support/BeanDefinitionRegistry;
+	public fun <init> ()V
+	protected fun getRegistry ()Lorg/springframework/beans/factory/support/BeanDefinitionRegistry;
+	public fun postProcessBeanDefinitionRegistry (Lorg/springframework/beans/factory/support/BeanDefinitionRegistry;)V
+	public fun postProcessBeanFactory (Lorg/springframework/beans/factory/config/ConfigurableListableBeanFactory;)V
+	protected fun resolveCandidate (Lorg/springframework/beans/factory/config/ConfigurableListableBeanFactory;Ljava/lang/String;Ljava/lang/Class;Llove/forte/simbot/spring2/configuration/binder/ResolveBinderManagerProcessor$ParameterBinderManagerBuilderImpl;)V
+	protected fun resolveConfigurer (Lorg/springframework/beans/factory/config/ConfigurableListableBeanFactory;Ljava/lang/String;Ljava/lang/Class;Llove/forte/simbot/spring2/configuration/binder/ResolveBinderManagerProcessor$ParameterBinderManagerBuilderImpl;)V
+	protected fun resolveFactoryInstance (Lorg/springframework/beans/factory/config/ConfigurableListableBeanFactory;Ljava/lang/String;Ljava/lang/Class;Llove/forte/simbot/spring2/configuration/binder/ResolveBinderManagerProcessor$ParameterBinderManagerBuilderImpl;)V
+	protected fun resolveFactoryWithBinder (Llove/forte/simbot/quantcat/common/annotations/Binder;Ljava/lang/String;Llove/forte/simbot/quantcat/common/binder/ParameterBinderFactory;Llove/forte/simbot/spring2/configuration/binder/ResolveBinderManagerProcessor$ParameterBinderManagerBuilderImpl;)V
+	protected fun setRegistry (Lorg/springframework/beans/factory/support/BeanDefinitionRegistry;)V
+}
+
+public final class love/forte/simbot/spring2/configuration/binder/ResolveBinderManagerProcessor$Companion {
+}
+
+protected class love/forte/simbot/spring2/configuration/binder/ResolveBinderManagerProcessor$ParameterBinderManagerBuilderImpl : love/forte/simbot/spring2/configuration/binder/ParameterBinderManagerBuilder {
+	public fun <init> ()V
+	public fun addBinderFactory (Ljava/lang/String;Llove/forte/simbot/quantcat/common/binder/ParameterBinderFactory;)V
+	public fun addBinderFactory (Llove/forte/simbot/quantcat/common/binder/ParameterBinderFactory;)V
+	public fun getGlobalBinders ()Ljava/util/List;
+	public fun getIdBinders ()Ljava/util/Map;
+}
+
+public final class love/forte/simbot/spring2/configuration/binder/SpringAutoInjectBinderFactory : love/forte/simbot/quantcat/common/binder/ParameterBinderFactory {
+	public fun <init> (Lorg/springframework/beans/factory/BeanFactory;)V
+	public synthetic fun resolveToBinder (Llove/forte/simbot/quantcat/common/binder/BaseParameterBinderFactory$Context;)Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult;
+	public fun resolveToBinder (Llove/forte/simbot/quantcat/common/binder/ParameterBinderFactory$Context;)Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult;
+}
+
+public class love/forte/simbot/spring2/configuration/config/DefaultSimbotApplicationConfigurationProcessor : love/forte/simbot/spring2/configuration/config/SimbotApplicationConfigurationProcessor {
+	public static final field Companion Llove/forte/simbot/spring2/configuration/config/DefaultSimbotApplicationConfigurationProcessor$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public fun process (Llove/forte/simbot/spring/common/application/SpringApplicationBuilder;)V
+}
+
+public final class love/forte/simbot/spring2/configuration/config/DefaultSimbotApplicationConfigurationProcessor$Companion {
+}
+
+public class love/forte/simbot/spring2/configuration/config/DefaultSimbotApplicationConfigurationProcessorConfiguration {
+	public static final field Companion Llove/forte/simbot/spring2/configuration/config/DefaultSimbotApplicationConfigurationProcessorConfiguration$Companion;
+	public static final field DEFAULT_SIMBOT_APPLICATION_CONFIGURATION_PROCESSOR_BEAN_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun defaultSimbotApplicationConfigurationProcessor (Ljava/util/List;)Llove/forte/simbot/spring2/configuration/config/DefaultSimbotApplicationConfigurationProcessor;
+	public static synthetic fun defaultSimbotApplicationConfigurationProcessor$default (Llove/forte/simbot/spring2/configuration/config/DefaultSimbotApplicationConfigurationProcessorConfiguration;Ljava/util/List;ILjava/lang/Object;)Llove/forte/simbot/spring2/configuration/config/DefaultSimbotApplicationConfigurationProcessor;
+}
+
+public final class love/forte/simbot/spring2/configuration/config/DefaultSimbotApplicationConfigurationProcessorConfiguration$Companion {
+}
+
+public abstract interface class love/forte/simbot/spring2/configuration/config/SimbotApplicationConfigurationConfigurer {
+	public abstract fun configure (Llove/forte/simbot/spring/common/application/SpringApplicationBuilder;)V
+}
+
+public abstract interface class love/forte/simbot/spring2/configuration/config/SimbotApplicationConfigurationProcessor {
+	public abstract fun process (Llove/forte/simbot/spring/common/application/SpringApplicationBuilder;)V
+}
+
+public abstract class love/forte/simbot/spring2/configuration/listener/KFunctionEventListener : love/forte/simbot/quantcat/common/binder/FunctionalBindableEventListener {
+	public static final field Companion Llove/forte/simbot/spring2/configuration/listener/KFunctionEventListener$Companion;
+	public static final field RAW_BINDERS_ATTRIBUTE_NAME Ljava/lang/String;
+	public static final field RAW_FUNCTION_ATTRIBUTE_NAME Ljava/lang/String;
+	public static final field RAW_LISTEN_TARGET_ATTRIBUTE_NAME Ljava/lang/String;
+	public static final field RawBindersAttribute Llove/forte/simbot/common/attribute/Attribute;
+	public static final field RawFunctionAttribute Llove/forte/simbot/common/attribute/Attribute;
+	public static final field RawListenTargetAttribute Llove/forte/simbot/common/attribute/Attribute;
+	public fun <init> (Ljava/lang/Object;Lkotlin/reflect/KFunction;)V
+	public abstract fun getAttributes ()Llove/forte/simbot/common/attribute/AttributeMap;
+}
+
+public final class love/forte/simbot/spring2/configuration/listener/KFunctionEventListener$Companion {
+}
+
+public class love/forte/simbot/spring2/configuration/listener/SimbotEventListenerFunctionProcessor : org/springframework/context/annotation/ConfigurationClassPostProcessor, org/springframework/context/ApplicationContextAware {
+	public static final field Companion Llove/forte/simbot/spring2/configuration/listener/SimbotEventListenerFunctionProcessor$Companion;
+	public fun <init> ()V
+	public fun postProcessBeanDefinitionRegistry (Lorg/springframework/beans/factory/support/BeanDefinitionRegistry;)V
+	public fun postProcessBeanFactory (Lorg/springframework/beans/factory/config/ConfigurableListableBeanFactory;)V
+	public fun setApplicationContext (Lorg/springframework/context/ApplicationContext;)V
+}
+
+public final class love/forte/simbot/spring2/configuration/listener/SimbotEventListenerFunctionProcessor$Companion {
+}
+
+public abstract interface class love/forte/simbot/spring2/configuration/listener/SimbotEventListenerResolver {
+	public abstract fun resolve (Llove/forte/simbot/application/Application;)V
+}
+
+public final class love/forte/simbot/spring2/utils/ConfigurableListableBeanFactoryUtilsKt {
+	public static final fun findMergedAnnotationSafely (Ljava/lang/reflect/AnnotatedElement;Lkotlin/reflect/KClass;)Ljava/lang/annotation/Annotation;
+	public static final fun findRepeatableMergedAnnotationSafely (Ljava/lang/reflect/AnnotatedElement;Lkotlin/reflect/KClass;)Ljava/util/Set;
+	public static final fun selectMethodsSafely (Ljava/lang/Class;Lkotlin/reflect/KClass;)Ljava/util/Map;
+}
+
+public abstract interface annotation class love/forte/simbot/spring2/warn/MigratingSpringBootVersion : java/lang/annotation/Annotation {
+}
+
+public final class love/forte/simbot/spring2/warn/MigratingSpringBootVersionKt {
+	public static final field MIGRATING_SPRING_BOOT_VERSION_WARNING Ljava/lang/String;
+}
+
+public class love/forte/simbot/spring2/warn/MigratingSpringBootVersionWarningPrinter : org/springframework/boot/CommandLineRunner, org/springframework/core/Ordered {
+	public static final field Companion Llove/forte/simbot/spring2/warn/MigratingSpringBootVersionWarningPrinter$Companion;
+	public fun <init> ()V
+	public fun getOrder ()I
+	public fun run ([Ljava/lang/String;)V
+}
+
+public final class love/forte/simbot/spring2/warn/MigratingSpringBootVersionWarningPrinter$Companion {
+}
+

--- a/simbot-cores/simbot-core-spring-boot-starter/api/simbot-core-spring-boot-starter.api
+++ b/simbot-cores/simbot-core-spring-boot-starter/api/simbot-core-spring-boot-starter.api
@@ -1,0 +1,375 @@
+public abstract interface annotation class love/forte/simbot/spring/EnableSimbot : java/lang/annotation/Annotation {
+}
+
+public final class love/forte/simbot/spring/application/Spring : love/forte/simbot/spring/common/application/SpringApplicationFactory {
+	public static final field INSTANCE Llove/forte/simbot/spring/application/Spring;
+	public synthetic fun create (Llove/forte/simbot/common/function/ConfigurerFunction;)Llove/forte/simbot/application/ApplicationLauncher;
+	public fun create (Llove/forte/simbot/common/function/ConfigurerFunction;)Llove/forte/simbot/spring/common/application/SpringApplicationLauncher;
+}
+
+public final class love/forte/simbot/spring/configuration/DefaultSimbotComponentInstallProcessor : love/forte/simbot/spring/configuration/SimbotComponentInstallProcessor {
+	public static final field Companion Llove/forte/simbot/spring/configuration/DefaultSimbotComponentInstallProcessor$Companion;
+	public fun <init> (ZZLjava/util/List;Ljava/util/List;)V
+	public fun process (Llove/forte/simbot/component/ComponentInstaller;)V
+}
+
+public final class love/forte/simbot/spring/configuration/DefaultSimbotComponentInstallProcessor$Companion {
+}
+
+public class love/forte/simbot/spring/configuration/DefaultSimbotComponentInstallProcessorConfiguration {
+	public static final field Companion Llove/forte/simbot/spring/configuration/DefaultSimbotComponentInstallProcessorConfiguration$Companion;
+	public static final field DEFAULT_SIMBOT_COMPONENT_INSTALL_PROCESSOR_BEAN_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun defaultSimbotComponentInstallProcessor (Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties;Ljava/util/List;Ljava/util/List;)Llove/forte/simbot/spring/configuration/DefaultSimbotComponentInstallProcessor;
+	public static synthetic fun defaultSimbotComponentInstallProcessor$default (Llove/forte/simbot/spring/configuration/DefaultSimbotComponentInstallProcessorConfiguration;Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Llove/forte/simbot/spring/configuration/DefaultSimbotComponentInstallProcessor;
+}
+
+public final class love/forte/simbot/spring/configuration/DefaultSimbotComponentInstallProcessorConfiguration$Companion {
+}
+
+public class love/forte/simbot/spring/configuration/DefaultSimbotDispatcherProcessor : love/forte/simbot/spring/configuration/SimbotDispatcherProcessor {
+	public static final field Companion Llove/forte/simbot/spring/configuration/DefaultSimbotDispatcherProcessor$Companion;
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public fun process (Llove/forte/simbot/spring/common/application/SpringEventDispatcherConfiguration;)V
+}
+
+public final class love/forte/simbot/spring/configuration/DefaultSimbotDispatcherProcessor$Companion {
+}
+
+public class love/forte/simbot/spring/configuration/DefaultSimbotDispatcherProcessorConfiguration {
+	public static final field Companion Llove/forte/simbot/spring/configuration/DefaultSimbotDispatcherProcessorConfiguration$Companion;
+	public static final field DEFAULT_SIMBOT_DISPATCHER_PROCESSOR_BEAN_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun defaultSimbotDispatcherProcessor (Ljava/util/List;Ljava/util/List;Ljava/util/List;)Llove/forte/simbot/spring/configuration/DefaultSimbotDispatcherProcessor;
+	public static synthetic fun defaultSimbotDispatcherProcessor$default (Llove/forte/simbot/spring/configuration/DefaultSimbotDispatcherProcessorConfiguration;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Llove/forte/simbot/spring/configuration/DefaultSimbotDispatcherProcessor;
+}
+
+public final class love/forte/simbot/spring/configuration/DefaultSimbotDispatcherProcessorConfiguration$Companion {
+}
+
+public class love/forte/simbot/spring/configuration/DefaultSimbotEventDispatcherProcessor : love/forte/simbot/spring/configuration/SimbotEventDispatcherProcessor {
+	public static final field Companion Llove/forte/simbot/spring/configuration/DefaultSimbotEventDispatcherProcessor$Companion;
+	public fun <init> (Llove/forte/simbot/spring/configuration/SimbotEventListenerRegistrarProcessor;Ljava/util/List;)V
+	public fun process (Llove/forte/simbot/event/EventDispatcher;)V
+}
+
+public final class love/forte/simbot/spring/configuration/DefaultSimbotEventDispatcherProcessor$Companion {
+}
+
+public class love/forte/simbot/spring/configuration/DefaultSimbotEventDispatcherProcessorConfiguration {
+	public static final field Companion Llove/forte/simbot/spring/configuration/DefaultSimbotEventDispatcherProcessorConfiguration$Companion;
+	public static final field DEFAULT_SIMBOT_EVENT_DISPATCHER_PROCESSOR_BEAN_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun defaultSimbotEventDispatcherProcessor (Llove/forte/simbot/spring/configuration/SimbotEventListenerRegistrarProcessor;Ljava/util/List;)Llove/forte/simbot/spring/configuration/DefaultSimbotEventDispatcherProcessor;
+	public static synthetic fun defaultSimbotEventDispatcherProcessor$default (Llove/forte/simbot/spring/configuration/DefaultSimbotEventDispatcherProcessorConfiguration;Llove/forte/simbot/spring/configuration/SimbotEventListenerRegistrarProcessor;Ljava/util/List;ILjava/lang/Object;)Llove/forte/simbot/spring/configuration/DefaultSimbotEventDispatcherProcessor;
+}
+
+public final class love/forte/simbot/spring/configuration/DefaultSimbotEventDispatcherProcessorConfiguration$Companion {
+}
+
+public class love/forte/simbot/spring/configuration/DefaultSimbotEventListenerRegistrarProcessor : love/forte/simbot/spring/configuration/SimbotEventListenerRegistrarProcessor {
+	public static final field Companion Llove/forte/simbot/spring/configuration/DefaultSimbotEventListenerRegistrarProcessor$Companion;
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public fun process (Llove/forte/simbot/event/EventListenerRegistrar;)V
+}
+
+public final class love/forte/simbot/spring/configuration/DefaultSimbotEventListenerRegistrarProcessor$Companion {
+}
+
+public class love/forte/simbot/spring/configuration/DefaultSimbotEventListenerRegistrarProcessorConfiguration {
+	public static final field Companion Llove/forte/simbot/spring/configuration/DefaultSimbotEventListenerRegistrarProcessorConfiguration$Companion;
+	public static final field DEFAULT_SIMBOT_EVENT_LISTENER_REGISTRAR_PROCESSOR_BEAN_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun defaultSimbotEventListenerRegistrarProcessor (Ljava/util/List;Ljava/util/List;)Llove/forte/simbot/spring/configuration/DefaultSimbotEventListenerRegistrarProcessor;
+	public static synthetic fun defaultSimbotEventListenerRegistrarProcessor$default (Llove/forte/simbot/spring/configuration/DefaultSimbotEventListenerRegistrarProcessorConfiguration;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Llove/forte/simbot/spring/configuration/DefaultSimbotEventListenerRegistrarProcessor;
+}
+
+public final class love/forte/simbot/spring/configuration/DefaultSimbotEventListenerRegistrarProcessorConfiguration$Companion {
+}
+
+public final class love/forte/simbot/spring/configuration/DefaultSimbotPluginInstallProcessor : love/forte/simbot/spring/configuration/SimbotPluginInstallProcessor {
+	public static final field Companion Llove/forte/simbot/spring/configuration/DefaultSimbotPluginInstallProcessor$Companion;
+	public fun <init> (ZZLjava/util/List;Ljava/util/List;)V
+	public fun process (Llove/forte/simbot/plugin/PluginInstaller;)V
+}
+
+public final class love/forte/simbot/spring/configuration/DefaultSimbotPluginInstallProcessor$Companion {
+}
+
+public class love/forte/simbot/spring/configuration/DefaultSimbotPluginInstallProcessorConfiguration {
+	public static final field Companion Llove/forte/simbot/spring/configuration/DefaultSimbotPluginInstallProcessorConfiguration$Companion;
+	public static final field DEFAULT_SIMBOT_PLUGIN_INSTALL_PROCESSOR_BEAN_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun defaultSimbotPluginInstallProcessor (Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties;Ljava/util/List;Ljava/util/List;)Llove/forte/simbot/spring/configuration/DefaultSimbotPluginInstallProcessor;
+	public static synthetic fun defaultSimbotPluginInstallProcessor$default (Llove/forte/simbot/spring/configuration/DefaultSimbotPluginInstallProcessorConfiguration;Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Llove/forte/simbot/spring/configuration/DefaultSimbotPluginInstallProcessor;
+}
+
+public final class love/forte/simbot/spring/configuration/DefaultSimbotPluginInstallProcessorConfiguration$Companion {
+}
+
+public abstract interface class love/forte/simbot/spring/configuration/SimbotComponentInstallProcessor {
+	public abstract fun process (Llove/forte/simbot/component/ComponentInstaller;)V
+}
+
+public abstract interface class love/forte/simbot/spring/configuration/SimbotComponentInstaller {
+	public abstract fun install (Llove/forte/simbot/component/ComponentInstaller;)V
+}
+
+public abstract interface class love/forte/simbot/spring/configuration/SimbotDispatcherConfigurer {
+	public abstract fun configure (Llove/forte/simbot/spring/common/application/SpringEventDispatcherConfiguration;)V
+}
+
+public abstract interface class love/forte/simbot/spring/configuration/SimbotDispatcherProcessor {
+	public abstract fun process (Llove/forte/simbot/spring/common/application/SpringEventDispatcherConfiguration;)V
+}
+
+public abstract interface class love/forte/simbot/spring/configuration/SimbotEventDispatcherPostConfigurer {
+	public abstract fun configure (Llove/forte/simbot/event/EventDispatcher;)V
+}
+
+public abstract interface class love/forte/simbot/spring/configuration/SimbotEventDispatcherProcessor {
+	public abstract fun process (Llove/forte/simbot/event/EventDispatcher;)V
+}
+
+public abstract interface class love/forte/simbot/spring/configuration/SimbotEventListenerRegistrarPostConfigurer {
+	public abstract fun configure (Llove/forte/simbot/event/EventListenerRegistrar;)V
+}
+
+public abstract interface class love/forte/simbot/spring/configuration/SimbotEventListenerRegistrarProcessor {
+	public abstract fun process (Llove/forte/simbot/event/EventListenerRegistrar;)V
+}
+
+public abstract interface class love/forte/simbot/spring/configuration/SimbotPluginInstallProcessor {
+	public abstract fun process (Llove/forte/simbot/plugin/PluginInstaller;)V
+}
+
+public abstract interface class love/forte/simbot/spring/configuration/SimbotPluginInstaller {
+	public abstract fun install (Llove/forte/simbot/plugin/PluginInstaller;)V
+}
+
+public class love/forte/simbot/spring/configuration/SimbotSpringPropertiesConfiguration {
+	public fun <init> ()V
+	public fun springApplicationConfigurationProperties ()Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties;
+}
+
+public final class love/forte/simbot/spring/configuration/application/DefaultSimbotApplicationLauncherFactory : love/forte/simbot/spring/configuration/application/SimbotApplicationLauncherFactory {
+	public fun <init> (Ljava/util/List;Ljava/util/List;Llove/forte/simbot/spring/configuration/config/SimbotApplicationConfigurationProcessor;Llove/forte/simbot/spring/configuration/SimbotDispatcherProcessor;Llove/forte/simbot/spring/configuration/SimbotComponentInstallProcessor;Llove/forte/simbot/spring/configuration/SimbotPluginInstallProcessor;)V
+	public fun process (Llove/forte/simbot/spring/application/Spring;)Llove/forte/simbot/spring/common/application/SpringApplicationLauncher;
+}
+
+public final class love/forte/simbot/spring/configuration/application/DefaultSimbotApplicationLauncherFactoryProcessor : love/forte/simbot/spring/configuration/application/SimbotApplicationLauncherFactoryProcessor {
+	public static final field INSTANCE Llove/forte/simbot/spring/configuration/application/DefaultSimbotApplicationLauncherFactoryProcessor;
+	public fun process (Llove/forte/simbot/spring/configuration/application/SimbotApplicationLauncherFactory;)Llove/forte/simbot/spring/common/application/SpringApplicationLauncher;
+}
+
+public class love/forte/simbot/spring/configuration/application/DefaultSimbotApplicationLauncherFactoryProcessorConfiguration {
+	public static final field Companion Llove/forte/simbot/spring/configuration/application/DefaultSimbotApplicationLauncherFactoryProcessorConfiguration$Companion;
+	public static final field DEFAULT_SIMBOT_APPLICATION_LAUNCHER_FACTORY_PROCESSOR_BEAN_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun defaultSimbotApplicationLauncherFactoryProcessor ()Llove/forte/simbot/spring/configuration/application/DefaultSimbotApplicationLauncherFactoryProcessor;
+}
+
+public final class love/forte/simbot/spring/configuration/application/DefaultSimbotApplicationLauncherFactoryProcessorConfiguration$Companion {
+}
+
+public final class love/forte/simbot/spring/configuration/application/DefaultSimbotApplicationProcessor : love/forte/simbot/spring/configuration/application/SimbotApplicationProcessor {
+	public static final field Companion Llove/forte/simbot/spring/configuration/application/DefaultSimbotApplicationProcessor$Companion;
+	public fun <init> (Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties;Ljava/util/List;Ljava/util/List;Ljava/util/List;Llove/forte/simbot/spring/configuration/SimbotEventDispatcherProcessor;)V
+	public fun process (Llove/forte/simbot/spring/common/application/SpringApplication;)V
+}
+
+public final class love/forte/simbot/spring/configuration/application/DefaultSimbotApplicationProcessor$Companion {
+}
+
+public class love/forte/simbot/spring/configuration/application/DefaultSimbotSpringApplicationLauncherFactoryConfiguration {
+	public static final field Companion Llove/forte/simbot/spring/configuration/application/DefaultSimbotSpringApplicationLauncherFactoryConfiguration$Companion;
+	public static final field DEFAULT_SPRING_APPLICATION_LAUNCHER_PROCESSOR_BEAN_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun defaultSpringApplicationLauncherProcessor (Ljava/util/List;Ljava/util/List;Llove/forte/simbot/spring/configuration/config/SimbotApplicationConfigurationProcessor;Llove/forte/simbot/spring/configuration/SimbotDispatcherProcessor;Llove/forte/simbot/spring/configuration/SimbotComponentInstallProcessor;Llove/forte/simbot/spring/configuration/SimbotPluginInstallProcessor;)Llove/forte/simbot/spring/configuration/application/DefaultSimbotApplicationLauncherFactory;
+	public static synthetic fun defaultSpringApplicationLauncherProcessor$default (Llove/forte/simbot/spring/configuration/application/DefaultSimbotSpringApplicationLauncherFactoryConfiguration;Ljava/util/List;Ljava/util/List;Llove/forte/simbot/spring/configuration/config/SimbotApplicationConfigurationProcessor;Llove/forte/simbot/spring/configuration/SimbotDispatcherProcessor;Llove/forte/simbot/spring/configuration/SimbotComponentInstallProcessor;Llove/forte/simbot/spring/configuration/SimbotPluginInstallProcessor;ILjava/lang/Object;)Llove/forte/simbot/spring/configuration/application/DefaultSimbotApplicationLauncherFactory;
+}
+
+public final class love/forte/simbot/spring/configuration/application/DefaultSimbotSpringApplicationLauncherFactoryConfiguration$Companion {
+}
+
+public class love/forte/simbot/spring/configuration/application/DefaultSimbotSpringApplicationProcessorConfiguration {
+	public static final field Companion Llove/forte/simbot/spring/configuration/application/DefaultSimbotSpringApplicationProcessorConfiguration$Companion;
+	public static final field DEFAULT_SIMBOT_APPLICATION_PROCESSOR_BEAN_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun defaultSimbotApplicationProcessor (Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties;Ljava/util/List;Ljava/util/List;Ljava/util/List;Llove/forte/simbot/spring/configuration/SimbotEventDispatcherProcessor;)Llove/forte/simbot/spring/configuration/application/DefaultSimbotApplicationProcessor;
+	public static synthetic fun defaultSimbotApplicationProcessor$default (Llove/forte/simbot/spring/configuration/application/DefaultSimbotSpringApplicationProcessorConfiguration;Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties;Ljava/util/List;Ljava/util/List;Ljava/util/List;Llove/forte/simbot/spring/configuration/SimbotEventDispatcherProcessor;ILjava/lang/Object;)Llove/forte/simbot/spring/configuration/application/DefaultSimbotApplicationProcessor;
+}
+
+public final class love/forte/simbot/spring/configuration/application/DefaultSimbotSpringApplicationProcessorConfiguration$Companion {
+}
+
+public class love/forte/simbot/spring/configuration/application/SimbotApplicationConfiguration {
+	public static final field Companion Llove/forte/simbot/spring/configuration/application/SimbotApplicationConfiguration$Companion;
+	public static final field SPRING_APPLICATION_BEAN_NAME Ljava/lang/String;
+	public static final field SPRING_APPLICATION_LAUNCHER_BEAN_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun springApplication (Llove/forte/simbot/spring/common/application/SpringApplicationLauncher;)Llove/forte/simbot/spring/common/application/SpringApplication;
+	public fun springApplicationLauncher (Llove/forte/simbot/spring/configuration/application/SimbotApplicationLauncherFactory;Llove/forte/simbot/spring/configuration/application/SimbotApplicationLauncherFactoryProcessor;)Llove/forte/simbot/spring/common/application/SpringApplicationLauncher;
+}
+
+public final class love/forte/simbot/spring/configuration/application/SimbotApplicationConfiguration$Companion {
+}
+
+public abstract interface class love/forte/simbot/spring/configuration/application/SimbotApplicationConfigurer {
+	public abstract fun configure (Llove/forte/simbot/spring/common/application/SpringApplication;)V
+}
+
+public abstract interface class love/forte/simbot/spring/configuration/application/SimbotApplicationLauncherConfigurer {
+	public abstract fun configure (Llove/forte/simbot/application/ApplicationFactoryConfigurer;)V
+}
+
+public abstract interface class love/forte/simbot/spring/configuration/application/SimbotApplicationLauncherFactory {
+	public abstract fun process (Llove/forte/simbot/spring/application/Spring;)Llove/forte/simbot/spring/common/application/SpringApplicationLauncher;
+}
+
+public abstract interface class love/forte/simbot/spring/configuration/application/SimbotApplicationLauncherFactoryProcessor {
+	public abstract fun process (Llove/forte/simbot/spring/configuration/application/SimbotApplicationLauncherFactory;)Llove/forte/simbot/spring/common/application/SpringApplicationLauncher;
+}
+
+public abstract interface class love/forte/simbot/spring/configuration/application/SimbotApplicationLauncherPostConfigurer : love/forte/simbot/spring/configuration/application/SimbotApplicationLauncherConfigurer {
+}
+
+public abstract interface class love/forte/simbot/spring/configuration/application/SimbotApplicationLauncherPreConfigurer : love/forte/simbot/spring/configuration/application/SimbotApplicationLauncherConfigurer {
+}
+
+public abstract interface class love/forte/simbot/spring/configuration/application/SimbotApplicationPostConfigurer : love/forte/simbot/spring/configuration/application/SimbotApplicationConfigurer {
+}
+
+public abstract interface class love/forte/simbot/spring/configuration/application/SimbotApplicationPreConfigurer : love/forte/simbot/spring/configuration/application/SimbotApplicationConfigurer {
+}
+
+public abstract interface class love/forte/simbot/spring/configuration/application/SimbotApplicationProcessor {
+	public abstract fun process (Llove/forte/simbot/spring/common/application/SpringApplication;)V
+}
+
+public class love/forte/simbot/spring/configuration/application/SimbotApplicationRunner : org/springframework/boot/ApplicationRunner, org/springframework/context/ApplicationContextAware {
+	public static final field Companion Llove/forte/simbot/spring/configuration/application/SimbotApplicationRunner$Companion;
+	public fun <init> (Llove/forte/simbot/spring/common/application/SpringApplication;Llove/forte/simbot/spring/common/application/SpringApplicationConfigurationProperties;Llove/forte/simbot/spring/configuration/application/SimbotApplicationProcessor;)V
+	public fun run (Lorg/springframework/boot/ApplicationArguments;)V
+	public fun setApplicationContext (Lorg/springframework/context/ApplicationContext;)V
+}
+
+public final class love/forte/simbot/spring/configuration/application/SimbotApplicationRunner$Companion {
+}
+
+public class love/forte/simbot/spring/configuration/binder/DefaultBinderManagerProvidersConfiguration {
+	public fun <init> ()V
+	public fun eventParameterBinderFactory ()Llove/forte/simbot/quantcat/common/binder/impl/EventParameterBinderFactory;
+	public fun keywordBinderFactory ()Llove/forte/simbot/quantcat/common/binder/impl/KeywordBinderFactory;
+}
+
+public class love/forte/simbot/spring/configuration/binder/DuplicateBinderIdException : java/lang/IllegalArgumentException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public abstract interface class love/forte/simbot/spring/configuration/binder/ParameterBinderManagerBuilder {
+	public abstract fun addBinderFactory (Ljava/lang/String;Llove/forte/simbot/quantcat/common/binder/ParameterBinderFactory;)V
+	public abstract fun addBinderFactory (Llove/forte/simbot/quantcat/common/binder/ParameterBinderFactory;)V
+}
+
+public abstract interface class love/forte/simbot/spring/configuration/binder/ParameterBinderManagerBuilderConfigurer {
+	public abstract fun configure (Llove/forte/simbot/spring/configuration/binder/ParameterBinderManagerBuilder;)V
+}
+
+public class love/forte/simbot/spring/configuration/binder/ResolveBinderManagerProcessor : org/springframework/context/annotation/ConfigurationClassPostProcessor {
+	public static final field BINDER_MANAGER_BEAN_NAME Ljava/lang/String;
+	public static final field Companion Llove/forte/simbot/spring/configuration/binder/ResolveBinderManagerProcessor$Companion;
+	protected field registry Lorg/springframework/beans/factory/support/BeanDefinitionRegistry;
+	public fun <init> ()V
+	protected fun getRegistry ()Lorg/springframework/beans/factory/support/BeanDefinitionRegistry;
+	public fun postProcessBeanDefinitionRegistry (Lorg/springframework/beans/factory/support/BeanDefinitionRegistry;)V
+	public fun postProcessBeanFactory (Lorg/springframework/beans/factory/config/ConfigurableListableBeanFactory;)V
+	protected fun resolveCandidate (Lorg/springframework/beans/factory/config/ConfigurableListableBeanFactory;Ljava/lang/String;Ljava/lang/Class;Llove/forte/simbot/spring/configuration/binder/ResolveBinderManagerProcessor$ParameterBinderManagerBuilderImpl;)V
+	protected fun resolveConfigurer (Lorg/springframework/beans/factory/config/ConfigurableListableBeanFactory;Ljava/lang/String;Ljava/lang/Class;Llove/forte/simbot/spring/configuration/binder/ResolveBinderManagerProcessor$ParameterBinderManagerBuilderImpl;)V
+	protected fun resolveFactoryInstance (Lorg/springframework/beans/factory/config/ConfigurableListableBeanFactory;Ljava/lang/String;Ljava/lang/Class;Llove/forte/simbot/spring/configuration/binder/ResolveBinderManagerProcessor$ParameterBinderManagerBuilderImpl;)V
+	protected fun resolveFactoryWithBinder (Llove/forte/simbot/quantcat/common/annotations/Binder;Ljava/lang/String;Llove/forte/simbot/quantcat/common/binder/ParameterBinderFactory;Llove/forte/simbot/spring/configuration/binder/ResolveBinderManagerProcessor$ParameterBinderManagerBuilderImpl;)V
+	protected fun setRegistry (Lorg/springframework/beans/factory/support/BeanDefinitionRegistry;)V
+}
+
+public final class love/forte/simbot/spring/configuration/binder/ResolveBinderManagerProcessor$Companion {
+}
+
+protected class love/forte/simbot/spring/configuration/binder/ResolveBinderManagerProcessor$ParameterBinderManagerBuilderImpl : love/forte/simbot/spring/configuration/binder/ParameterBinderManagerBuilder {
+	public fun <init> ()V
+	public fun addBinderFactory (Ljava/lang/String;Llove/forte/simbot/quantcat/common/binder/ParameterBinderFactory;)V
+	public fun addBinderFactory (Llove/forte/simbot/quantcat/common/binder/ParameterBinderFactory;)V
+	public fun getGlobalBinders ()Ljava/util/List;
+	public fun getIdBinders ()Ljava/util/Map;
+}
+
+public final class love/forte/simbot/spring/configuration/binder/SpringAutoInjectBinderFactory : love/forte/simbot/quantcat/common/binder/ParameterBinderFactory {
+	public fun <init> (Lorg/springframework/beans/factory/BeanFactory;)V
+	public synthetic fun resolveToBinder (Llove/forte/simbot/quantcat/common/binder/BaseParameterBinderFactory$Context;)Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult;
+	public fun resolveToBinder (Llove/forte/simbot/quantcat/common/binder/ParameterBinderFactory$Context;)Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult;
+}
+
+public class love/forte/simbot/spring/configuration/config/DefaultSimbotApplicationConfigurationProcessor : love/forte/simbot/spring/configuration/config/SimbotApplicationConfigurationProcessor {
+	public static final field Companion Llove/forte/simbot/spring/configuration/config/DefaultSimbotApplicationConfigurationProcessor$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public fun process (Llove/forte/simbot/spring/common/application/SpringApplicationBuilder;)V
+}
+
+public final class love/forte/simbot/spring/configuration/config/DefaultSimbotApplicationConfigurationProcessor$Companion {
+}
+
+public class love/forte/simbot/spring/configuration/config/DefaultSimbotApplicationConfigurationProcessorConfiguration {
+	public static final field Companion Llove/forte/simbot/spring/configuration/config/DefaultSimbotApplicationConfigurationProcessorConfiguration$Companion;
+	public static final field DEFAULT_SIMBOT_APPLICATION_CONFIGURATION_PROCESSOR_BEAN_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun defaultSimbotApplicationConfigurationProcessor (Ljava/util/List;)Llove/forte/simbot/spring/configuration/config/DefaultSimbotApplicationConfigurationProcessor;
+	public static synthetic fun defaultSimbotApplicationConfigurationProcessor$default (Llove/forte/simbot/spring/configuration/config/DefaultSimbotApplicationConfigurationProcessorConfiguration;Ljava/util/List;ILjava/lang/Object;)Llove/forte/simbot/spring/configuration/config/DefaultSimbotApplicationConfigurationProcessor;
+}
+
+public final class love/forte/simbot/spring/configuration/config/DefaultSimbotApplicationConfigurationProcessorConfiguration$Companion {
+}
+
+public abstract interface class love/forte/simbot/spring/configuration/config/SimbotApplicationConfigurationConfigurer {
+	public abstract fun configure (Llove/forte/simbot/spring/common/application/SpringApplicationBuilder;)V
+}
+
+public abstract interface class love/forte/simbot/spring/configuration/config/SimbotApplicationConfigurationProcessor {
+	public abstract fun process (Llove/forte/simbot/spring/common/application/SpringApplicationBuilder;)V
+}
+
+public abstract class love/forte/simbot/spring/configuration/listener/KFunctionEventListener : love/forte/simbot/quantcat/common/binder/FunctionalBindableEventListener {
+	public static final field Companion Llove/forte/simbot/spring/configuration/listener/KFunctionEventListener$Companion;
+	public static final field RAW_BINDERS_ATTRIBUTE_NAME Ljava/lang/String;
+	public static final field RAW_FUNCTION_ATTRIBUTE_NAME Ljava/lang/String;
+	public static final field RAW_LISTEN_TARGET_ATTRIBUTE_NAME Ljava/lang/String;
+	public static final field RawBindersAttribute Llove/forte/simbot/common/attribute/Attribute;
+	public static final field RawFunctionAttribute Llove/forte/simbot/common/attribute/Attribute;
+	public static final field RawListenTargetAttribute Llove/forte/simbot/common/attribute/Attribute;
+	public fun <init> (Ljava/lang/Object;Lkotlin/reflect/KFunction;)V
+	public abstract fun getAttributes ()Llove/forte/simbot/common/attribute/AttributeMap;
+}
+
+public final class love/forte/simbot/spring/configuration/listener/KFunctionEventListener$Companion {
+}
+
+public class love/forte/simbot/spring/configuration/listener/SimbotEventListenerFunctionProcessor : org/springframework/context/annotation/ConfigurationClassPostProcessor, org/springframework/context/ApplicationContextAware {
+	public static final field Companion Llove/forte/simbot/spring/configuration/listener/SimbotEventListenerFunctionProcessor$Companion;
+	public fun <init> ()V
+	public fun postProcessBeanDefinitionRegistry (Lorg/springframework/beans/factory/support/BeanDefinitionRegistry;)V
+	public fun postProcessBeanFactory (Lorg/springframework/beans/factory/config/ConfigurableListableBeanFactory;)V
+	public fun setApplicationContext (Lorg/springframework/context/ApplicationContext;)V
+}
+
+public final class love/forte/simbot/spring/configuration/listener/SimbotEventListenerFunctionProcessor$Companion {
+}
+
+public abstract interface class love/forte/simbot/spring/configuration/listener/SimbotEventListenerResolver {
+	public abstract fun resolve (Llove/forte/simbot/application/Application;)V
+}
+
+public final class love/forte/simbot/spring/utils/ConfigurableListableBeanFactoryUtilsKt {
+	public static final fun findMergedAnnotationSafely (Ljava/lang/reflect/AnnotatedElement;Lkotlin/reflect/KClass;)Ljava/lang/annotation/Annotation;
+	public static final fun findRepeatableMergedAnnotationSafely (Ljava/lang/reflect/AnnotatedElement;Lkotlin/reflect/KClass;)Ljava/util/Set;
+	public static final fun selectMethodsSafely (Ljava/lang/Class;Lkotlin/reflect/KClass;)Ljava/util/Map;
+}
+

--- a/simbot-cores/simbot-core/api/simbot-core.api
+++ b/simbot-cores/simbot-core/api/simbot-core.api
@@ -1,0 +1,125 @@
+public final class love/forte/simbot/core/application/Simple : love/forte/simbot/application/ApplicationFactory {
+	public static final field INSTANCE Llove/forte/simbot/core/application/Simple;
+	public synthetic fun create (Llove/forte/simbot/common/function/ConfigurerFunction;)Llove/forte/simbot/application/ApplicationLauncher;
+	public fun create (Llove/forte/simbot/common/function/ConfigurerFunction;)Llove/forte/simbot/core/application/SimpleApplicationLauncher;
+}
+
+public abstract interface class love/forte/simbot/core/application/SimpleApplication : love/forte/simbot/application/Application {
+	public abstract fun getConfiguration ()Llove/forte/simbot/core/application/SimpleApplicationConfiguration;
+}
+
+public final class love/forte/simbot/core/application/SimpleApplicationBuilder : love/forte/simbot/application/AbstractApplicationBuilder {
+	public fun <init> ()V
+}
+
+public abstract interface class love/forte/simbot/core/application/SimpleApplicationConfiguration : love/forte/simbot/application/ApplicationConfiguration {
+}
+
+public final class love/forte/simbot/core/application/SimpleApplicationKt {
+	public static final fun launchSimpleApplication (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun launchSimpleApplication$default (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/core/application/SimpleApplicationLauncher : love/forte/simbot/application/ApplicationLauncher {
+}
+
+public abstract interface class love/forte/simbot/core/event/SimpleEventDispatchInterceptorRegistrationProperties : love/forte/simbot/event/EventDispatchInterceptorRegistrationProperties {
+}
+
+public abstract interface class love/forte/simbot/core/event/SimpleEventDispatcher : love/forte/simbot/event/EventDispatcher {
+}
+
+public abstract interface class love/forte/simbot/core/event/SimpleEventDispatcherConfiguration : love/forte/simbot/event/EventDispatcherConfiguration {
+}
+
+public abstract interface class love/forte/simbot/core/event/SimpleEventInterceptorRegistrationProperties : love/forte/simbot/event/EventInterceptorRegistrationProperties {
+}
+
+public abstract interface class love/forte/simbot/core/event/SimpleEventListenerRegistrationProperties : love/forte/simbot/event/EventListenerRegistrationProperties {
+}
+
+public final class love/forte/simbot/core/event/impl/SimpleEventDispatchInterceptorInvoker : java/lang/Comparable, love/forte/simbot/event/EventDispatchInterceptor {
+	public fun <init> (Llove/forte/simbot/event/EventDispatchInterceptor;I)V
+	public synthetic fun compareTo (Ljava/lang/Object;)I
+	public fun compareTo (Llove/forte/simbot/core/event/impl/SimpleEventDispatchInterceptorInvoker;)I
+	public fun intercept (Llove/forte/simbot/event/EventDispatchInterceptor$Context;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public class love/forte/simbot/core/event/impl/SimpleEventDispatchInterceptorRegistrationPropertiesImpl : love/forte/simbot/core/event/SimpleEventDispatchInterceptorRegistrationProperties {
+	public fun <init> ()V
+	public fun getPriority ()I
+	public fun setPriority (I)V
+}
+
+public final class love/forte/simbot/core/event/impl/SimpleEventDispatchInterceptorsInvoker {
+	public fun <init> (Ljava/lang/Iterable;)V
+	public final fun invoke (Llove/forte/simbot/event/EventContext;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public class love/forte/simbot/core/event/impl/SimpleEventDispatcherConfigurationImpl : love/forte/simbot/event/AbstractEventDispatcherConfiguration, love/forte/simbot/core/event/SimpleEventDispatcherConfiguration {
+	public fun <init> ()V
+	public fun getDispatchInterceptors ()Ljava/util/List;
+	public fun getInterceptors ()Ljava/util/List;
+}
+
+public final class love/forte/simbot/core/event/impl/SimpleEventDispatcherImpl : love/forte/simbot/core/event/SimpleEventDispatcher {
+	public fun <init> (Llove/forte/simbot/core/event/SimpleEventDispatcherConfiguration;Llove/forte/simbot/core/event/impl/SimpleEventInterceptors;)V
+	public fun <init> (Llove/forte/simbot/core/event/impl/SimpleEventDispatcherConfigurationImpl;)V
+	public fun dispose (Llove/forte/simbot/event/EventListener;)V
+	public fun getListeners ()Lkotlin/sequences/Sequence;
+	public fun push (Llove/forte/simbot/event/Event;)Lkotlinx/coroutines/flow/Flow;
+	public fun register (Llove/forte/simbot/common/function/ConfigurerFunction;Llove/forte/simbot/event/EventListener;)Llove/forte/simbot/event/EventListenerRegistrationHandle;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/core/event/impl/SimpleEventDispatcherImpls {
+	public static final fun resolveInterceptors (Llove/forte/simbot/core/event/impl/SimpleEventDispatcherConfigurationImpl;)Llove/forte/simbot/core/event/impl/SimpleEventInterceptors;
+}
+
+public final class love/forte/simbot/core/event/impl/SimpleEventInterceptorInvoker : java/lang/Comparable, love/forte/simbot/event/EventInterceptor {
+	public fun <init> (Llove/forte/simbot/event/EventInterceptor;I)V
+	public synthetic fun compareTo (Ljava/lang/Object;)I
+	public fun compareTo (Llove/forte/simbot/core/event/impl/SimpleEventInterceptorInvoker;)I
+	public fun intercept (Llove/forte/simbot/event/EventInterceptor$Context;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class love/forte/simbot/core/event/impl/SimpleEventInterceptorRegistrationPropertiesImpl : love/forte/simbot/core/event/SimpleEventInterceptorRegistrationProperties {
+	public fun <init> ()V
+	public fun getPriority ()I
+	public fun setPriority (I)V
+}
+
+public final class love/forte/simbot/core/event/impl/SimpleEventInterceptors {
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Llove/forte/simbot/core/event/impl/SimpleEventInterceptors;
+	public static synthetic fun copy$default (Llove/forte/simbot/core/event/impl/SimpleEventInterceptors;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Llove/forte/simbot/core/event/impl/SimpleEventInterceptors;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDispatchInterceptors ()Ljava/util/List;
+	public final fun getInterceptors ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/core/event/impl/SimpleEventInterceptorsBuilder {
+	public fun <init> ()V
+	public final fun addDispatchInterceptor (Llove/forte/simbot/event/EventDispatchInterceptor;Llove/forte/simbot/common/function/ConfigurerFunction;)V
+	public static synthetic fun addDispatchInterceptor$default (Llove/forte/simbot/core/event/impl/SimpleEventInterceptorsBuilder;Llove/forte/simbot/event/EventDispatchInterceptor;Llove/forte/simbot/common/function/ConfigurerFunction;ILjava/lang/Object;)V
+	public final fun addInterceptor (Llove/forte/simbot/event/EventInterceptor;Llove/forte/simbot/common/function/ConfigurerFunction;)V
+	public static synthetic fun addInterceptor$default (Llove/forte/simbot/core/event/impl/SimpleEventInterceptorsBuilder;Llove/forte/simbot/event/EventInterceptor;Llove/forte/simbot/common/function/ConfigurerFunction;ILjava/lang/Object;)V
+	public final fun build ()Llove/forte/simbot/core/event/impl/SimpleEventInterceptors;
+}
+
+public final class love/forte/simbot/core/event/impl/SimpleEventInterceptorsInvoker {
+	public fun <init> (Ljava/lang/Iterable;)V
+	public final synthetic fun invoke (Llove/forte/simbot/event/EventListenerContext;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/core/event/impl/SimpleEventListenerRegistrationPropertiesImpl : love/forte/simbot/core/event/SimpleEventListenerRegistrationProperties {
+	public fun <init> (Llove/forte/simbot/core/event/impl/SimpleEventInterceptorsBuilder;)V
+	public fun addInterceptor (Llove/forte/simbot/common/function/ConfigurerFunction;Llove/forte/simbot/event/EventInterceptor;)V
+	public fun getPriority ()I
+	public fun setPriority (I)V
+}
+

--- a/simbot-cores/simbot-core/build.gradle.kts
+++ b/simbot-cores/simbot-core/build.gradle.kts
@@ -4,7 +4,7 @@
  *     Project    https://github.com/simple-robot/simpler-robot
  *     Email      ForteScarlet@163.com
  *
- *     This file is part of the Simple Robot Library.
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Lesser General Public License as published by
@@ -22,7 +22,7 @@
  */
 
 import love.forte.gradle.common.core.project.setup
-import love.forte.plugin.suspendtrans.gradle.withKotlinTargets
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 
 plugins {
     kotlin("multiplatform")
@@ -78,11 +78,11 @@ kotlin {
 //    @Suppress("OPT_IN_USAGE")
 //    wasmWasi()
 
-    withKotlinTargets { target ->
-        targets.findByName(target.name)?.compilations?.all {
-            // 'expect'/'actual' classes (including interfaces, objects, annotations, enums, and 'actual' typealiases) are in Beta. You can use -Xexpect-actual-classes flag to suppress this warning. Also see: https://youtrack.jetbrains.com/issue/KT-61573
-            kotlinOptions.freeCompilerArgs += "-Xexpect-actual-classes"
-        }
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
+    compilerOptions {
+        freeCompilerArgs.addAll(
+            "-Xexpect-actual-classes"
+        )
     }
 
     sourceSets {
@@ -90,7 +90,7 @@ kotlin {
             dependencies {
                 compileOnly(project(":simbot-commons:simbot-common-annotations"))
                 compileOnly(project(":simbot-commons:simbot-common-collection"))
-                compileOnly(libs.suspend.reversal.annotations)
+
                 api(project(":simbot-api"))
                 api(libs.kotlinx.coroutines.core)
                 // api(libs.kotlinx.serialization.core)
@@ -122,7 +122,7 @@ kotlin {
         nativeMain.dependencies {
             api(project(":simbot-commons:simbot-common-annotations"))
             api(project(":simbot-commons:simbot-common-collection"))
-            api(libs.suspend.reversal.annotations)
+
         }
     }
 }

--- a/simbot-cores/simbot-core/src/jvmTest/kotlin/SerTest.kt
+++ b/simbot-cores/simbot-core/src/jvmTest/kotlin/SerTest.kt
@@ -1,0 +1,83 @@
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.overwriteWith
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+@Serializable
+abstract class Base
+
+@Serializable
+@SerialName("T1")
+class T1 : Base()
+
+@Serializable
+@SerialName("T2")
+class T2 : Base()
+
+class SerTest {
+    @Test
+    fun serialTest() {
+        // My distribution
+        val defaultModule = SerializersModule {
+            polymorphic(Base::class) {
+                subclass(T1.serializer())
+                subclass(T2.serializer())
+                defaultDeserializer { T2.serializer() }
+            }
+        }
+        // Clients
+        @Serializable
+        @SerialName("T3")
+        class T3 : Base()
+
+        @Serializable
+        @SerialName("T4")
+        class T4 : Base()
+
+        val clientModule = defaultModule overwriteWith SerializersModule {
+            polymorphic(Base::class) {
+                subclass(T3.serializer())
+                subclass(T4.serializer())
+                defaultDeserializer { T4.serializer() }
+            }
+        }
+
+        val json = Json {
+            isLenient = true
+            serializersModule = clientModule
+        }
+
+        assertIs<T4>(json.decodeFromString(Base.serializer(), """{}"""))
+        assertIs<T1>(json.decodeFromString(Base.serializer(), """{"type": "T1"}"""))
+        assertIs<T2>(json.decodeFromString(Base.serializer(), """{"type": "T2"}"""))
+        assertIs<T3>(json.decodeFromString(Base.serializer(), """{"type": "T3"}"""))
+    }
+}

--- a/simbot-extensions/simbot-extension-continuous-session/api/simbot-extension-continuous-session.api
+++ b/simbot-extensions/simbot-extension-continuous-session/api/simbot-extension-continuous-session.api
@@ -1,0 +1,166 @@
+public abstract class love/forte/simbot/extension/continuous/session/AbstractContinuousSessionContext : love/forte/simbot/extension/continuous/session/ContinuousSessionContext {
+	public fun <init> (Lkotlin/coroutines/CoroutineContext;)V
+	protected abstract fun computeSession (Ljava/lang/Object;Llove/forte/simbot/extension/continuous/session/InSession;)Llove/forte/simbot/extension/continuous/session/ContinuousSessionProvider;
+	public fun contains (Ljava/lang/Object;)Z
+	public fun get (Ljava/lang/Object;)Llove/forte/simbot/extension/continuous/session/ContinuousSessionProvider;
+	protected final fun getLaunchScope ()Lkotlinx/coroutines/CoroutineScope;
+	protected final fun getSessions ()Ljava/util/Map;
+	protected final fun getSubScope ()Lkotlinx/coroutines/CoroutineScope;
+	public fun remove (Ljava/lang/Object;)Llove/forte/simbot/extension/continuous/session/ContinuousSessionProvider;
+	public fun session (Ljava/lang/Object;Llove/forte/simbot/extension/continuous/session/ContinuousSessionContext$ConflictStrategy;Llove/forte/simbot/extension/continuous/session/InSession;)Llove/forte/simbot/extension/continuous/session/ContinuousSessionProvider;
+}
+
+public final class love/forte/simbot/extension/continuous/session/AbstractContinuousSessionContext$inlined$sam$i$java_util_function_BiFunction$0 : java/util/function/BiFunction {
+	public fun <init> (Lkotlin/jvm/functions/Function2;)V
+	public final synthetic fun apply (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/extension/continuous/session/AbstractContinuousSessionContext$inlined$sam$i$java_util_function_Function$0 : java/util/function/Function {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public final synthetic fun apply (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/extension/continuous/session/AsyncInSession : love/forte/simbot/extension/continuous/session/InSession {
+	public abstract fun async (Llove/forte/simbot/extension/continuous/session/ContinuousSessionReceiver;)Ljava/util/concurrent/CompletionStage;
+	public fun invoke (Llove/forte/simbot/extension/continuous/session/ContinuousSessionReceiver;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun invoke$suspendImpl (Llove/forte/simbot/extension/continuous/session/AsyncInSession;Llove/forte/simbot/extension/continuous/session/ContinuousSessionReceiver;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/extension/continuous/session/BlockInSession : love/forte/simbot/extension/continuous/session/InSession {
+	public abstract fun block (Llove/forte/simbot/extension/continuous/session/ContinuousSessionReceiver;)V
+	public fun invoke (Llove/forte/simbot/extension/continuous/session/ContinuousSessionReceiver;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun invoke$suspendImpl (Llove/forte/simbot/extension/continuous/session/BlockInSession;Llove/forte/simbot/extension/continuous/session/ContinuousSessionReceiver;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/extension/continuous/session/ConflictSessionKeyException : java/lang/IllegalArgumentException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public abstract interface class love/forte/simbot/extension/continuous/session/ContinuousSession : love/forte/simbot/extension/continuous/session/ContinuousSessionProvider, love/forte/simbot/extension/continuous/session/ContinuousSessionReceiver {
+}
+
+public abstract interface class love/forte/simbot/extension/continuous/session/ContinuousSessionContext {
+	public abstract fun contains (Ljava/lang/Object;)Z
+	public abstract fun get (Ljava/lang/Object;)Llove/forte/simbot/extension/continuous/session/ContinuousSessionProvider;
+	public abstract fun remove (Ljava/lang/Object;)Llove/forte/simbot/extension/continuous/session/ContinuousSessionProvider;
+	public abstract fun session (Ljava/lang/Object;Llove/forte/simbot/extension/continuous/session/ContinuousSessionContext$ConflictStrategy;Llove/forte/simbot/extension/continuous/session/InSession;)Llove/forte/simbot/extension/continuous/session/ContinuousSessionProvider;
+	public fun session (Ljava/lang/Object;Llove/forte/simbot/extension/continuous/session/InSession;)Llove/forte/simbot/extension/continuous/session/ContinuousSessionProvider;
+	public static synthetic fun session$default (Llove/forte/simbot/extension/continuous/session/ContinuousSessionContext;Ljava/lang/Object;Llove/forte/simbot/extension/continuous/session/ContinuousSessionContext$ConflictStrategy;Llove/forte/simbot/extension/continuous/session/InSession;ILjava/lang/Object;)Llove/forte/simbot/extension/continuous/session/ContinuousSessionProvider;
+}
+
+public final class love/forte/simbot/extension/continuous/session/ContinuousSessionContext$ConflictStrategy : java/lang/Enum {
+	public static final field EXISTING Llove/forte/simbot/extension/continuous/session/ContinuousSessionContext$ConflictStrategy;
+	public static final field FAILURE Llove/forte/simbot/extension/continuous/session/ContinuousSessionContext$ConflictStrategy;
+	public static final field REPLACE Llove/forte/simbot/extension/continuous/session/ContinuousSessionContext$ConflictStrategy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Llove/forte/simbot/extension/continuous/session/ContinuousSessionContext$ConflictStrategy;
+	public static fun values ()[Llove/forte/simbot/extension/continuous/session/ContinuousSessionContext$ConflictStrategy;
+}
+
+public final class love/forte/simbot/extension/continuous/session/ContinuousSessionContexts {
+	public static final fun createContinuousSessionContext (Lkotlin/coroutines/CoroutineContext;)Llove/forte/simbot/extension/continuous/session/ContinuousSessionContext;
+}
+
+public abstract interface class love/forte/simbot/extension/continuous/session/ContinuousSessionProvider : love/forte/simbot/ability/CompletionAware {
+	public fun asFuture ()Ljava/util/concurrent/CompletableFuture;
+	public fun cancel ()V
+	public abstract fun cancel (Ljava/lang/Throwable;)V
+	public abstract fun isActive ()Z
+	public abstract fun isCancelled ()Z
+	public abstract fun isCompleted ()Z
+	public abstract synthetic fun join (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun joinBlocking ()V
+	public fun joinReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun onCompletion (Llove/forte/simbot/ability/OnCompletion;)V
+	public abstract synthetic fun push (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun pushAsync (Ljava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public fun pushBlocking (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun pushReserve (Ljava/lang/Object;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/extension/continuous/session/ContinuousSessionReceiver : kotlinx/coroutines/CoroutineScope {
+	public abstract synthetic fun await (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun await (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun await (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun awaitAsFuture ()Ljava/util/concurrent/CompletableFuture;
+	public fun awaitAsFuture (Ljava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public fun awaitAsFuture (Lkotlin/jvm/functions/Function1;)Ljava/util/concurrent/CompletableFuture;
+	public fun awaitBlocking ()Llove/forte/simbot/extension/continuous/session/SessionContinuation;
+	public fun awaitBlocking (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun awaitBlocking (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun awaitReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun awaitReserve (Ljava/lang/Object;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun awaitReserve (Lkotlin/jvm/functions/Function1;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+}
+
+public final class love/forte/simbot/extension/continuous/session/ContinuousSessions {
+	public static final fun createSimpleSessionContinuation (Ljava/lang/Object;Lkotlinx/coroutines/CancellableContinuation;Lkotlinx/coroutines/DisposableHandle;)Llove/forte/simbot/extension/continuous/session/SessionContinuation;
+	public static synthetic fun createSimpleSessionContinuation$default (Ljava/lang/Object;Lkotlinx/coroutines/CancellableContinuation;Lkotlinx/coroutines/DisposableHandle;ILjava/lang/Object;)Llove/forte/simbot/extension/continuous/session/SessionContinuation;
+}
+
+public abstract interface class love/forte/simbot/extension/continuous/session/EventContinuousSessionContext : love/forte/simbot/extension/continuous/session/ContinuousSessionContext, love/forte/simbot/plugin/Plugin {
+	public static final field Factory Llove/forte/simbot/extension/continuous/session/EventContinuousSessionContext$Factory;
+}
+
+public final class love/forte/simbot/extension/continuous/session/EventContinuousSessionContext$Factory : love/forte/simbot/plugin/PluginFactory {
+	public synthetic fun create (Ljava/lang/Object;Llove/forte/simbot/common/function/ConfigurerFunction;)Ljava/lang/Object;
+	public fun create (Llove/forte/simbot/plugin/PluginConfigureContext;Llove/forte/simbot/common/function/ConfigurerFunction;)Llove/forte/simbot/extension/continuous/session/EventContinuousSessionContext;
+	public synthetic fun getKey ()Llove/forte/simbot/common/function/MergeableFactory$Key;
+	public fun getKey ()Llove/forte/simbot/plugin/PluginFactory$Key;
+}
+
+public final class love/forte/simbot/extension/continuous/session/EventContinuousSessionContextConfiguration {
+	public fun <init> ()V
+	public final fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	public final fun getCoroutineDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public final fun setCoroutineContext (Lkotlin/coroutines/CoroutineContext;)V
+	public final fun setCoroutineDispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)V
+}
+
+public abstract interface class love/forte/simbot/extension/continuous/session/InSession {
+	public abstract synthetic fun invoke (Llove/forte/simbot/extension/continuous/session/ContinuousSessionReceiver;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/extension/continuous/session/InSessions {
+	public static final fun async (Llove/forte/simbot/extension/continuous/session/AsyncInSession;)Llove/forte/simbot/extension/continuous/session/InSession;
+	public static final fun block (Lkotlin/coroutines/CoroutineContext;Llove/forte/simbot/extension/continuous/session/BlockInSession;)Llove/forte/simbot/extension/continuous/session/InSession;
+	public static final fun block (Llove/forte/simbot/extension/continuous/session/BlockInSession;)Llove/forte/simbot/extension/continuous/session/InSession;
+	public static synthetic fun block$default (Lkotlin/coroutines/CoroutineContext;Llove/forte/simbot/extension/continuous/session/BlockInSession;ILjava/lang/Object;)Llove/forte/simbot/extension/continuous/session/InSession;
+	public static final fun mono (Llove/forte/simbot/extension/continuous/session/MonoInSession;)Llove/forte/simbot/extension/continuous/session/InSession;
+}
+
+public abstract interface class love/forte/simbot/extension/continuous/session/MonoInSession : love/forte/simbot/extension/continuous/session/InSession {
+	public fun invoke (Llove/forte/simbot/extension/continuous/session/ContinuousSessionReceiver;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun invoke$suspendImpl (Llove/forte/simbot/extension/continuous/session/MonoInSession;Llove/forte/simbot/extension/continuous/session/ContinuousSessionReceiver;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun mono (Llove/forte/simbot/extension/continuous/session/ContinuousSessionReceiver;)Lreactor/core/publisher/Mono;
+}
+
+public final class love/forte/simbot/extension/continuous/session/ReplacedBecauseOfConflictSessionKeyException : java/lang/IllegalStateException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class love/forte/simbot/extension/continuous/session/SessionAwaitOnFailureException : java/lang/IllegalStateException {
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public final class love/forte/simbot/extension/continuous/session/SessionCompletedWithoutResumeException : java/lang/IllegalStateException {
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public abstract interface class love/forte/simbot/extension/continuous/session/SessionContinuation {
+	public abstract fun getValue ()Ljava/lang/Object;
+	public abstract fun resume (Ljava/lang/Object;)V
+	public abstract fun resumeWithException (Ljava/lang/Throwable;)V
+}
+
+public final class love/forte/simbot/extension/continuous/session/SessionPushOnFailureException : java/lang/IllegalStateException {
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+

--- a/simbot-extensions/simbot-extension-continuous-session/build.gradle.kts
+++ b/simbot-extensions/simbot-extension-continuous-session/build.gradle.kts
@@ -110,14 +110,14 @@ kotlin {
             api(libs.kotlinx.serialization.json)
             api(libs.jetbrains.annotations)
             api(project(":simbot-commons:simbot-common-annotations"))
-            api(libs.suspend.reversal.annotations)
+
         }
 
         jsMain.dependencies {
             api(libs.kotlinx.serialization.json)
             api(project(":simbot-commons:simbot-common-annotations"))
             api(libs.jetbrains.annotations)
-            api(libs.suspend.reversal.annotations)
+
         }
 
         jsTest.dependencies {

--- a/simbot-extensions/simbot-extension-continuous-session/src/commonMain/kotlin/love/forte/simbot/extension/continuous/session/ContinuousSession.kt
+++ b/simbot-extensions/simbot-extension-continuous-session/src/commonMain/kotlin/love/forte/simbot/extension/continuous/session/ContinuousSession.kt
@@ -149,7 +149,7 @@ public interface ContinuousSessionReceiver<out T, R> : CoroutineScope {
      * @throws CancellationException 如果内部的管道已经被关闭或任务已经结束
      * @throws ClosedReceiveChannelException 如果内部的管道的接收已经被关闭
      */
-    @ST(asyncSuffix = "asFuture")
+    @ST(asyncSuffix = "AsFuture")
     public suspend fun await(result: R): T
 
     /**
@@ -170,7 +170,7 @@ public interface ContinuousSessionReceiver<out T, R> : CoroutineScope {
      * @throws CancellationException 如果内部的管道已经被关闭或任务已经结束
      * @throws ClosedReceiveChannelException 如果内部的管道的接收已经被关闭
      */
-    @ST(asyncSuffix = "asFuture")
+    @ST(asyncSuffix = "AsFuture")
     public suspend fun await(result: (T) -> R): T
 
     /**
@@ -215,7 +215,7 @@ public interface ContinuousSessionReceiver<out T, R> : CoroutineScope {
      * @see SessionContinuation
      *
      */
-    @ST(asyncSuffix = "asFuture")
+    @ST(asyncSuffix = "AsFuture")
     public suspend fun await(): SessionContinuation<T, R>
 }
 

--- a/simbot-gradles/simbot-gradle-suspendtransforms/api/simbot-gradle-suspendtransforms.api
+++ b/simbot-gradles/simbot-gradle-suspendtransforms/api/simbot-gradle-suspendtransforms.api
@@ -1,0 +1,15 @@
+public final class love/forte/simbot/gradle/suspendtransforms/SuspendTransforms {
+	public static final field INSTANCE Llove/forte/simbot/gradle/suspendtransforms/SuspendTransforms;
+	public final fun getJsPromiseTransformer ()Llove/forte/plugin/suspendtrans/Transformer;
+	public final fun getJvmAsyncTransformer ()Llove/forte/plugin/suspendtrans/Transformer;
+	public final fun getJvmBlockingTransformer ()Llove/forte/plugin/suspendtrans/Transformer;
+	public final fun getJvmReserveTransformer ()Llove/forte/plugin/suspendtrans/Transformer;
+	public final fun getJvmSuspendTransPropTransformerForAsync ()Llove/forte/plugin/suspendtrans/Transformer;
+	public final fun getJvmSuspendTransPropTransformerForBlocking ()Llove/forte/plugin/suspendtrans/Transformer;
+	public final fun getJvmSuspendTransPropTransformerForReserve ()Llove/forte/plugin/suspendtrans/Transformer;
+	public final fun getSuspendTransTransformerForJsPromise ()Llove/forte/plugin/suspendtrans/Transformer;
+	public final fun getSuspendTransTransformerForJvmAsync ()Llove/forte/plugin/suspendtrans/Transformer;
+	public final fun getSuspendTransTransformerForJvmBlocking ()Llove/forte/plugin/suspendtrans/Transformer;
+	public final fun getSuspendTransTransformerForJvmReserve ()Llove/forte/plugin/suspendtrans/Transformer;
+}
+

--- a/simbot-logger-slf4j2-impl/api/simbot-logger-slf4j2-impl.api
+++ b/simbot-logger-slf4j2-impl/api/simbot-logger-slf4j2-impl.api
@@ -1,0 +1,305 @@
+public final class love/forte/simbot/logger/slf4j2/ConsoleSimbotLoggerProcessor : love/forte/simbot/logger/slf4j2/SimbotLoggerProcessor {
+	public static final field Companion Llove/forte/simbot/logger/slf4j2/ConsoleSimbotLoggerProcessor$Companion;
+	public fun <init> (Llove/forte/simbot/logger/slf4j2/SimbotLoggerConfiguration;)V
+	public fun doHandle (Llove/forte/simbot/logger/slf4j2/LogInfo;)V
+	public fun isLevelEnabled (Ljava/lang/String;Lorg/slf4j/event/Level;Lorg/slf4j/Marker;)Z
+}
+
+public final class love/forte/simbot/logger/slf4j2/ConsoleSimbotLoggerProcessor$Companion {
+}
+
+public final class love/forte/simbot/logger/slf4j2/DefaultSimbotLoggerProcessorsFactory : love/forte/simbot/logger/slf4j2/SimbotLoggerProcessorsFactory {
+	public static final field INSTANCE Llove/forte/simbot/logger/slf4j2/DefaultSimbotLoggerProcessorsFactory;
+	public fun getProcessors (Llove/forte/simbot/logger/slf4j2/SimbotLoggerConfiguration;)Ljava/util/List;
+}
+
+public final class love/forte/simbot/logger/slf4j2/DispatchMode : java/lang/Enum {
+	public static final field ASYNC Llove/forte/simbot/logger/slf4j2/DispatchMode;
+	public static final field Companion Llove/forte/simbot/logger/slf4j2/DispatchMode$Companion;
+	public static final field DISRUPTOR Llove/forte/simbot/logger/slf4j2/DispatchMode;
+	public static final field SYNC Llove/forte/simbot/logger/slf4j2/DispatchMode;
+	public static final fun find (Ljava/lang/String;)Llove/forte/simbot/logger/slf4j2/DispatchMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Llove/forte/simbot/logger/slf4j2/DispatchMode;
+	public static fun values ()[Llove/forte/simbot/logger/slf4j2/DispatchMode;
+}
+
+public final class love/forte/simbot/logger/slf4j2/DispatchMode$Companion {
+	public final fun find (Ljava/lang/String;)Llove/forte/simbot/logger/slf4j2/DispatchMode;
+}
+
+public final class love/forte/simbot/logger/slf4j2/LogInfo {
+	public static final field Companion Llove/forte/simbot/logger/slf4j2/LogInfo$Companion;
+	public fun <init> (Lorg/slf4j/event/Level;Lorg/slf4j/Marker;Ljava/lang/String;[Ljava/lang/Object;Ljava/lang/Throwable;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Thread;J)V
+	public final fun getArgs ()[Ljava/lang/Object;
+	public final fun getError ()Ljava/lang/Throwable;
+	public final fun getFormattedMsg ()Ljava/lang/String;
+	public final fun getFullName ()Ljava/lang/String;
+	public final fun getLevel ()Lorg/slf4j/event/Level;
+	public final fun getMarker ()Lorg/slf4j/Marker;
+	public final fun getMsg ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getThread ()Ljava/lang/Thread;
+	public final fun getTimestamp ()J
+}
+
+public final class love/forte/simbot/logger/slf4j2/LogInfo$Companion {
+}
+
+public final class love/forte/simbot/logger/slf4j2/SimbotLogger : org/slf4j/Logger {
+	public static final field Companion Llove/forte/simbot/logger/slf4j2/SimbotLogger$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;)V
+	public fun debug (Ljava/lang/String;)V
+	public fun debug (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun debug (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun debug (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun debug (Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun debug (Lorg/slf4j/Marker;Ljava/lang/String;)V
+	public fun debug (Lorg/slf4j/Marker;Ljava/lang/String;Ljava/lang/Object;)V
+	public fun debug (Lorg/slf4j/Marker;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun debug (Lorg/slf4j/Marker;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun debug (Lorg/slf4j/Marker;Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun error (Ljava/lang/String;)V
+	public fun error (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun error (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun error (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun error (Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun error (Lorg/slf4j/Marker;Ljava/lang/String;)V
+	public fun error (Lorg/slf4j/Marker;Ljava/lang/String;Ljava/lang/Object;)V
+	public fun error (Lorg/slf4j/Marker;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun error (Lorg/slf4j/Marker;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun error (Lorg/slf4j/Marker;Ljava/lang/String;[Ljava/lang/Object;)V
+	public final fun getFullyQualifiedCallerName ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun info (Ljava/lang/String;)V
+	public fun info (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun info (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun info (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun info (Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun info (Lorg/slf4j/Marker;Ljava/lang/String;)V
+	public fun info (Lorg/slf4j/Marker;Ljava/lang/String;Ljava/lang/Object;)V
+	public fun info (Lorg/slf4j/Marker;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun info (Lorg/slf4j/Marker;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun info (Lorg/slf4j/Marker;Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun isDebugEnabled ()Z
+	public fun isDebugEnabled (Lorg/slf4j/Marker;)Z
+	public fun isErrorEnabled ()Z
+	public fun isErrorEnabled (Lorg/slf4j/Marker;)Z
+	public fun isInfoEnabled ()Z
+	public fun isInfoEnabled (Lorg/slf4j/Marker;)Z
+	public fun isTraceEnabled ()Z
+	public fun isTraceEnabled (Lorg/slf4j/Marker;)Z
+	public fun isWarnEnabled ()Z
+	public fun isWarnEnabled (Lorg/slf4j/Marker;)Z
+	public fun trace (Ljava/lang/String;)V
+	public fun trace (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun trace (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun trace (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun trace (Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun trace (Lorg/slf4j/Marker;Ljava/lang/String;)V
+	public fun trace (Lorg/slf4j/Marker;Ljava/lang/String;Ljava/lang/Object;)V
+	public fun trace (Lorg/slf4j/Marker;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun trace (Lorg/slf4j/Marker;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun trace (Lorg/slf4j/Marker;Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun warn (Ljava/lang/String;)V
+	public fun warn (Ljava/lang/String;Ljava/lang/Object;)V
+	public fun warn (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun warn (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun warn (Ljava/lang/String;[Ljava/lang/Object;)V
+	public fun warn (Lorg/slf4j/Marker;Ljava/lang/String;)V
+	public fun warn (Lorg/slf4j/Marker;Ljava/lang/String;Ljava/lang/Object;)V
+	public fun warn (Lorg/slf4j/Marker;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun warn (Lorg/slf4j/Marker;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun warn (Lorg/slf4j/Marker;Ljava/lang/String;[Ljava/lang/Object;)V
+}
+
+public final class love/forte/simbot/logger/slf4j2/SimbotLogger$Companion {
+}
+
+public abstract class love/forte/simbot/logger/slf4j2/SimbotLoggerConfiguration {
+	public static final field Companion Llove/forte/simbot/logger/slf4j2/SimbotLoggerConfiguration$Companion;
+	public static final field DEBUG_PROPERTY Ljava/lang/String;
+	public static final field DEFAULT_LEVEL_PROPERTY Ljava/lang/String;
+	public static final field DISPATCH_MODE_PROPERTY Ljava/lang/String;
+	public static final field JVM_PROPERTY_PREFIX Ljava/lang/String;
+	public fun <init> ()V
+	public fun get (Ljava/lang/String;)Llove/forte/simbot/logger/slf4j2/SimbotLoggerConfiguration$Property;
+	public abstract fun getDebug ()Z
+	public abstract fun getDefaultLevel ()Lorg/slf4j/event/Level;
+	public abstract fun getDispatcherMode ()Llove/forte/simbot/logger/slf4j2/DispatchMode;
+	public abstract fun getPrefixLevelList ()Ljava/util/List;
+	public abstract fun getProperties ()Ljava/util/Map;
+}
+
+public final class love/forte/simbot/logger/slf4j2/SimbotLoggerConfiguration$Companion {
+}
+
+public abstract interface class love/forte/simbot/logger/slf4j2/SimbotLoggerConfiguration$PrefixLogLevel {
+	public abstract fun getLevel ()Lorg/slf4j/event/Level;
+	public abstract fun getPrefix ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/logger/slf4j2/SimbotLoggerConfiguration$Property {
+	public abstract fun getKey ()Ljava/lang/String;
+	public abstract fun getStringValue ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/logger/slf4j2/SimbotLoggerFactory : org/slf4j/ILoggerFactory {
+	public static final field Companion Llove/forte/simbot/logger/slf4j2/SimbotLoggerFactory$Companion;
+	public fun <init> (Ljava/util/List;Llove/forte/simbot/logger/slf4j2/SimbotLoggerConfiguration;)V
+	public fun getLogger (Ljava/lang/String;)Lorg/slf4j/Logger;
+}
+
+public final class love/forte/simbot/logger/slf4j2/SimbotLoggerFactory$Companion {
+}
+
+public abstract interface class love/forte/simbot/logger/slf4j2/SimbotLoggerProcessor {
+	public abstract fun doHandle (Llove/forte/simbot/logger/slf4j2/LogInfo;)V
+	public abstract fun isLevelEnabled (Ljava/lang/String;Lorg/slf4j/event/Level;Lorg/slf4j/Marker;)Z
+}
+
+public final class love/forte/simbot/logger/slf4j2/SimbotLoggerProcessorKt {
+	public static final fun doHandleIfLevelEnabled (Llove/forte/simbot/logger/slf4j2/SimbotLoggerProcessor;Llove/forte/simbot/logger/slf4j2/LogInfo;)V
+}
+
+public abstract interface class love/forte/simbot/logger/slf4j2/SimbotLoggerProcessorsFactory {
+	public abstract fun getProcessors (Llove/forte/simbot/logger/slf4j2/SimbotLoggerConfiguration;)Ljava/util/List;
+}
+
+public final class love/forte/simbot/logger/slf4j2/SimbotLoggerProvider : org/slf4j/spi/SLF4JServiceProvider {
+	public static final field Companion Llove/forte/simbot/logger/slf4j2/SimbotLoggerProvider$Companion;
+	public fun <init> ()V
+	public fun getLoggerFactory ()Lorg/slf4j/ILoggerFactory;
+	public fun getMDCAdapter ()Lorg/slf4j/spi/MDCAdapter;
+	public fun getMarkerFactory ()Lorg/slf4j/IMarkerFactory;
+	public fun getRequestedApiVersion ()Ljava/lang/String;
+	public fun initialize ()V
+}
+
+public final class love/forte/simbot/logger/slf4j2/SimbotLoggerProvider$Companion {
+}
+
+public final class love/forte/simbot/logger/slf4j2/color/BackGroundColor : java/lang/Enum, love/forte/simbot/logger/slf4j2/color/Color {
+	public static final field BLACK Llove/forte/simbot/logger/slf4j2/color/BackGroundColor;
+	public static final field BLUE Llove/forte/simbot/logger/slf4j2/color/BackGroundColor;
+	public static final field Companion Llove/forte/simbot/logger/slf4j2/color/BackGroundColor$Companion;
+	public static final field DARK_GREEN Llove/forte/simbot/logger/slf4j2/color/BackGroundColor;
+	public static final field DARK_RED Llove/forte/simbot/logger/slf4j2/color/BackGroundColor;
+	public static final field GREEN Llove/forte/simbot/logger/slf4j2/color/BackGroundColor;
+	public static final field PURPLE Llove/forte/simbot/logger/slf4j2/color/BackGroundColor;
+	public static final field WHITE Llove/forte/simbot/logger/slf4j2/color/BackGroundColor;
+	public static final field YELLOW Llove/forte/simbot/logger/slf4j2/color/BackGroundColor;
+	public static final fun getColor (I)Llove/forte/simbot/logger/slf4j2/color/BackGroundColor;
+	public fun getColorIndex ()I
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getPrefix ()Ljava/lang/String;
+	public fun getSuffix ()Ljava/lang/String;
+	public fun isBackGround ()Z
+	public fun isFont ()Z
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Llove/forte/simbot/logger/slf4j2/color/BackGroundColor;
+	public static fun values ()[Llove/forte/simbot/logger/slf4j2/color/BackGroundColor;
+}
+
+public final class love/forte/simbot/logger/slf4j2/color/BackGroundColor$Companion {
+	public final fun getColor (I)Llove/forte/simbot/logger/slf4j2/color/BackGroundColor;
+}
+
+public abstract interface class love/forte/simbot/logger/slf4j2/color/Color {
+	public abstract fun getColorIndex ()I
+	public abstract fun getPrefix ()Ljava/lang/String;
+	public abstract fun getSuffix ()Ljava/lang/String;
+	public abstract fun isBackGround ()Z
+	public abstract fun isFont ()Z
+}
+
+public final class love/forte/simbot/logger/slf4j2/color/Color$DefaultImpls {
+	public static fun isBackGround (Llove/forte/simbot/logger/slf4j2/color/Color;)Z
+	public static fun isFont (Llove/forte/simbot/logger/slf4j2/color/Color;)Z
+}
+
+public final class love/forte/simbot/logger/slf4j2/color/ColorKt {
+	public static final fun appendColor (Ljava/lang/StringBuilder;Llove/forte/simbot/logger/slf4j2/color/Color;C)Ljava/lang/StringBuilder;
+	public static final fun appendColor (Ljava/lang/StringBuilder;Llove/forte/simbot/logger/slf4j2/color/Color;Ljava/lang/String;)Ljava/lang/StringBuilder;
+	public static final fun appendColorPrefix (Ljava/lang/StringBuilder;Llove/forte/simbot/logger/slf4j2/color/Color;)Ljava/lang/StringBuilder;
+	public static final fun appendColorSuffix (Ljava/lang/StringBuilder;Llove/forte/simbot/logger/slf4j2/color/Color;)Ljava/lang/StringBuilder;
+	public static final fun decorativeColor (Ljava/lang/String;Llove/forte/simbot/logger/slf4j2/color/Color;)Ljava/lang/String;
+}
+
+public final class love/forte/simbot/logger/slf4j2/color/FontColor : java/lang/Enum, love/forte/simbot/logger/slf4j2/color/Color {
+	public static final field BLACK Llove/forte/simbot/logger/slf4j2/color/FontColor;
+	public static final field BLUE Llove/forte/simbot/logger/slf4j2/color/FontColor;
+	public static final field Companion Llove/forte/simbot/logger/slf4j2/color/FontColor$Companion;
+	public static final field DARK_GREEN Llove/forte/simbot/logger/slf4j2/color/FontColor;
+	public static final field GREEN Llove/forte/simbot/logger/slf4j2/color/FontColor;
+	public static final field PURPLE Llove/forte/simbot/logger/slf4j2/color/FontColor;
+	public static final field RED Llove/forte/simbot/logger/slf4j2/color/FontColor;
+	public static final field WHITE Llove/forte/simbot/logger/slf4j2/color/FontColor;
+	public static final field YELLOW Llove/forte/simbot/logger/slf4j2/color/FontColor;
+	public static final fun getColor (I)Llove/forte/simbot/logger/slf4j2/color/FontColor;
+	public fun getColorIndex ()I
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getPrefix ()Ljava/lang/String;
+	public fun getSuffix ()Ljava/lang/String;
+	public fun isBackGround ()Z
+	public fun isFont ()Z
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Llove/forte/simbot/logger/slf4j2/color/FontColor;
+	public static fun values ()[Llove/forte/simbot/logger/slf4j2/color/FontColor;
+}
+
+public final class love/forte/simbot/logger/slf4j2/color/FontColor$Companion {
+	public final fun getColor (I)Llove/forte/simbot/logger/slf4j2/color/FontColor;
+}
+
+public final class love/forte/simbot/logger/slf4j2/dispatcher/AsyncDispatcher : love/forte/simbot/logger/slf4j2/dispatcher/LogDispatcher {
+	public static final field CORE_POOL_SIZE_KEY Ljava/lang/String;
+	public static final field DAEMON_KEY Ljava/lang/String;
+	public static final field Factory Llove/forte/simbot/logger/slf4j2/dispatcher/AsyncDispatcher$Factory;
+	public static final field KEEP_ALIVE_TIME_MS_KEY Ljava/lang/String;
+	public static final field MAXIMUM_POOL_SIZE_KEY Ljava/lang/String;
+	public static final field PREFIX_KEY Ljava/lang/String;
+	public static final field THREAD_GROUP_NAME_KEY Ljava/lang/String;
+	public static final field TIME_UNIT_KEY Ljava/lang/String;
+	public fun <init> (Ljava/util/List;Llove/forte/simbot/logger/slf4j2/SimbotLoggerConfiguration;)V
+	public fun close ()V
+	public fun onLog (Llove/forte/simbot/logger/slf4j2/LogInfo;)V
+}
+
+public final class love/forte/simbot/logger/slf4j2/dispatcher/AsyncDispatcher$Factory : love/forte/simbot/logger/slf4j2/dispatcher/LogDispatcherFactory {
+	public fun create (Ljava/util/List;Llove/forte/simbot/logger/slf4j2/SimbotLoggerConfiguration;)Llove/forte/simbot/logger/slf4j2/dispatcher/LogDispatcher;
+}
+
+public final class love/forte/simbot/logger/slf4j2/dispatcher/DisruptorDispatcher : love/forte/simbot/logger/slf4j2/dispatcher/LogDispatcher {
+	public static final field Companion Llove/forte/simbot/logger/slf4j2/dispatcher/DisruptorDispatcher$Companion;
+	public static final field PREFIX_KEY Ljava/lang/String;
+	public static final field RING_BUFFER_SIZE_KEY Ljava/lang/String;
+	public static final field THREAD_GROUP_NAME_KEY Ljava/lang/String;
+	public fun close ()V
+	public fun onLog (Llove/forte/simbot/logger/slf4j2/LogInfo;)V
+}
+
+public final class love/forte/simbot/logger/slf4j2/dispatcher/DisruptorDispatcher$Companion : love/forte/simbot/logger/slf4j2/dispatcher/LogDispatcherFactory {
+	public fun create (Ljava/util/List;Llove/forte/simbot/logger/slf4j2/SimbotLoggerConfiguration;)Llove/forte/simbot/logger/slf4j2/dispatcher/LogDispatcher;
+}
+
+public abstract interface class love/forte/simbot/logger/slf4j2/dispatcher/LogDispatcher : java/io/Closeable {
+	public abstract fun close ()V
+	public abstract fun onLog (Llove/forte/simbot/logger/slf4j2/LogInfo;)V
+}
+
+public abstract interface class love/forte/simbot/logger/slf4j2/dispatcher/LogDispatcherFactory {
+	public abstract fun create (Ljava/util/List;Llove/forte/simbot/logger/slf4j2/SimbotLoggerConfiguration;)Llove/forte/simbot/logger/slf4j2/dispatcher/LogDispatcher;
+}
+
+public final class love/forte/simbot/logger/slf4j2/dispatcher/SyncDispatcher : love/forte/simbot/logger/slf4j2/dispatcher/LogDispatcher {
+	public static final field Factory Llove/forte/simbot/logger/slf4j2/dispatcher/SyncDispatcher$Factory;
+	public fun <init> (Ljava/util/List;)V
+	public fun close ()V
+	public fun onLog (Llove/forte/simbot/logger/slf4j2/LogInfo;)V
+}
+
+public final class love/forte/simbot/logger/slf4j2/dispatcher/SyncDispatcher$Factory : love/forte/simbot/logger/slf4j2/dispatcher/LogDispatcherFactory {
+	public fun create (Ljava/util/List;Llove/forte/simbot/logger/slf4j2/SimbotLoggerConfiguration;)Llove/forte/simbot/logger/slf4j2/dispatcher/LogDispatcher;
+}
+

--- a/simbot-logger/api/simbot-logger.api
+++ b/simbot-logger/api/simbot-logger.api
@@ -1,0 +1,48 @@
+public final class love/forte/simbot/logger/LoggerFactory {
+	public static final field INSTANCE Llove/forte/simbot/logger/LoggerFactory;
+	public static final fun getLogger (Ljava/lang/Class;)Lorg/slf4j/Logger;
+	public static final fun getLogger (Ljava/lang/String;)Lorg/slf4j/Logger;
+	public static final fun getLogger (Lkotlin/reflect/KClass;)Lorg/slf4j/Logger;
+}
+
+public final class love/forte/simbot/logger/LoggerKt {
+	public static final fun getName (Lorg/slf4j/Logger;)Ljava/lang/String;
+	public static final fun isDebugEnabled (Lorg/slf4j/Logger;)Z
+	public static final fun isErrorEnabled (Lorg/slf4j/Logger;)Z
+	public static final fun isInfoEnabled (Lorg/slf4j/Logger;)Z
+	public static final fun isTraceEnabled (Lorg/slf4j/Logger;)Z
+	public static final fun isWarnEnabled (Lorg/slf4j/Logger;)Z
+}
+
+public abstract class love/forte/simbot/logger/internal/AbstractSimpleLogger : org/slf4j/Logger {
+	public fun <init> ()V
+	public fun debug (Ljava/lang/String;)V
+	public fun debug (Ljava/lang/String;[Ljava/lang/Object;)V
+	protected abstract fun debug0 (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public static synthetic fun debug0$default (Llove/forte/simbot/logger/internal/AbstractSimpleLogger;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public fun error (Ljava/lang/String;)V
+	public fun error (Ljava/lang/String;[Ljava/lang/Object;)V
+	protected abstract fun error0 (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public static synthetic fun error0$default (Llove/forte/simbot/logger/internal/AbstractSimpleLogger;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	protected abstract fun getDisplayName ()Ljava/lang/String;
+	protected abstract fun getLevel ()Lorg/slf4j/event/Level;
+	public abstract fun getName ()Ljava/lang/String;
+	public fun info (Ljava/lang/String;)V
+	public fun info (Ljava/lang/String;[Ljava/lang/Object;)V
+	protected abstract fun info0 (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public static synthetic fun info0$default (Llove/forte/simbot/logger/internal/AbstractSimpleLogger;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public fun isDebugEnabled ()Z
+	public fun isErrorEnabled ()Z
+	public fun isInfoEnabled ()Z
+	public fun isTraceEnabled ()Z
+	public fun isWarnEnabled ()Z
+	public fun trace (Ljava/lang/String;)V
+	public fun trace (Ljava/lang/String;[Ljava/lang/Object;)V
+	protected abstract fun trace0 (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public static synthetic fun trace0$default (Llove/forte/simbot/logger/internal/AbstractSimpleLogger;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public fun warn (Ljava/lang/String;)V
+	public fun warn (Ljava/lang/String;[Ljava/lang/Object;)V
+	protected abstract fun warn0 (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public static synthetic fun warn0$default (Llove/forte/simbot/logger/internal/AbstractSimpleLogger;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+}
+

--- a/simbot-logger/build.gradle.kts
+++ b/simbot-logger/build.gradle.kts
@@ -4,7 +4,7 @@
  *     Project    https://github.com/simple-robot/simpler-robot
  *     Email      ForteScarlet@163.com
  *
- *     This file is part of the Simple Robot Library.
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Lesser General Public License as published by
@@ -25,7 +25,7 @@ import love.forte.gradle.common.core.project.setup
 import love.forte.gradle.common.kotlin.multiplatform.applyTier1
 import love.forte.gradle.common.kotlin.multiplatform.applyTier2
 import love.forte.gradle.common.kotlin.multiplatform.applyTier3
-import love.forte.plugin.suspendtrans.gradle.withKotlinTargets
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 /*
@@ -70,11 +70,11 @@ kotlin {
         binaries.library()
     }
 
-    withKotlinTargets { target ->
-        targets.findByName(target.name)?.compilations?.all {
-            // 'expect'/'actual' classes (including interfaces, objects, annotations, enums, and 'actual' typealiases) are in Beta. You can use -Xexpect-actual-classes flag to suppress this warning. Also see: https://youtrack.jetbrains.com/issue/KT-61573
-            kotlinOptions.freeCompilerArgs += "-Xexpect-actual-classes"
-        }
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
+    compilerOptions {
+        freeCompilerArgs.addAll(
+            "-Xexpect-actual-classes"
+        )
     }
 
     sourceSets {

--- a/simbot-quantcat/simbot-quantcat-annotations/build.gradle.kts
+++ b/simbot-quantcat/simbot-quantcat-annotations/build.gradle.kts
@@ -4,7 +4,7 @@
  *     Project    https://github.com/simple-robot/simpler-robot
  *     Email      ForteScarlet@163.com
  *
- *     This file is part of the Simple Robot Library.
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Lesser General Public License as published by
@@ -96,7 +96,7 @@ kotlin {
         commonMain {
             dependencies {
                 compileOnly(project(":simbot-api"))
-                compileOnly(libs.suspend.reversal.annotations)
+                // compileOnly(libs.suspend.reversal.annotations)
                 compileOnly(project(":simbot-commons:simbot-common-annotations"))
                 compileOnly(project(":simbot-quantcat:simbot-quantcat-common"))
             }
@@ -120,14 +120,14 @@ kotlin {
 
         jsMain.dependencies {
             implementation(project(":simbot-api"))
-            implementation(libs.suspend.reversal.annotations)
+            // implementation(libs.suspend.reversal.annotations)
             implementation(project(":simbot-commons:simbot-common-annotations"))
             implementation(project(":simbot-quantcat:simbot-quantcat-common"))
         }
 
         jsMain.dependencies {
             api(project(":simbot-api"))
-            api(libs.suspend.reversal.annotations)
+            // api(libs.suspend.reversal.annotations)
             api(project(":simbot-commons:simbot-common-annotations"))
             api(project(":simbot-quantcat:simbot-quantcat-common"))
         }

--- a/simbot-quantcat/simbot-quantcat-common/api/simbot-quantcat-common.api
+++ b/simbot-quantcat/simbot-quantcat-common/api/simbot-quantcat-common.api
@@ -1,0 +1,440 @@
+public abstract interface annotation class love/forte/simbot/quantcat/common/annotations/ApplyBinder : java/lang/annotation/Annotation {
+	public abstract fun factories ()[Ljava/lang/Class;
+	public abstract fun value ()[Ljava/lang/String;
+}
+
+public abstract interface annotation class love/forte/simbot/quantcat/common/annotations/Binder : java/lang/annotation/Annotation {
+	public abstract fun id ()Ljava/lang/String;
+	public abstract fun scope ()Llove/forte/simbot/quantcat/common/annotations/Binder$Scope;
+}
+
+public final class love/forte/simbot/quantcat/common/annotations/Binder$Scope : java/lang/Enum {
+	public static final field DEFAULT Llove/forte/simbot/quantcat/common/annotations/Binder$Scope;
+	public static final field GLOBAL Llove/forte/simbot/quantcat/common/annotations/Binder$Scope;
+	public static final field SPECIFY Llove/forte/simbot/quantcat/common/annotations/Binder$Scope;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Llove/forte/simbot/quantcat/common/annotations/Binder$Scope;
+	public static fun values ()[Llove/forte/simbot/quantcat/common/annotations/Binder$Scope;
+}
+
+public abstract interface annotation class love/forte/simbot/quantcat/common/annotations/ContentTrim : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class love/forte/simbot/quantcat/common/annotations/Filter : java/lang/annotation/Annotation {
+	public abstract fun ifNullPass ()Z
+	public abstract fun matchType ()Llove/forte/simbot/quantcat/common/filter/MatchType;
+	public abstract fun mode ()Llove/forte/simbot/quantcat/common/filter/FilterMode;
+	public abstract fun priority ()I
+	public abstract fun targets ()[Llove/forte/simbot/quantcat/common/annotations/Filter$Targets;
+	public abstract fun value ()Ljava/lang/String;
+}
+
+public abstract interface annotation class love/forte/simbot/quantcat/common/annotations/Filter$Container : java/lang/annotation/Annotation {
+	public abstract fun value ()[Llove/forte/simbot/quantcat/common/annotations/Filter;
+}
+
+public abstract interface annotation class love/forte/simbot/quantcat/common/annotations/Filter$Targets : java/lang/annotation/Annotation {
+	public static final field Companion Llove/forte/simbot/quantcat/common/annotations/Filter$Targets$Companion;
+	public static final field NON_PREFIX Ljava/lang/String;
+	public abstract fun actors ()[Ljava/lang/String;
+	public abstract fun atBot ()Z
+	public abstract fun ats ()[Ljava/lang/String;
+	public abstract fun authors ()[Ljava/lang/String;
+	public abstract fun bots ()[Ljava/lang/String;
+	public abstract fun chatRooms ()[Ljava/lang/String;
+	public abstract fun components ()[Ljava/lang/String;
+	public abstract fun contacts ()[Ljava/lang/String;
+	public abstract fun groups ()[Ljava/lang/String;
+	public abstract fun guilds ()[Ljava/lang/String;
+	public abstract fun organizations ()[Ljava/lang/String;
+}
+
+public final class love/forte/simbot/quantcat/common/annotations/Filter$Targets$Companion {
+	public static final field NON_PREFIX Ljava/lang/String;
+}
+
+public final class love/forte/simbot/quantcat/common/annotations/FilterKt {
+	public static final fun toProperties (Llove/forte/simbot/quantcat/common/annotations/Filter$Targets;)Llove/forte/simbot/quantcat/common/filter/FilterTargetsProperties;
+	public static final fun toProperties (Llove/forte/simbot/quantcat/common/annotations/Filter;)Llove/forte/simbot/quantcat/common/filter/FilterProperties;
+}
+
+public abstract interface annotation class love/forte/simbot/quantcat/common/annotations/FilterValue : java/lang/annotation/Annotation {
+	public abstract fun required ()Z
+	public abstract fun value ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/quantcat/common/annotations/FilterValueKt {
+	public static final fun toProperties (Llove/forte/simbot/quantcat/common/annotations/FilterValue;)Llove/forte/simbot/quantcat/common/filter/FilterValueProperties;
+}
+
+public abstract interface annotation class love/forte/simbot/quantcat/common/annotations/Interceptor : java/lang/annotation/Annotation {
+	public abstract fun priority ()I
+	public abstract fun value ()Ljava/lang/Class;
+}
+
+public abstract interface annotation class love/forte/simbot/quantcat/common/annotations/Interceptor$Container : java/lang/annotation/Annotation {
+	public abstract fun value ()[Llove/forte/simbot/quantcat/common/annotations/Interceptor;
+}
+
+public abstract interface annotation class love/forte/simbot/quantcat/common/annotations/Listener : java/lang/annotation/Annotation {
+	public abstract fun id ()Ljava/lang/String;
+	public abstract fun priority ()I
+}
+
+public abstract interface annotation class love/forte/simbot/quantcat/common/annotations/MultiFilter : java/lang/annotation/Annotation {
+	public abstract fun matchType ()Llove/forte/simbot/quantcat/common/filter/MultiFilterMatchType;
+}
+
+public abstract interface class love/forte/simbot/quantcat/common/binder/BaseParameterBinderFactory$Context {
+	public abstract fun getSource ()Lkotlin/reflect/KFunction;
+}
+
+public class love/forte/simbot/quantcat/common/binder/BindException : java/lang/IllegalStateException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public abstract interface class love/forte/simbot/quantcat/common/binder/BinderManager {
+	public abstract fun get (Ljava/lang/String;)Llove/forte/simbot/quantcat/common/binder/ParameterBinderFactory;
+	public abstract fun getGlobalBinderFactorySize ()I
+	public abstract fun getGlobals ()Ljava/util/List;
+	public abstract fun getNormalBinderFactorySize ()I
+}
+
+public abstract class love/forte/simbot/quantcat/common/binder/FunctionalBindableEventListener : love/forte/simbot/quantcat/common/listener/FunctionalEventListener {
+	public fun <init> (Ljava/lang/Object;Lkotlin/reflect/KFunction;Lkotlin/coroutines/CoroutineContext;)V
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/reflect/KFunction;Lkotlin/coroutines/CoroutineContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	protected fun convertValue (Ljava/lang/Object;Lkotlin/reflect/KParameter;)Ljava/lang/Object;
+	protected abstract fun getBinders ()[Llove/forte/simbot/quantcat/common/binder/ParameterBinder;
+	public final fun getCaller ()Lkotlin/reflect/KFunction;
+	public fun handle (Llove/forte/simbot/event/EventListenerContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected abstract fun match (Llove/forte/simbot/event/EventListenerContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected fun resultProcess (Ljava/lang/Object;)Llove/forte/simbot/event/EventResult;
+}
+
+public abstract interface class love/forte/simbot/quantcat/common/binder/ParameterBinder {
+	public abstract fun arg-IoAF18A (Llove/forte/simbot/event/EventListenerContext;)Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/quantcat/common/binder/ParameterBinder$Ignore {
+	public static final field INSTANCE Llove/forte/simbot/quantcat/common/binder/ParameterBinder$Ignore;
+}
+
+public abstract interface class love/forte/simbot/quantcat/common/binder/ParameterBinderFactory : love/forte/simbot/quantcat/common/binder/BaseParameterBinderFactory {
+	public fun getPriority ()I
+	public abstract fun resolveToBinder (Llove/forte/simbot/quantcat/common/binder/ParameterBinderFactory$Context;)Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult;
+}
+
+public abstract interface class love/forte/simbot/quantcat/common/binder/ParameterBinderFactory$Context : love/forte/simbot/quantcat/common/binder/BaseParameterBinderFactory$Context {
+	public abstract fun getParameter ()Lkotlin/reflect/KParameter;
+	public fun getParameterType ()Ljava/lang/Class;
+	public abstract fun getSource ()Lkotlin/reflect/KFunction;
+	public fun getSourceMethod ()Ljava/lang/reflect/Method;
+}
+
+public abstract interface class love/forte/simbot/quantcat/common/binder/ParameterBinderFactoryContainer {
+	public abstract fun get (Ljava/lang/String;)Llove/forte/simbot/quantcat/common/binder/ParameterBinderFactory;
+	public abstract fun getGlobals ()Ljava/util/List;
+	public abstract fun resolveFunctionToBinderFactory (Ljava/lang/String;Lkotlin/reflect/KFunction;)Llove/forte/simbot/quantcat/common/binder/ParameterBinderFactory;
+	public static synthetic fun resolveFunctionToBinderFactory$default (Llove/forte/simbot/quantcat/common/binder/ParameterBinderFactoryContainer;Ljava/lang/String;Lkotlin/reflect/KFunction;ILjava/lang/Object;)Llove/forte/simbot/quantcat/common/binder/ParameterBinderFactory;
+}
+
+public abstract class love/forte/simbot/quantcat/common/binder/ParameterBinderResult {
+	public static final field Companion Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult$Companion;
+	public static final fun empty ()Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult$Empty;
+	public abstract fun getBinder ()Llove/forte/simbot/quantcat/common/binder/ParameterBinder;
+	public fun getPriority ()I
+	public static final fun normal (Llove/forte/simbot/quantcat/common/binder/ParameterBinder;)Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult$NotEmpty;
+	public static final fun normal (Llove/forte/simbot/quantcat/common/binder/ParameterBinder;I)Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult$NotEmpty;
+	public static final fun only (Llove/forte/simbot/quantcat/common/binder/ParameterBinder;)Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult$NotEmpty;
+	public static final fun only (Llove/forte/simbot/quantcat/common/binder/ParameterBinder;I)Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult$NotEmpty;
+	public static final fun spare (Llove/forte/simbot/quantcat/common/binder/ParameterBinder;)Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult$NotEmpty;
+	public static final fun spare (Llove/forte/simbot/quantcat/common/binder/ParameterBinder;I)Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult$NotEmpty;
+}
+
+public final class love/forte/simbot/quantcat/common/binder/ParameterBinderResult$Companion {
+	public final fun empty ()Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult$Empty;
+	public final fun normal (Llove/forte/simbot/quantcat/common/binder/ParameterBinder;)Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult$NotEmpty;
+	public final fun normal (Llove/forte/simbot/quantcat/common/binder/ParameterBinder;I)Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult$NotEmpty;
+	public static synthetic fun normal$default (Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult$Companion;Llove/forte/simbot/quantcat/common/binder/ParameterBinder;IILjava/lang/Object;)Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult$NotEmpty;
+	public final fun only (Llove/forte/simbot/quantcat/common/binder/ParameterBinder;)Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult$NotEmpty;
+	public final fun only (Llove/forte/simbot/quantcat/common/binder/ParameterBinder;I)Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult$NotEmpty;
+	public static synthetic fun only$default (Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult$Companion;Llove/forte/simbot/quantcat/common/binder/ParameterBinder;IILjava/lang/Object;)Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult$NotEmpty;
+	public final fun spare (Llove/forte/simbot/quantcat/common/binder/ParameterBinder;)Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult$NotEmpty;
+	public final fun spare (Llove/forte/simbot/quantcat/common/binder/ParameterBinder;I)Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult$NotEmpty;
+	public static synthetic fun spare$default (Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult$Companion;Llove/forte/simbot/quantcat/common/binder/ParameterBinder;IILjava/lang/Object;)Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult$NotEmpty;
+}
+
+public final class love/forte/simbot/quantcat/common/binder/ParameterBinderResult$Empty : love/forte/simbot/quantcat/common/binder/ParameterBinderResult {
+	public static final field INSTANCE Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult$Empty;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBinder ()Llove/forte/simbot/quantcat/common/binder/ParameterBinder;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/quantcat/common/binder/ParameterBinderResult$Normal : love/forte/simbot/quantcat/common/binder/ParameterBinderResult$NotEmpty {
+	public fun getBinder ()Llove/forte/simbot/quantcat/common/binder/ParameterBinder;
+	public fun getPriority ()I
+}
+
+public abstract class love/forte/simbot/quantcat/common/binder/ParameterBinderResult$NotEmpty : love/forte/simbot/quantcat/common/binder/ParameterBinderResult {
+	public abstract fun getBinder ()Llove/forte/simbot/quantcat/common/binder/ParameterBinder;
+}
+
+public final class love/forte/simbot/quantcat/common/binder/ParameterBinderResult$Only : love/forte/simbot/quantcat/common/binder/ParameterBinderResult$NotEmpty {
+	public fun getBinder ()Llove/forte/simbot/quantcat/common/binder/ParameterBinder;
+	public fun getPriority ()I
+}
+
+public final class love/forte/simbot/quantcat/common/binder/ParameterBinderResult$Spare : love/forte/simbot/quantcat/common/binder/ParameterBinderResult$NotEmpty {
+	public fun getBinder ()Llove/forte/simbot/quantcat/common/binder/ParameterBinder;
+	public fun getPriority ()I
+}
+
+public final class love/forte/simbot/quantcat/common/binder/impl/EmptyBinder : love/forte/simbot/quantcat/common/binder/ParameterBinder {
+	public fun <init> (Lkotlin/reflect/KParameter;)V
+	public fun arg-IoAF18A (Llove/forte/simbot/event/EventListenerContext;)Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/quantcat/common/binder/impl/EventParameterBinderFactory : love/forte/simbot/quantcat/common/binder/ParameterBinderFactory {
+	public static final field INSTANCE Llove/forte/simbot/quantcat/common/binder/impl/EventParameterBinderFactory;
+	public synthetic fun resolveToBinder (Llove/forte/simbot/quantcat/common/binder/BaseParameterBinderFactory$Context;)Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult;
+	public fun resolveToBinder (Llove/forte/simbot/quantcat/common/binder/ParameterBinderFactory$Context;)Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult;
+}
+
+public final class love/forte/simbot/quantcat/common/binder/impl/KeywordBinderFactory : love/forte/simbot/quantcat/common/binder/ParameterBinderFactory {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun resolveToBinder (Llove/forte/simbot/quantcat/common/binder/BaseParameterBinderFactory$Context;)Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult;
+	public fun resolveToBinder (Llove/forte/simbot/quantcat/common/binder/ParameterBinderFactory$Context;)Llove/forte/simbot/quantcat/common/binder/ParameterBinderResult;
+}
+
+public final class love/forte/simbot/quantcat/common/binder/impl/MergedBinder : love/forte/simbot/quantcat/common/binder/ParameterBinder {
+	public fun <init> (Ljava/util/List;Ljava/util/List;Lkotlin/reflect/KParameter;)V
+	public fun arg-IoAF18A (Llove/forte/simbot/event/EventListenerContext;)Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/quantcat/common/convert/ConvertException : java/lang/ClassCastException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Ljava/lang/Object;)V
+}
+
+public final class love/forte/simbot/quantcat/common/filter/FilterMode : java/lang/Enum {
+	public static final field INTERCEPTOR Llove/forte/simbot/quantcat/common/filter/FilterMode;
+	public static final field IN_LISTENER Llove/forte/simbot/quantcat/common/filter/FilterMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Llove/forte/simbot/quantcat/common/filter/FilterMode;
+	public static fun values ()[Llove/forte/simbot/quantcat/common/filter/FilterMode;
+}
+
+public final class love/forte/simbot/quantcat/common/filter/FilterProperties {
+	public fun <init> (Ljava/lang/String;Llove/forte/simbot/quantcat/common/filter/FilterMode;ILjava/util/List;ZLlove/forte/simbot/quantcat/common/filter/MatchType;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Llove/forte/simbot/quantcat/common/filter/FilterMode;
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Z
+	public final fun component6 ()Llove/forte/simbot/quantcat/common/filter/MatchType;
+	public final fun copy (Ljava/lang/String;Llove/forte/simbot/quantcat/common/filter/FilterMode;ILjava/util/List;ZLlove/forte/simbot/quantcat/common/filter/MatchType;)Llove/forte/simbot/quantcat/common/filter/FilterProperties;
+	public static synthetic fun copy$default (Llove/forte/simbot/quantcat/common/filter/FilterProperties;Ljava/lang/String;Llove/forte/simbot/quantcat/common/filter/FilterMode;ILjava/util/List;ZLlove/forte/simbot/quantcat/common/filter/MatchType;ILjava/lang/Object;)Llove/forte/simbot/quantcat/common/filter/FilterProperties;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIfNullPass ()Z
+	public final fun getMatchType ()Llove/forte/simbot/quantcat/common/filter/MatchType;
+	public final fun getMode ()Llove/forte/simbot/quantcat/common/filter/FilterMode;
+	public final fun getPriority ()I
+	public final fun getTargets ()Ljava/util/List;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/quantcat/common/filter/FilterTargetsProperties {
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Z)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component10 ()Ljava/util/List;
+	public final fun component11 ()Z
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Z)Llove/forte/simbot/quantcat/common/filter/FilterTargetsProperties;
+	public static synthetic fun copy$default (Llove/forte/simbot/quantcat/common/filter/FilterTargetsProperties;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZILjava/lang/Object;)Llove/forte/simbot/quantcat/common/filter/FilterTargetsProperties;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActors ()Ljava/util/List;
+	public final fun getAtBot ()Z
+	public final fun getAts ()Ljava/util/List;
+	public final fun getAuthors ()Ljava/util/List;
+	public final fun getBots ()Ljava/util/List;
+	public final fun getChatRooms ()Ljava/util/List;
+	public final fun getComponents ()Ljava/util/List;
+	public final fun getContacts ()Ljava/util/List;
+	public final fun getGroups ()Ljava/util/List;
+	public final fun getGuilds ()Ljava/util/List;
+	public final fun getOrganizations ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/quantcat/common/filter/FilterValueProperties {
+	public fun <init> (Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun copy (Ljava/lang/String;Z)Llove/forte/simbot/quantcat/common/filter/FilterValueProperties;
+	public static synthetic fun copy$default (Llove/forte/simbot/quantcat/common/filter/FilterValueProperties;Ljava/lang/String;ZILjava/lang/Object;)Llove/forte/simbot/quantcat/common/filter/FilterValueProperties;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRequired ()Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/quantcat/common/filter/MatchType : java/lang/Enum {
+	public static final field REGEX_CONTAINS Llove/forte/simbot/quantcat/common/filter/MatchType;
+	public static final field REGEX_MATCHES Llove/forte/simbot/quantcat/common/filter/MatchType;
+	public static final field TEXT_CONTAINS Llove/forte/simbot/quantcat/common/filter/MatchType;
+	public static final field TEXT_ENDS_WITH Llove/forte/simbot/quantcat/common/filter/MatchType;
+	public static final field TEXT_EQUALS Llove/forte/simbot/quantcat/common/filter/MatchType;
+	public static final field TEXT_EQUALS_IGNORE_CASE Llove/forte/simbot/quantcat/common/filter/MatchType;
+	public static final field TEXT_STARTS_WITH Llove/forte/simbot/quantcat/common/filter/MatchType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun isPlainText ()Z
+	public final fun match (Llove/forte/simbot/quantcat/common/keyword/Keyword;Ljava/lang/String;)Z
+	public static fun valueOf (Ljava/lang/String;)Llove/forte/simbot/quantcat/common/filter/MatchType;
+	public static fun values ()[Llove/forte/simbot/quantcat/common/filter/MatchType;
+}
+
+public final class love/forte/simbot/quantcat/common/filter/MultiFilterMatchType : java/lang/Enum {
+	public static final field ALL Llove/forte/simbot/quantcat/common/filter/MultiFilterMatchType;
+	public static final field ANY Llove/forte/simbot/quantcat/common/filter/MultiFilterMatchType;
+	public static final field Companion Llove/forte/simbot/quantcat/common/filter/MultiFilterMatchType$Companion;
+	public static final field NONE Llove/forte/simbot/quantcat/common/filter/MultiFilterMatchType;
+	public static final fun getDefault ()Llove/forte/simbot/quantcat/common/filter/MultiFilterMatchType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Llove/forte/simbot/quantcat/common/filter/MultiFilterMatchType;
+	public static fun values ()[Llove/forte/simbot/quantcat/common/filter/MultiFilterMatchType;
+}
+
+public final class love/forte/simbot/quantcat/common/filter/MultiFilterMatchType$Companion {
+	public final fun getDefault ()Llove/forte/simbot/quantcat/common/filter/MultiFilterMatchType;
+}
+
+public abstract interface class love/forte/simbot/quantcat/common/interceptor/AnnotationEventInterceptorFactory {
+	public abstract fun create (Llove/forte/simbot/quantcat/common/interceptor/AnnotationEventInterceptorFactory$Context;)Llove/forte/simbot/quantcat/common/interceptor/AnnotationEventInterceptorFactory$Result;
+}
+
+public abstract interface class love/forte/simbot/quantcat/common/interceptor/AnnotationEventInterceptorFactory$Context {
+	public abstract fun findAnnotation (Lkotlin/reflect/KClass;)Ljava/lang/annotation/Annotation;
+	public abstract fun findAnnotations (Lkotlin/reflect/KClass;)Ljava/util/List;
+	public abstract fun getFunction ()Lkotlin/reflect/KFunction;
+	public abstract fun getPriority ()I
+}
+
+public abstract class love/forte/simbot/quantcat/common/interceptor/AnnotationEventInterceptorFactory$Result {
+	public static final field Companion Llove/forte/simbot/quantcat/common/interceptor/AnnotationEventInterceptorFactory$Result$Companion;
+	public fun <init> ()V
+	public static final fun build (Llove/forte/simbot/common/function/ConfigurerFunction;)Llove/forte/simbot/quantcat/common/interceptor/AnnotationEventInterceptorFactory$Result;
+	public static final fun builder ()Llove/forte/simbot/quantcat/common/interceptor/AnnotationEventInterceptorFactory$Result$Builder;
+	public abstract fun getConfiguration ()Llove/forte/simbot/common/function/ConfigurerFunction;
+	public abstract fun getInterceptor ()Llove/forte/simbot/event/EventInterceptor;
+}
+
+public abstract interface class love/forte/simbot/quantcat/common/interceptor/AnnotationEventInterceptorFactory$Result$Builder {
+	public abstract fun build ()Llove/forte/simbot/quantcat/common/interceptor/AnnotationEventInterceptorFactory$Result;
+	public abstract fun configuration (Llove/forte/simbot/common/function/ConfigurerFunction;)Llove/forte/simbot/quantcat/common/interceptor/AnnotationEventInterceptorFactory$Result$Builder;
+	public abstract fun interceptor (Llove/forte/simbot/event/EventInterceptor;)Llove/forte/simbot/quantcat/common/interceptor/AnnotationEventInterceptorFactory$Result$Builder;
+}
+
+public final class love/forte/simbot/quantcat/common/interceptor/AnnotationEventInterceptorFactory$Result$Companion {
+	public final fun build (Llove/forte/simbot/common/function/ConfigurerFunction;)Llove/forte/simbot/quantcat/common/interceptor/AnnotationEventInterceptorFactory$Result;
+	public final fun builder ()Llove/forte/simbot/quantcat/common/interceptor/AnnotationEventInterceptorFactory$Result$Builder;
+}
+
+public final class love/forte/simbot/quantcat/common/interceptor/impl/ContentTrimEventInterceptorFactory : love/forte/simbot/quantcat/common/interceptor/impl/StandardAnnotationEventInterceptorFactory {
+	public static final field INSTANCE Llove/forte/simbot/quantcat/common/interceptor/impl/ContentTrimEventInterceptorFactory;
+	public fun create (Llove/forte/simbot/quantcat/common/interceptor/AnnotationEventInterceptorFactory$Context;)Llove/forte/simbot/quantcat/common/interceptor/AnnotationEventInterceptorFactory$Result;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class love/forte/simbot/quantcat/common/interceptor/impl/StandardAnnotationEventInterceptorFactory : love/forte/simbot/quantcat/common/interceptor/AnnotationEventInterceptorFactory {
+}
+
+public final class love/forte/simbot/quantcat/common/keyword/EmptyFilterParameterMatcher : love/forte/simbot/quantcat/common/keyword/ValueMatcher {
+	public static final field INSTANCE Llove/forte/simbot/quantcat/common/keyword/EmptyFilterParameterMatcher;
+	public fun getOriginal ()Ljava/lang/String;
+	public fun getParam (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public fun getParameters (Ljava/lang/String;)Llove/forte/simbot/quantcat/common/keyword/MatchParameters;
+	public fun getRegex ()Lkotlin/text/Regex;
+	public fun matches (Ljava/lang/String;)Z
+}
+
+public final class love/forte/simbot/quantcat/common/keyword/EmptyFilterParameters : love/forte/simbot/quantcat/common/keyword/MatchParameters {
+	public static final field INSTANCE Llove/forte/simbot/quantcat/common/keyword/EmptyFilterParameters;
+	public fun get (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class love/forte/simbot/quantcat/common/keyword/EmptyKeyword : love/forte/simbot/quantcat/common/keyword/Keyword {
+	public static final field INSTANCE Llove/forte/simbot/quantcat/common/keyword/EmptyKeyword;
+	public fun getRegex ()Lkotlin/text/Regex;
+	public fun getRegexValueMatcher ()Llove/forte/simbot/quantcat/common/keyword/ValueMatcher;
+	public fun getText ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/quantcat/common/keyword/Keyword {
+	public abstract fun getRegex ()Lkotlin/text/Regex;
+	public abstract fun getRegexValueMatcher ()Llove/forte/simbot/quantcat/common/keyword/ValueMatcher;
+	public abstract fun getText ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/quantcat/common/keyword/KeywordListAttributeKt {
+	public static final fun getKeywordListAttribute ()Llove/forte/simbot/common/attribute/Attribute;
+}
+
+public abstract interface class love/forte/simbot/quantcat/common/keyword/KeywordMatcher {
+	public abstract fun test (Llove/forte/simbot/quantcat/common/keyword/Keyword;Ljava/lang/String;)Z
+}
+
+public abstract interface class love/forte/simbot/quantcat/common/keyword/MatchParameters {
+	public abstract fun get (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class love/forte/simbot/quantcat/common/keyword/RegexValueMatcher : love/forte/simbot/quantcat/common/keyword/ValueMatcher {
+	public fun <init> (Ljava/lang/String;Z)V
+	public fun getOriginal ()Ljava/lang/String;
+	public fun getParam (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public fun getParameters (Ljava/lang/String;)Llove/forte/simbot/quantcat/common/keyword/MatchParameters;
+	public fun getRegex ()Lkotlin/text/Regex;
+	public fun matches (Ljava/lang/String;)Z
+}
+
+public final class love/forte/simbot/quantcat/common/keyword/SimpleKeyword : love/forte/simbot/quantcat/common/keyword/Keyword {
+	public fun <init> (Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getRegex ()Lkotlin/text/Regex;
+	public fun getRegexValueMatcher ()Llove/forte/simbot/quantcat/common/keyword/ValueMatcher;
+	public fun getText ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/quantcat/common/keyword/ValueMatcher {
+	public abstract fun getOriginal ()Ljava/lang/String;
+	public abstract fun getParam (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public abstract fun getParameters (Ljava/lang/String;)Llove/forte/simbot/quantcat/common/keyword/MatchParameters;
+	public abstract fun getRegex ()Lkotlin/text/Regex;
+	public abstract fun matches (Ljava/lang/String;)Z
+}
+
+public abstract class love/forte/simbot/quantcat/common/listener/FunctionalEventListener : love/forte/simbot/event/EventListener {
+	public fun <init> ()V
+	protected abstract fun getCaller ()Lkotlin/reflect/KFunction;
+}
+

--- a/simbot-quantcat/simbot-quantcat-common/build.gradle.kts
+++ b/simbot-quantcat/simbot-quantcat-common/build.gradle.kts
@@ -4,7 +4,7 @@
  *     Project    https://github.com/simple-robot/simpler-robot
  *     Email      ForteScarlet@163.com
  *
- *     This file is part of the Simple Robot Library.
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Lesser General Public License as published by
@@ -25,7 +25,7 @@ import love.forte.gradle.common.core.project.setup
 import love.forte.gradle.common.kotlin.multiplatform.applyTier1
 import love.forte.gradle.common.kotlin.multiplatform.applyTier2
 import love.forte.gradle.common.kotlin.multiplatform.applyTier3
-import love.forte.plugin.suspendtrans.gradle.withKotlinTargets
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 
 /*
  * Copyright (c) 2023 ForteScarlet.
@@ -64,11 +64,11 @@ kotlin {
     applyTier2()
     applyTier3()
 
-    withKotlinTargets { target ->
-        targets.findByName(target.name)?.compilations?.all {
-            // 'expect'/'actual' classes (including interfaces, objects, annotations, enums, and 'actual' typealiases) are in Beta. You can use -Xexpect-actual-classes flag to suppress this warning. Also see: https://youtrack.jetbrains.com/issue/KT-61573
-            kotlinOptions.freeCompilerArgs += "-Xexpect-actual-classes"
-        }
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
+    compilerOptions {
+        freeCompilerArgs.addAll(
+            "-Xexpect-actual-classes"
+        )
     }
 
     sourceSets {
@@ -76,7 +76,7 @@ kotlin {
             dependencies {
                 compileOnly(project(":simbot-api"))
                 compileOnly(project(":simbot-commons:simbot-common-annotations"))
-                compileOnly(libs.suspend.reversal.annotations)
+
             }
         }
 
@@ -100,13 +100,13 @@ kotlin {
         jsMain.dependencies {
             api(project(":simbot-api"))
             api(project(":simbot-commons:simbot-common-annotations"))
-            api(libs.suspend.reversal.annotations)
+
         }
 
         nativeMain.dependencies {
             api(project(":simbot-api"))
             api(project(":simbot-commons:simbot-common-annotations"))
-            api(libs.suspend.reversal.annotations)
+
         }
     }
 

--- a/simbot-test/build.gradle.kts
+++ b/simbot-test/build.gradle.kts
@@ -22,7 +22,7 @@
  */
 
 import love.forte.gradle.common.core.project.setup
-import love.forte.plugin.suspendtrans.gradle.withKotlinTargets
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 
 plugins {
     kotlin("multiplatform")
@@ -80,11 +80,11 @@ kotlin {
 //    @Suppress("OPT_IN_USAGE")
 //    wasmWasi()
 
-    withKotlinTargets { target ->
-        targets.findByName(target.name)?.compilations?.all {
-            // 'expect'/'actual' classes (including interfaces, objects, annotations, enums, and 'actual' typealiases) are in Beta. You can use -Xexpect-actual-classes flag to suppress this warning. Also see: https://youtrack.jetbrains.com/issue/KT-61573
-            kotlinOptions.freeCompilerArgs += "-Xexpect-actual-classes"
-        }
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
+    compilerOptions {
+        freeCompilerArgs.addAll(
+            "-Xexpect-actual-classes"
+        )
     }
 
     sourceSets {
@@ -94,9 +94,9 @@ kotlin {
                 compileOnly(libs.jetbrains.annotations)
                 compileOnly(project(":simbot-commons:simbot-common-annotations"))
                 api(project(":simbot-api"))
-                compileOnly(libs.suspend.reversal.annotations)
+
                 // suspend reversal annotations
-                // compileOnly(libs.suspend.reversal.annotations)
+
             }
         }
         commonTest {


### PR DESCRIPTION
更新 Kotlin 到 2.0.0，并籍此开始启用 K2 编译器。

其他依赖更新：
- kotlinx-coroutines to `v1.8.1`
- ksp to `v2.0.0-1.0.21`
- suspendTransform to `v0.8.0-beta1`

增加应用 [binary-compatibility-validator](https://github.com/Kotlin/binary-compatibility-validator) 来增加二进制兼容性的检测与保障


close #826