### PR TITLE
JVM中的EventListener兼容类型增加一个 nonBlock 类型用于简化响应式结果的使用

### DIFF
--- a/simbot-api/api/simbot-api.api
+++ b/simbot-api/api/simbot-api.api
@@ -1238,6 +1238,8 @@ public final class love/forte/simbot/event/EventListeners {
 	public static synthetic fun block$default (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Class;Llove/forte/simbot/event/TypedJBlockEventListener;ILjava/lang/Object;)Llove/forte/simbot/event/EventListener;
 	public static synthetic fun block$default (Lkotlin/coroutines/CoroutineContext;Llove/forte/simbot/event/JBlockEventListener;ILjava/lang/Object;)Llove/forte/simbot/event/EventListener;
 	public static final fun handleWith (Llove/forte/simbot/event/EventListener;Llove/forte/simbot/event/EventListenerContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun nonBlock (Ljava/lang/Class;Llove/forte/simbot/event/TypedJNonBlockEventListener;)Llove/forte/simbot/event/EventListener;
+	public static final fun nonBlock (Llove/forte/simbot/event/JNonBlockEventListener;)Llove/forte/simbot/event/EventListener;
 }
 
 public abstract interface class love/forte/simbot/event/EventProcessor {
@@ -1480,6 +1482,16 @@ public final class love/forte/simbot/event/JBlockEventListener$Companion {
 	public final fun toListener (Lkotlin/coroutines/CoroutineContext;Llove/forte/simbot/event/JBlockEventListener;)Llove/forte/simbot/event/EventListener;
 	public final fun toListener (Llove/forte/simbot/event/JBlockEventListener;)Llove/forte/simbot/event/EventListener;
 	public static synthetic fun toListener$default (Llove/forte/simbot/event/JBlockEventListener$Companion;Lkotlin/coroutines/CoroutineContext;Llove/forte/simbot/event/JBlockEventListener;ILjava/lang/Object;)Llove/forte/simbot/event/EventListener;
+}
+
+public abstract interface class love/forte/simbot/event/JNonBlockEventListener {
+	public static final field Companion Llove/forte/simbot/event/JNonBlockEventListener$Companion;
+	public abstract fun handle (Llove/forte/simbot/event/EventListenerContext;)Llove/forte/simbot/event/EventResult;
+	public static fun toListener (Llove/forte/simbot/event/JNonBlockEventListener;)Llove/forte/simbot/event/EventListener;
+}
+
+public final class love/forte/simbot/event/JNonBlockEventListener$Companion {
+	public final fun toListener (Llove/forte/simbot/event/JNonBlockEventListener;)Llove/forte/simbot/event/EventListener;
 }
 
 public abstract interface class love/forte/simbot/event/MemberAuthorAwareMessageEvent : love/forte/simbot/event/ActorAuthorAwareMessageEvent {
@@ -1727,6 +1739,16 @@ public final class love/forte/simbot/event/TypedJBlockEventListener$Companion {
 	public final fun toListener (Ljava/lang/Class;Llove/forte/simbot/event/TypedJBlockEventListener;)Llove/forte/simbot/event/EventListener;
 	public final fun toListener (Lkotlin/coroutines/CoroutineContext;Ljava/lang/Class;Llove/forte/simbot/event/TypedJBlockEventListener;)Llove/forte/simbot/event/EventListener;
 	public static synthetic fun toListener$default (Llove/forte/simbot/event/TypedJBlockEventListener$Companion;Lkotlin/coroutines/CoroutineContext;Ljava/lang/Class;Llove/forte/simbot/event/TypedJBlockEventListener;ILjava/lang/Object;)Llove/forte/simbot/event/EventListener;
+}
+
+public abstract interface class love/forte/simbot/event/TypedJNonBlockEventListener {
+	public static final field Companion Llove/forte/simbot/event/TypedJNonBlockEventListener$Companion;
+	public abstract fun handle (Llove/forte/simbot/event/EventListenerContext;Llove/forte/simbot/event/Event;)Llove/forte/simbot/event/EventResult;
+	public static fun toListener (Ljava/lang/Class;Llove/forte/simbot/event/TypedJNonBlockEventListener;)Llove/forte/simbot/event/EventListener;
+}
+
+public final class love/forte/simbot/event/TypedJNonBlockEventListener$Companion {
+	public final fun toListener (Ljava/lang/Class;Llove/forte/simbot/event/TypedJNonBlockEventListener;)Llove/forte/simbot/event/EventListener;
 }
 
 public abstract class love/forte/simbot/message/AggregatedMessageReceipt : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker, love/forte/simbot/message/StandardMessageReceipt {

--- a/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/EventResult.kt
+++ b/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/EventResult.kt
@@ -4,7 +4,7 @@
  *     Project    https://github.com/simple-robot/simpler-robot
  *     Email      ForteScarlet@163.com
  *
- *     This file is part of the Simple Robot Library.
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Lesser General Public License as published by
@@ -261,6 +261,8 @@ public sealed class StandardEventResult : EventResult {
      *
      * 首次结果收集应当由 [EventDispatcher] 推送结果之前即完成，因此 [EventProcessor.push]
      * 的结果中不会出现从未收集过结果的 result。
+     *
+     * @see Simple
      */
     public abstract class CollectableReactivelyResult : StandardEventResult() {
 

--- a/simbot-cores/simbot-core/src/jvmTest/kotlin/ReactiveEventResultTests.kt
+++ b/simbot-cores/simbot-core/src/jvmTest/kotlin/ReactiveEventResultTests.kt
@@ -1,0 +1,97 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.test.runTest
+import love.forte.simbot.annotations.ExperimentalSimbotAPI
+import love.forte.simbot.common.id.ID
+import love.forte.simbot.common.id.UUID
+import love.forte.simbot.common.time.Timestamp
+import love.forte.simbot.core.application.launchSimpleApplication
+import love.forte.simbot.event.Event
+import love.forte.simbot.event.EventResult
+import love.forte.simbot.event.nonBlock
+import reactor.core.publisher.Mono
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ *
+ * @author ForteScarlet
+ */
+class ReactiveEventResultTests {
+
+    @Test
+    @OptIn(ExperimentalSimbotAPI::class)
+    fun reactiveResultCollectTest() = runTest {
+        val app = launchSimpleApplication { }
+        val event = object : Event {
+            override val id: ID = UUID.random()
+            override val time: Timestamp = Timestamp.now()
+        }
+
+        val monoCollected = AtomicBoolean(false)
+
+        app.eventDispatcher.register(
+            nonBlock {
+                EventResult.of(
+                    Mono.just(1).then(
+                        Mono.fromSupplier {
+                            monoCollected.set(true)
+                            2
+                        }
+                    )
+                )
+            }
+        )
+
+        app.eventDispatcher.push(event).collect()
+
+        assertTrue(monoCollected.get())
+    }
+
+}


### PR DESCRIPTION
```java
var listener = EventListeners.nonBlock(
    context -> {
        return EventResult.of(
            Mono.just("Hello.");
        );
    }
);
```

```java
var listener = EventListeners.nonBlock(
    Event.class,
    (context, event) -> {
        return EventResult.of(
            Mono.just("Hello.");
        );
    }
);
```