### PR TITLE
Application的coroutineContext应当始终有一个Job

### DIFF
--- a/simbot-cores/simbot-core-spring-boot-starter-common/src/main/kotlin/love/forte/simbot/spring/common/application/SpringApplication.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter-common/src/main/kotlin/love/forte/simbot/spring/common/application/SpringApplication.kt
@@ -24,6 +24,8 @@
 package love.forte.simbot.spring.common.application
 
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import love.forte.simbot.annotations.InternalSimbotAPI
 import love.forte.simbot.application.*
@@ -65,11 +67,16 @@ public open class SpringApplicationBuilder : AbstractApplicationBuilder() {
      * Build [SpringApplicationConfiguration]
      */
     @InternalSimbotAPI
-    public open fun build(): SpringApplicationConfiguration =
-        SpringApplicationConfigurationImpl(
-            coroutineContext,
+    public open fun build(): SpringApplicationConfiguration {
+        val context = coroutineContext
+        val job = SupervisorJob(context[Job])
+
+        return SpringApplicationConfigurationImpl(
+            context.minusKey(Job) + job,
             applicationConfigurationProperties
         )
+    }
+
 
 }
 

--- a/simbot-cores/simbot-core/src/commonMain/kotlin/love/forte/simbot/core/application/SimpleApplicationFactory.kt
+++ b/simbot-cores/simbot-core/src/commonMain/kotlin/love/forte/simbot/core/application/SimpleApplicationFactory.kt
@@ -261,7 +261,13 @@ private class SimpleApplicationFactoryConfigurer(
  * 通过 [Simple] 构建 [SimpleApplication] 时使用的构建器。
  */
 public class SimpleApplicationBuilder : AbstractApplicationBuilder() {
-    internal fun build(): SimpleApplicationConfiguration = SimpleApplicationConfigurationImpl(coroutineContext)
+    internal fun build(): SimpleApplicationConfiguration {
+        val context = coroutineContext
+        val job = SupervisorJob(context[Job])
+
+        // 至少有个 Job
+        return SimpleApplicationConfigurationImpl(context.minusKey(Job) + job)
+    }
 }
 
 private class SimpleApplicationConfigurationImpl(override val coroutineContext: CoroutineContext) :


### PR DESCRIPTION
ApplicationConfiguration构建完成后应当确保存在一个 Job，否则可能会导致后续关闭 application 时无法正确的影响其下其他内容的生命周期（例如无法关闭 BotManager）

```kotlin
val app = launchApplication { ... }


app.cancel()
// 在修复之前，如果没有手动指定 Job
// 那么此处关闭，无法影响到 BotManager
```