### PR TITLE
更多模块支持wasmJs平台: 所有与Ktor无关的多平台模块均支持wasmJs平台目标

### DIFF
--- a/buildSrc/src/main/kotlin/JsConfig.kt
+++ b/buildSrc/src/main/kotlin/JsConfig.kt
@@ -71,15 +71,17 @@ fun Project.configJsTestTasks() {
     }
 }
 
-@Suppress("UNUSED_PARAMETER")
 inline fun KotlinWasmJsTargetDsl.configWasmJs(
     nodeJs: Boolean = true,
     browser: Boolean = true,
     block: () -> Unit = {}
 ) {
+    if (nodeJs) {
+        nodejs()
+    }
     // if (nodeJs && isLinux) {
-        // win in candy node `21.0.0-v8-canary202309143a48826a08` is not supported
-        // nodejs()
+    // // win in candy node `21.0.0-v8-canary202309143a48826a08` is not supported
+    // nodejs()
     // }
 
     if (browser) {

--- a/simbot-api/build.gradle.kts
+++ b/simbot-api/build.gradle.kts
@@ -26,6 +26,7 @@ import love.forte.gradle.common.kotlin.multiplatform.applyTier1
 import love.forte.gradle.common.kotlin.multiplatform.applyTier2
 import love.forte.gradle.common.kotlin.multiplatform.applyTier3
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 plugins {
     kotlin("multiplatform")
@@ -58,9 +59,11 @@ kotlin {
     applyTier3()
 
     // wasm?
-//    @Suppress("OPT_IN_USAGE")
-//    wasmJs()
-//    @Suppress("OPT_IN_USAGE")
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        configWasmJs()
+    }
+
 //    wasmWasi()
 
     compilerOptions {
@@ -69,20 +72,13 @@ kotlin {
         )
     }
 
-    // withKotlinTargets { target ->
-    // targets.findByName(target.name)?.compilations?.all {
-    //     // 'expect'/'actual' classes (including interfaces, objects, annotations, enums, and 'actual' typealiases) are in Beta. You can use -Xexpect-actual-classes flag to suppress this warning. Also see: https://youtrack.jetbrains.com/issue/KT-61573
-    //     kotlinOptions.freeCompilerArgs += "-Xexpect-actual-classes"
-    // }
-    // }
-
     sourceSets {
         commonMain {
             dependencies {
                 // jvm compile only
-                compileOnly(libs.jetbrains.annotations)
-                compileOnly(project(":simbot-commons:simbot-common-annotations"))
-                compileOnly(libs.kotlinx.serialization.json)
+                api(libs.jetbrains.annotations)
+                api(project(":simbot-commons:simbot-common-annotations"))
+                api(libs.kotlinx.serialization.json)
                 api(project(":simbot-commons:simbot-common-suspend-runner"))
                 api(project(":simbot-commons:simbot-common-core"))
                 api(project(":simbot-commons:simbot-common-collection"))
@@ -105,6 +101,10 @@ kotlin {
 
         jvmMain {
             dependencies {
+                compileOnly(libs.jetbrains.annotations)
+                compileOnly(libs.kotlinx.serialization.json)
+                compileOnly(project(":simbot-commons:simbot-common-annotations"))
+
                 compileOnly(libs.kotlinx.coroutines.reactive)
                 compileOnly(libs.kotlinx.coroutines.reactor)
                 compileOnly(libs.kotlinx.coroutines.rx2)
@@ -124,20 +124,6 @@ kotlin {
                 implementation(kotlin("reflect"))
                 implementation(libs.ktor.client.cio)
             }
-        }
-
-        nativeMain.dependencies {
-            api(libs.kotlinx.serialization.json)
-            api(libs.jetbrains.annotations)
-            api(project(":simbot-commons:simbot-common-annotations"))
-
-        }
-
-        jsMain.dependencies {
-            api(libs.kotlinx.serialization.json)
-            api(project(":simbot-commons:simbot-common-annotations"))
-            api(libs.jetbrains.annotations)
-
         }
 
         jsTest.dependencies {
@@ -164,7 +150,6 @@ kotlin {
             // implementation(libs.ktor.client.core)
             // implementation(libs.ktor.client.winhttp)
         }
-
 
     }
 }

--- a/simbot-api/src/wasmJsMain/kotlin/love/forte/simbot/bot/configuration/DispatcherConfiguration.wasmjs.kt
+++ b/simbot-api/src/wasmJsMain/kotlin/love/forte/simbot/bot/configuration/DispatcherConfiguration.wasmjs.kt
@@ -21,8 +21,26 @@
  *
  */
 
-import love.forte.simbot.message.MessagesBuilder
+package love.forte.simbot.bot.configuration
 
-internal actual fun MessagesBuilder.addIntoMessages() {
-    // nothing.
-}
+import kotlinx.coroutines.CoroutineDispatcher
+
+/**
+ * 获取 `IO` 调度器，始终返回 `null`。
+ */
+internal actual fun ioDispatcher(): CoroutineDispatcher? = null
+
+/**
+ * 获取自定义调度器。不支持或无法构建时返回 `null`。
+ */
+internal actual fun customDispatcher(
+    coreThreads: Int?,
+    maxThreads: Int?,
+    keepAliveMillis: Long?,
+    name: String?
+): CoroutineDispatcher? = null
+
+/**
+ * 当平台为 Java21+ 的 JVM平台时得到虚拟线程调度器，否则得到 `null`。
+ */
+internal actual fun virtualDispatcher(): CoroutineDispatcher? = null

--- a/simbot-api/src/wasmJsMain/kotlin/love/forte/simbot/component/ComponentFactoryProvider.wasmJs.kt
+++ b/simbot-api/src/wasmJsMain/kotlin/love/forte/simbot/component/ComponentFactoryProvider.wasmJs.kt
@@ -21,8 +21,12 @@
  *
  */
 
-import love.forte.simbot.message.MessagesBuilder
+package love.forte.simbot.component
 
-internal actual fun MessagesBuilder.addIntoMessages() {
-    // nothing.
-}
+import love.forte.simbot.common.services.Services
+
+/**
+ * 获取通过 [addComponentFactoryProvider] 添加的内容的副本序列。
+ */
+public actual fun loadComponentProviders(): Sequence<ComponentFactoryProvider<*>> =
+    Services.loadProviders<ComponentFactoryProvider<*>>().map { it() }

--- a/simbot-api/src/wasmJsMain/kotlin/love/forte/simbot/event/EventResult.wasmJs.kt
+++ b/simbot-api/src/wasmJsMain/kotlin/love/forte/simbot/event/EventResult.wasmJs.kt
@@ -1,0 +1,50 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.event
+
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.await
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.toList
+import kotlin.js.Promise
+
+/**
+ * 收集 [StandardEventResult.CollectableReactivelyResult.content] 的结果并返回。
+ * 如果结果不可收集或不支持收集，则得到原值。
+ *
+ * native 平台下支持 Kotlin Coroutines 本身的可挂起类型 [Deferred] 和 [Flow] 和 [Promise]。
+ * 可收集类型参考 [StandardEventResult.CollectableReactivelyResult.content] 说明。
+ *
+ * @see StandardEventResult.CollectableReactivelyResult.content
+ * @return The collected result.
+ */
+public actual suspend fun StandardEventResult.CollectableReactivelyResult.collectCollectableReactively(): Any? {
+    return when (val c = content) {
+        null -> null
+        is Deferred<*> -> c.await()
+        is Flow<*> -> c.toList()
+        is Promise<*> -> c.await()
+        else -> content
+    }
+}

--- a/simbot-api/src/wasmJsMain/kotlin/love/forte/simbot/message/Messages.wasmJs.kt
+++ b/simbot-api/src/wasmJsMain/kotlin/love/forte/simbot/message/Messages.wasmJs.kt
@@ -21,8 +21,13 @@
  *
  */
 
-import love.forte.simbot.message.MessagesBuilder
+package love.forte.simbot.message
 
-internal actual fun MessagesBuilder.addIntoMessages() {
+import kotlinx.serialization.modules.PolymorphicModuleBuilder
+
+/**
+ * 整合平台特别实现的序列化信息。
+ */
+internal actual fun PolymorphicModuleBuilder<Message.Element>.resolvePlatformStandardSerializers() {
     // nothing.
 }

--- a/simbot-api/src/wasmJsMain/kotlin/love/forte/simbot/message/StandardMessages.wasmjs.kt
+++ b/simbot-api/src/wasmJsMain/kotlin/love/forte/simbot/message/StandardMessages.wasmjs.kt
@@ -21,8 +21,13 @@
  *
  */
 
-import love.forte.simbot.message.MessagesBuilder
+package love.forte.simbot.message
 
-internal actual fun MessagesBuilder.addIntoMessages() {
-    // nothing.
-}
+import love.forte.simbot.resource.Resource
+
+/**
+ * 将 [Resource] 转化为 [OfflineResourceImage]。
+ *
+ */
+public actual fun Resource.toOfflineResourceImage(): OfflineResourceImage =
+    SimpleOfflineResourceImage(this)

--- a/simbot-api/src/wasmJsMain/kotlin/love/forte/simbot/plugin/PluginFactoryProvider.wasmjs.kt
+++ b/simbot-api/src/wasmJsMain/kotlin/love/forte/simbot/plugin/PluginFactoryProvider.wasmjs.kt
@@ -21,8 +21,13 @@
  *
  */
 
-import love.forte.simbot.message.MessagesBuilder
+package love.forte.simbot.plugin
 
-internal actual fun MessagesBuilder.addIntoMessages() {
-    // nothing.
-}
+import love.forte.simbot.common.services.Services
+import love.forte.simbot.component.addComponentFactoryProvider
+
+/**
+ * 加载所有通过 [addComponentFactoryProvider] 添加的函数构建出来的 [PluginFactoryProvider] 实例。
+ */
+public actual fun loadPluginProviders(): Sequence<PluginFactoryProvider<*>> =
+    Services.loadProviders<PluginFactoryProvider<*>>().map { it() }

--- a/simbot-api/src/wasmJsTest/kotlin/MessagesTests.wasmJs.kt
+++ b/simbot-api/src/wasmJsTest/kotlin/MessagesTests.wasmJs.kt
@@ -23,6 +23,29 @@
 
 import love.forte.simbot.message.MessagesBuilder
 
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 internal actual fun MessagesBuilder.addIntoMessages() {
     // nothing.
 }

--- a/simbot-cores/simbot-core/build.gradle.kts
+++ b/simbot-cores/simbot-core/build.gradle.kts
@@ -22,7 +22,11 @@
  */
 
 import love.forte.gradle.common.core.project.setup
+import love.forte.gradle.common.kotlin.multiplatform.applyTier1
+import love.forte.gradle.common.kotlin.multiplatform.applyTier2
+import love.forte.gradle.common.kotlin.multiplatform.applyTier3
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 plugins {
     kotlin("multiplatform")
@@ -47,36 +51,14 @@ kotlin {
     }
 
     // tier1
-    linuxX64()
-    macosX64()
-    macosArm64()
-    iosSimulatorArm64()
-    iosX64()
+    applyTier1()
+    applyTier2()
+    applyTier3()
 
-    // tier2
-    linuxArm64()
-    watchosSimulatorArm64()
-    watchosX64()
-    watchosArm32()
-    watchosArm64()
-    tvosSimulatorArm64()
-    tvosX64()
-    tvosArm64()
-    iosArm64()
-
-    // tier3
-    androidNativeArm32()
-    androidNativeArm64()
-    androidNativeX86()
-    androidNativeX64()
-    mingwX64()
-    watchosDeviceArm64()
-
-    // wasm?
-//    @Suppress("OPT_IN_USAGE")
-//    wasmJs()
-//    @Suppress("OPT_IN_USAGE")
-//    wasmWasi()
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        configWasmJs()
+    }
 
     @OptIn(ExperimentalKotlinGradlePluginApi::class)
     compilerOptions {
@@ -88,12 +70,11 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                compileOnly(project(":simbot-commons:simbot-common-annotations"))
-                compileOnly(project(":simbot-commons:simbot-common-collection"))
+                api(project(":simbot-commons:simbot-common-annotations"))
+                api(project(":simbot-commons:simbot-common-collection"))
 
                 api(project(":simbot-api"))
                 api(libs.kotlinx.coroutines.core)
-                // api(libs.kotlinx.serialization.core)
             }
         }
         commonTest {
@@ -105,6 +86,11 @@ kotlin {
             }
         }
 
+        jvmMain.dependencies {
+            compileOnly(project(":simbot-commons:simbot-common-annotations"))
+            compileOnly(project(":simbot-commons:simbot-common-collection"))
+        }
+
         jvmTest {
             dependencies {
                 implementation(project(":simbot-api"))
@@ -112,17 +98,6 @@ kotlin {
                 implementation(libs.kotlinx.coroutines.reactor)
                 implementation(libs.reactor.core)
             }
-        }
-
-        jsMain.dependencies {
-            api(project(":simbot-commons:simbot-common-annotations"))
-            api(project(":simbot-commons:simbot-common-collection"))
-        }
-
-        nativeMain.dependencies {
-            api(project(":simbot-commons:simbot-common-annotations"))
-            api(project(":simbot-commons:simbot-common-collection"))
-
         }
     }
 }

--- a/simbot-cores/simbot-core/src/wasmJsMain/kotlin/love/forte/simbot/core/event/impl/SimpleEventDispatcherImpl.wasmjs.kt
+++ b/simbot-cores/simbot-core/src/wasmJsMain/kotlin/love/forte/simbot/core/event/impl/SimpleEventDispatcherImpl.wasmjs.kt
@@ -21,8 +21,32 @@
  *
  */
 
-import love.forte.simbot.message.MessagesBuilder
+package love.forte.simbot.core.event.impl
 
-internal actual fun MessagesBuilder.addIntoMessages() {
-    // nothing.
+import love.forte.simbot.common.collection.ExperimentalSimbotCollectionApi
+import love.forte.simbot.common.collection.PriorityConcurrentQueue
+import love.forte.simbot.event.EventListenerRegistrationHandle
+
+@OptIn(ExperimentalSimbotCollectionApi::class)
+internal actual fun <T : Any> createQueueRegistrationHandle(
+    priority: Int,
+    queue: PriorityConcurrentQueue<T>,
+    target: T
+): EventListenerRegistrationHandle =
+    CountDownEventListenerRegistrationHandle(priority, queue, target)
+
+@OptIn(ExperimentalSimbotCollectionApi::class)
+private class CountDownEventListenerRegistrationHandle<T>(
+    private val priority: Int,
+    private val queue: PriorityConcurrentQueue<T>,
+    private val target: T
+) : EventListenerRegistrationHandle {
+    private var disposed = false
+
+    override fun dispose() {
+        if (!disposed) {
+            queue.remove(priority, target)
+            disposed = true
+        }
+    }
 }

--- a/simbot-extensions/simbot-extension-continuous-session/build.gradle.kts
+++ b/simbot-extensions/simbot-extension-continuous-session/build.gradle.kts
@@ -25,6 +25,7 @@ import love.forte.gradle.common.core.project.setup
 import love.forte.gradle.common.kotlin.multiplatform.applyTier1
 import love.forte.gradle.common.kotlin.multiplatform.applyTier2
 import love.forte.gradle.common.kotlin.multiplatform.applyTier3
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 plugins {
     kotlin("multiplatform")
@@ -54,19 +55,16 @@ kotlin {
     applyTier2()
     applyTier3()
 
-    // wasm?
-//    @Suppress("OPT_IN_USAGE")
-//    wasmJs()
-//    @Suppress("OPT_IN_USAGE")
-//    wasmWasi()
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        configWasmJs()
+    }
 
     sourceSets {
         commonMain {
             dependencies {
                 // jvm compile only
-                // compileOnly(libs.jetbrains.annotations)
                 api(project(":simbot-api"))
-                // compileOnly(libs.kotlinx.serialization.json)
             }
         }
         commonTest {
@@ -79,10 +77,9 @@ kotlin {
             }
         }
 
-
-
         jvmMain {
             dependencies {
+                compileOnly(project(":simbot-api"))
                 compileOnly(project(":simbot-commons:simbot-common-annotations"))
                 compileOnly(libs.kotlinx.coroutines.reactive)
                 compileOnly(libs.kotlinx.coroutines.reactor)
@@ -106,45 +103,9 @@ kotlin {
             }
         }
 
-        nativeMain.dependencies {
-            api(libs.kotlinx.serialization.json)
-            api(libs.jetbrains.annotations)
-            api(project(":simbot-commons:simbot-common-annotations"))
-
-        }
-
-        jsMain.dependencies {
-            api(libs.kotlinx.serialization.json)
-            api(project(":simbot-commons:simbot-common-annotations"))
-            api(libs.jetbrains.annotations)
-
-        }
-
         jsTest.dependencies {
             implementation(libs.ktor.client.js)
             implementation(libs.ktor.client.core)
         }
-
-        nativeTest.dependencies {
-            // implementation(libs.ktor.client.core)
-            // implementation(libs.ktor.client.cio)
-        }
-
-        linuxTest.dependencies {
-            // implementation(libs.ktor.client.core)
-            // implementation(libs.ktor.client.cio)
-        }
-
-        appleTest.dependencies {
-            // implementation(libs.ktor.client.core)
-            // implementation(libs.ktor.client.cio)
-        }
-
-        mingwTest.dependencies {
-            // implementation(libs.ktor.client.core)
-            // implementation(libs.ktor.client.winhttp)
-        }
-
-
     }
 }

--- a/simbot-logger/build.gradle.kts
+++ b/simbot-logger/build.gradle.kts
@@ -66,8 +66,7 @@ kotlin {
 
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
-        browser()
-        binaries.library()
+        configWasmJs()
     }
 
     @OptIn(ExperimentalKotlinGradlePluginApi::class)

--- a/simbot-quantcat/simbot-quantcat-common/build.gradle.kts
+++ b/simbot-quantcat/simbot-quantcat-common/build.gradle.kts
@@ -26,6 +26,7 @@ import love.forte.gradle.common.kotlin.multiplatform.applyTier1
 import love.forte.gradle.common.kotlin.multiplatform.applyTier2
 import love.forte.gradle.common.kotlin.multiplatform.applyTier3
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 /*
  * Copyright (c) 2023 ForteScarlet.
@@ -64,6 +65,11 @@ kotlin {
     applyTier2()
     applyTier3()
 
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        configWasmJs()
+    }
+
     @OptIn(ExperimentalKotlinGradlePluginApi::class)
     compilerOptions {
         freeCompilerArgs.addAll(
@@ -74,8 +80,8 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                compileOnly(project(":simbot-api"))
-                compileOnly(project(":simbot-commons:simbot-common-annotations"))
+                api(project(":simbot-api"))
+                api(project(":simbot-commons:simbot-common-annotations"))
 
             }
         }
@@ -88,6 +94,8 @@ kotlin {
         }
 
         jvmMain.dependencies {
+            compileOnly(project(":simbot-api"))
+            compileOnly(project(":simbot-commons:simbot-common-annotations"))
             compileOnly(kotlin("reflect"))
         }
 
@@ -95,18 +103,6 @@ kotlin {
             dependencies {
                 implementation(kotlin("test-junit5"))
             }
-        }
-
-        jsMain.dependencies {
-            api(project(":simbot-api"))
-            api(project(":simbot-commons:simbot-common-annotations"))
-
-        }
-
-        nativeMain.dependencies {
-            api(project(":simbot-api"))
-            api(project(":simbot-commons:simbot-common-annotations"))
-
         }
     }
 

--- a/simbot-test/build.gradle.kts
+++ b/simbot-test/build.gradle.kts
@@ -22,7 +22,11 @@
  */
 
 import love.forte.gradle.common.core.project.setup
+import love.forte.gradle.common.kotlin.multiplatform.applyTier1
+import love.forte.gradle.common.kotlin.multiplatform.applyTier2
+import love.forte.gradle.common.kotlin.multiplatform.applyTier3
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 plugins {
     kotlin("multiplatform")
@@ -49,36 +53,14 @@ kotlin {
     }
 
     // tier1
-    linuxX64()
-    macosX64()
-    macosArm64()
-    iosSimulatorArm64()
-    iosX64()
+    applyTier1()
+    applyTier2()
+    applyTier3()
 
-    // tier2
-    linuxArm64()
-    watchosSimulatorArm64()
-    watchosX64()
-    watchosArm32()
-    watchosArm64()
-    tvosSimulatorArm64()
-    tvosX64()
-    tvosArm64()
-    iosArm64()
-
-    // tier3
-    androidNativeArm32()
-    androidNativeArm64()
-    androidNativeX86()
-    androidNativeX64()
-    mingwX64()
-    watchosDeviceArm64()
-
-    // wasm?
-//    @Suppress("OPT_IN_USAGE")
-//    wasmJs()
-//    @Suppress("OPT_IN_USAGE")
-//    wasmWasi()
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        configWasmJs()
+    }
 
     @OptIn(ExperimentalKotlinGradlePluginApi::class)
     compilerOptions {


### PR DESCRIPTION
本次新增的支持模块：
- simbot-api
- simbot-core
- simbot-quantcat-common
- simbot-extension-continuous-session

> [!warning]
> wasmJs 平台仍然是 Work-In-Prograss 状态，因此同样地我们也不对此平台地任何内容做保证。与之相关的内容或配置随时可能会在未来被更改或删除。