### PR TITLE
优化统一MergedBinder对null结果、失败结果的处理

### DIFF
--- a/.github/workflows/publish-v4-release.yml
+++ b/.github/workflows/publish-v4-release.yml
@@ -8,6 +8,7 @@ env:
   JAVA_VERSION: 21
   JAVA_DISTRIBUTION: zulu
   GRADLE_VERSION: 8.5
+  NODE_VERSION: 22
   IS_CI: true
   GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
   GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
@@ -30,6 +31,10 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
           cache: 'gradle'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
       - name: Run All Tests pre release
         uses: gradle/actions/setup-gradle@v3
         with:
@@ -56,7 +61,9 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
           cache: 'gradle'
-
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
       # setup Gradle
       - name: Gradle Publish Release
         uses: gradle/actions/setup-gradle@v3

--- a/.github/workflows/publish-v4-snapshot.yml
+++ b/.github/workflows/publish-v4-snapshot.yml
@@ -21,6 +21,7 @@ env:
   JAVA_VERSION: 21
   JAVA_DISTRIBUTION: zulu
   GRADLE_VERSION: 8.5
+  NODE_VERSION: 22
   IS_CI: true
   GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
   GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
@@ -49,7 +50,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
@@ -79,10 +80,9 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           cache: 'gradle'
 
-      # setup Node
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Publish snapshots
         uses: gradle/actions/setup-gradle@v3

--- a/.github/workflows/test-v4-branch.yml
+++ b/.github/workflows/test-v4-branch.yml
@@ -9,6 +9,7 @@ env:
   JAVA_VERSION: 21
   JAVA_DISTRIBUTION: zulu
   GRADLE_VERSION: 8.5
+  NODE_VERSION: 22
   IS_CI: true
   GRADLE_OPTS: "-Dfile.encoding=UTF-8"
 
@@ -30,6 +31,9 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
           cache: 'gradle'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Run V4 All Tests
         uses: gradle/gradle-build-action@v3

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -171,4 +171,13 @@ idea {
     }
 }
 
-
+// https://kotlinlang.org/docs/js-project-setup.html#node-js
+rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin> {
+    rootProject.the<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension>().apply {
+        // CI 中配置环境，不再单独下载
+        if (isCi) {
+            download = false
+        }
+    }
+    // "true" for default behavior
+}

--- a/buildSrc/src/main/kotlin/JsConfig.kt
+++ b/buildSrc/src/main/kotlin/JsConfig.kt
@@ -22,11 +22,8 @@
  */
 
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.the
-import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsTargetDsl
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinWasmJsTargetDsl
-import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
 
 
 inline fun KotlinJsTargetDsl.configJs(
@@ -77,7 +74,8 @@ inline fun KotlinWasmJsTargetDsl.configWasmJs(
     block: () -> Unit = {}
 ) {
     if (nodeJs) {
-        nodejs()
+        nodejs {
+        }
     }
     // if (nodeJs && isLinux) {
     // // win in candy node `21.0.0-v8-canary202309143a48826a08` is not supported
@@ -100,18 +98,18 @@ inline fun KotlinWasmJsTargetDsl.configWasmJs(
 }
 
 inline fun Project.configWasmJsTest(block: () -> Unit = {}) {
-    if (false) {
-        // see https://youtrack.jetbrains.com/issue/KT-63014/Running-tests-with-wasmJs-in-1.9.20-requires-Chrome-Canary#focus=Comments-27-8321383.0-0
-        rootProject.the<NodeJsRootExtension>().apply {
-            // nodeVersion = "21.0.0-v8-canary202309143a48826a08"
-            version = "21.0.0-v8-canary202309143a48826a08"
-            downloadBaseUrl = "https://nodejs.org/download/v8-canary"
-        }
-
-        tasks.withType<org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask>().configureEach {
-            args.add("--ignore-engines")
-        }
-    }
+    // if (false) {
+    //     // see https://youtrack.jetbrains.com/issue/KT-63014/Running-tests-with-wasmJs-in-1.9.20-requires-Chrome-Canary#focus=Comments-27-8321383.0-0
+    //     rootProject.the<NodeJsRootExtension>().apply {
+    //         // nodeVersion = "21.0.0-v8-canary202309143a48826a08"
+    //         version = "21.0.0-v8-canary202309143a48826a08"
+    //         downloadBaseUrl = "https://nodejs.org/download/v8-canary"
+    //     }
+    //
+    //     tasks.withType<org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask>().configureEach {
+    //         args.add("--ignore-engines")
+    //     }
+    // }
 
     block()
 }

--- a/buildSrc/src/main/kotlin/P.kt
+++ b/buildSrc/src/main/kotlin/P.kt
@@ -52,8 +52,8 @@ sealed class P(override val group: String) : ProjectDetail() {
 
      */
     companion object {
-        const val VERSION = "4.3.1"
-        const val NEXT_VERSION = "4.3.2"
+        const val VERSION = "4.4.0"
+        const val NEXT_VERSION = "4.4.0"
         const val SNAPSHOT_VERSION = "$VERSION-SNAPSHOT"
         const val NEXT_SNAPSHOT_VERSION = "$NEXT_VERSION-SNAPSHOT"
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -44,6 +44,7 @@ include(":simbot-gradles:simbot-gradle-suspendtransforms")
 
 include(":simbot-commons:simbot-common-annotations")
 include(":simbot-commons:simbot-common-collection")
+include(":simbot-commons:simbot-common-streamable")
 include(":simbot-commons:simbot-common-atomic")
 include(":simbot-commons:simbot-common-apidefinition")
 include(":simbot-commons:simbot-common-core")

--- a/simbot-api/api/simbot-api.api
+++ b/simbot-api/api/simbot-api.api
@@ -371,6 +371,8 @@ public abstract interface class love/forte/simbot/bot/BotManager : love/forte/si
 	public fun all (Llove/forte/simbot/common/id/ID;)Lkotlin/sequences/Sequence;
 	public fun allToList ()Ljava/util/List;
 	public fun allToList (Llove/forte/simbot/common/id/ID;)Ljava/util/List;
+	public fun allToStreamable ()Llove/forte/simbot/common/streamable/Streamable;
+	public fun allToStreamable (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/common/streamable/Streamable;
 	public fun asFuture ()Ljava/util/concurrent/CompletableFuture;
 	public abstract fun cancel (Ljava/lang/Throwable;)V
 	public static synthetic fun cancel$default (Llove/forte/simbot/bot/BotManager;Ljava/lang/Throwable;ILjava/lang/Object;)V
@@ -393,6 +395,7 @@ public final class love/forte/simbot/bot/BotManagerUtil {
 
 public abstract interface class love/forte/simbot/bot/BotManagers : java/util/Collection, kotlin/jvm/internal/markers/KMappedMarker {
 	public fun allBots ()Lkotlin/sequences/Sequence;
+	public fun allBotsToStreamable ()Llove/forte/simbot/common/streamable/Streamable;
 	public fun firstBot ()Llove/forte/simbot/bot/Bot;
 	public fun firstBot (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/bot/Bot;
 }
@@ -1206,6 +1209,7 @@ public abstract interface class love/forte/simbot/event/EventListener {
 
 public abstract interface class love/forte/simbot/event/EventListenerContainer {
 	public abstract fun getListeners ()Lkotlin/sequences/Sequence;
+	public fun listenersToStreamable ()Llove/forte/simbot/common/streamable/Streamable;
 }
 
 public abstract interface class love/forte/simbot/event/EventListenerContext {

--- a/simbot-api/build.gradle.kts
+++ b/simbot-api/build.gradle.kts
@@ -75,6 +75,7 @@ kotlin {
                 implementation(project(":simbot-commons:simbot-common-annotations"))
                 implementation(project(":simbot-logger"))
 
+                api(project(":simbot-commons:simbot-common-streamable"))
                 api(project(":simbot-commons:simbot-common-suspend-runner"))
                 api(project(":simbot-commons:simbot-common-core"))
                 api(project(":simbot-commons:simbot-common-collection"))

--- a/simbot-api/src/commonMain/kotlin/love/forte/simbot/bot/BotManager.kt
+++ b/simbot-api/src/commonMain/kotlin/love/forte/simbot/bot/BotManager.kt
@@ -27,6 +27,8 @@ import love.forte.simbot.ability.CompletionAware
 import love.forte.simbot.ability.LifecycleAware
 import love.forte.simbot.common.function.MergeableFactory
 import love.forte.simbot.common.id.ID
+import love.forte.simbot.common.streamable.Streamable
+import love.forte.simbot.common.streamable.Streamable.Companion.asStreamable
 import love.forte.simbot.plugin.PluginFactory
 import love.forte.simbot.suspendrunner.ST
 
@@ -56,6 +58,24 @@ public interface BotManager : AutoConfigurableBotPlugin, LifecycleAware, Complet
      * 得到所有 `id` 符合条件的 [Bot]，以序列的形式。
      */
     public fun all(id: ID): Sequence<Bot> = all().filter { bot -> bot.id == id }
+
+    /**
+     * 得到所有的 [Bot] 并转化为 [Streamable]。
+     *
+     * @since 4.4.0
+     * @see all
+     */
+    public fun allToStreamable(): Streamable<Bot> =
+        all().asStreamable()
+
+    /**
+     * 得到所有 `id` 符合条件的 [Bot] 并转化为 [Streamable]。
+     *
+     * @since 4.4.0
+     * @see all
+     */
+    public fun allToStreamable(id: ID): Streamable<Bot> =
+        all(id).asStreamable()
 
     /**
      * 将 [all] 收集为 [List] 并返回。

--- a/simbot-api/src/commonMain/kotlin/love/forte/simbot/bot/BotManagers.kt
+++ b/simbot-api/src/commonMain/kotlin/love/forte/simbot/bot/BotManagers.kt
@@ -28,6 +28,8 @@ package love.forte.simbot.bot
 
 import love.forte.simbot.common.collection.toImmutable
 import love.forte.simbot.common.id.ID
+import love.forte.simbot.common.streamable.Streamable
+import love.forte.simbot.common.streamable.Streamable.Companion.asStreamable
 import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
 
@@ -40,6 +42,13 @@ public interface BotManagers : Collection<BotManager> {
      * 以序列的形式获取当前 [BotManager] 中所有的 [Bot]。
      */
     public fun allBots(): Sequence<Bot> = asSequence().flatMap { it.all() }
+
+    /**
+     * 获取 [allBots] 的流转化器。
+     *
+     * @since 4.4.0
+     */
+    public fun allBotsToStreamable(): Streamable<Bot> = allBots().asStreamable()
 
     /**
      * 尝试获取第一个 [BotManager] 中的第一个 [Bot]。

--- a/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/EventListenerContainer.kt
+++ b/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/EventListenerContainer.kt
@@ -4,7 +4,7 @@
  *     Project    https://github.com/simple-robot/simpler-robot
  *     Email      ForteScarlet@163.com
  *
- *     This file is part of the Simple Robot Library.
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Lesser General Public License as published by
@@ -23,6 +23,9 @@
 
 package love.forte.simbot.event
 
+import love.forte.simbot.common.streamable.Streamable
+import love.forte.simbot.common.streamable.Streamable.Companion.asStreamable
+
 
 /**
  * 事件监听器的“容器”接口，提供用于获取其中的所有 [EventListener] 的API。
@@ -37,5 +40,11 @@ public interface EventListenerContainer {
      */
     public val listeners: Sequence<EventListener>
 
-
+    /**
+     * 获取到 [listeners] 并转化为 [Streamable]
+     *
+     * @see listeners
+     */
+    public fun listenersToStreamable(): Streamable<EventListener> =
+        listeners.asStreamable()
 }

--- a/simbot-api/src/jvmMain/java/module-info.java
+++ b/simbot-api/src/jvmMain/java/module-info.java
@@ -31,6 +31,7 @@ module simbot.api {
     requires simbot.logger;
     requires static org.jetbrains.annotations;
     requires static simbot.common.annotations;
+    requires simbot.common.streamable;
     requires simbot.common.suspendrunner;
     requires simbot.common.core;
     requires simbot.common.collection;

--- a/simbot-commons/simbot-common-streamable/api/simbot-common-streamable.api
+++ b/simbot-commons/simbot-common-streamable/api/simbot-common-streamable.api
@@ -1,0 +1,15 @@
+public final class love/forte/simbot/common/streamable/Streamable : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker {
+	public static final field Companion Llove/forte/simbot/common/streamable/Streamable$Companion;
+	public synthetic fun <init> (Lkotlin/sequences/Sequence;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun asSequence ()Lkotlin/sequences/Sequence;
+	public final fun asStream ()Ljava/util/stream/Stream;
+	public final fun collectTo (Ljava/util/Collection;)Ljava/util/Collection;
+	public final fun collectToList ()Ljava/util/List;
+	public fun iterator ()Ljava/util/Iterator;
+	public static final fun of (Lkotlin/sequences/Sequence;)Llove/forte/simbot/common/streamable/Streamable;
+}
+
+public final class love/forte/simbot/common/streamable/Streamable$Companion {
+	public final fun of (Lkotlin/sequences/Sequence;)Llove/forte/simbot/common/streamable/Streamable;
+}
+

--- a/simbot-commons/simbot-common-streamable/build.gradle.kts
+++ b/simbot-commons/simbot-common-streamable/build.gradle.kts
@@ -1,0 +1,92 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+import love.forte.gradle.common.kotlin.multiplatform.applyTier1
+import love.forte.gradle.common.kotlin.multiplatform.applyTier2
+import love.forte.gradle.common.kotlin.multiplatform.applyTier3
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
+
+plugins {
+    kotlin("multiplatform")
+    kotlin("plugin.serialization")
+    id("simbot.dokka-module-configuration")
+}
+
+configJavaCompileWithModule("simbot.common.streamable")
+apply(plugin = "simbot-multiplatform-maven-publish")
+
+kotlin {
+    explicitApi()
+    applyDefaultHierarchyTemplate()
+
+    configKotlinJvm(JVMConstants.KT_JVM_TARGET_VALUE)
+
+    js(IR) {
+        configJs()
+    }
+
+    applyTier1()
+    applyTier2()
+    applyTier3()
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        configWasmJs()
+    }
+
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
+    compilerOptions {
+        freeCompilerArgs.addAll(
+            "-Xexpect-actual-classes"
+        )
+    }
+
+    sourceSets {
+        commonTest {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
+
+        jvmTest {
+            dependencies {
+                implementation(kotlin("test-junit5"))
+            }
+        }
+    }
+}
+
+configWasmJsTest()
+
+// https://book.kotlincn.net/text/testing-strategies.html
+tasks.withType<Test> {
+    jvmArgs(
+        "--add-opens",
+        "java.base/jdk.internal.misc=ALL-UNNAMED",
+        "--add-exports",
+        "java.base/jdk.internal.util=ALL-UNNAMED",
+        "--add-exports",
+        "java.base/sun.security.action=ALL-UNNAMED"
+    )
+}

--- a/simbot-commons/simbot-common-streamable/src/commonMain/kotlin/love/forte/simbot/common/streamable/Streamable.kt
+++ b/simbot-commons/simbot-common-streamable/src/commonMain/kotlin/love/forte/simbot/common/streamable/Streamable.kt
@@ -1,0 +1,66 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.common.streamable
+
+
+/**
+ *
+ * 一个可流化的包装器类型。
+ * 用于提供更便捷地对 [Sequence] 进行转化的API。
+ *
+ * [Streamable] 是一种用于便捷操作的**转化器**，
+ * 而不是直接对流进行操作的类型。
+ * 它的作用是减小不同平台间对 [Sequence] 的部分操作差异。
+ *
+ * [Streamable] 会有部分平台专供的API，例如在 JVM 中可转化为 `Stream`。
+ *
+ * @since 4.4.0
+ *
+ * @author ForteScarlet
+ */
+public expect class Streamable<out T> private constructor(seq: Sequence<T>) : Iterable<T> {
+    /**
+     * 转化为 [Sequence].
+     */
+    public fun asSequence(): Sequence<T>
+
+    override fun iterator(): Iterator<T>
+
+    /**
+     * 将结果转化为 [List]
+     */
+    public fun collectToList(): List<T>
+
+    /**
+     * 将内部的序列结果收集到 [C] 中。
+     */
+    public fun <C : MutableCollection<in T>> collectTo(collection: C): C
+
+    public companion object {
+        /**
+         * 将 [Sequence] 转化为 [Streamable]
+         */
+        public fun <T> Sequence<T>.asStreamable(): Streamable<T>
+    }
+}

--- a/simbot-commons/simbot-common-streamable/src/jsMain/kotlin/love/forte/simbot/common/streamable/Streamable.js.kt
+++ b/simbot-commons/simbot-common-streamable/src/jsMain/kotlin/love/forte/simbot/common/streamable/Streamable.js.kt
@@ -1,0 +1,71 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.common.streamable
+
+/**
+ *
+ * 一个可流化的包装器类型。
+ * 用于提供更便捷地对 [Sequence] 进行转化的API。
+ *
+ * [Streamable] 是一种用于便捷操作的**转化器**，
+ * 而不是直接对流进行操作的类型。
+ * 它的作用是尽可能减小不同平台间对 [Sequence] 的操作差异。
+ *
+ * [Streamable] 会有部分平台专供的API，例如在 JVM 中可转化为 `Stream`。
+ *
+ * @since 4.4.0
+ *
+ * @author ForteScarlet
+ */
+public actual class Streamable<out T> private actual constructor(
+    private val seq: Sequence<T>
+) : Iterable<T> {
+    public actual fun asSequence(): Sequence<T> = seq
+    actual override fun iterator(): Iterator<T> = seq.iterator()
+
+    /**
+     * 将结果转化为 [List]
+     */
+    public actual fun collectToList(): List<T> = seq.toList()
+
+    /**
+     * 将内部的序列结果收集到 [C] 中。
+     */
+    public actual fun <C : MutableCollection<in T>> collectTo(collection: C): C =
+        seq.toCollection(collection)
+
+    /**
+     * 收集元素为数组。
+     */
+    public fun collectToArray(): Array<out T> =
+        seq.toList().toTypedArray()
+
+    public actual companion object {
+        /**
+         * 将 [Sequence] 转化为 [Streamable]
+         */
+        public actual fun <T> Sequence<T>.asStreamable(): Streamable<T> =
+            Streamable(this)
+    }
+}

--- a/simbot-commons/simbot-common-streamable/src/jvmMain/java/module-info.java
+++ b/simbot-commons/simbot-common-streamable/src/jvmMain/java/module-info.java
@@ -1,0 +1,5 @@
+module simbot.common.streamable {
+    requires kotlin.stdlib;
+
+    exports love.forte.simbot.common.streamable;
+}

--- a/simbot-commons/simbot-common-streamable/src/jvmMain/kotlin/love/forte/simbot/common/streamable/Streamable.jvm.kt
+++ b/simbot-commons/simbot-common-streamable/src/jvmMain/kotlin/love/forte/simbot/common/streamable/Streamable.jvm.kt
@@ -1,0 +1,77 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.common.streamable
+
+import java.util.stream.Stream
+import kotlin.streams.asStream
+
+/**
+ *
+ * 一个可流化的包装器类型。
+ * 用于提供更便捷地对 [Sequence] 进行转化的API。
+ *
+ * [Streamable] 是一种用于便捷操作的**转化器**，
+ * 而不是直接对流进行操作的类型。
+ * 它的作用是尽可能减小不同平台间对 [Sequence] 的操作差异。
+ *
+ * [Streamable] 会有部分平台专供的API，例如在 JVM 中可转化为 [Stream]。
+ *
+ * @since 4.4.0
+ *
+ * @author ForteScarlet
+ */
+public actual class Streamable<out T> private actual constructor(
+    private val seq: Sequence<T>
+) : Iterable<T> {
+    public actual fun asSequence(): Sequence<T> = seq
+    actual override fun iterator(): Iterator<T> = seq.iterator()
+
+    /**
+     * 将结果转化为 [List]
+     */
+    public actual fun collectToList(): List<T> = seq.toList()
+
+    /**
+     * 将内部的序列结果收集到 [C] 中。
+     */
+    public actual fun <C : MutableCollection<in T>> collectTo(collection: C): C =
+        seq.toCollection(collection)
+
+    // ↓ 为了这碟醋包了这盘饺子
+
+    /**
+     * 转化为 [Stream].
+     */
+    public fun asStream(): Stream<out T> = seq.asStream()
+
+    public actual companion object {
+        /**
+         * 将 [Sequence] 转化为 [Streamable]
+         */
+        @JvmName("of")
+        @JvmStatic
+        public actual fun <T> Sequence<T>.asStreamable(): Streamable<T> =
+            Streamable(this)
+    }
+}

--- a/simbot-commons/simbot-common-streamable/src/nativeMain/kotlin/love/forte/simbot/common/streamable/Streamable.native.kt
+++ b/simbot-commons/simbot-common-streamable/src/nativeMain/kotlin/love/forte/simbot/common/streamable/Streamable.native.kt
@@ -1,0 +1,66 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.common.streamable
+
+
+/**
+ *
+ * 一个可流化的包装器类型。
+ * 用于提供更便捷地对 [Sequence] 进行转化的API。
+ *
+ * [Streamable] 是一种用于便捷操作的**转化器**，
+ * 而不是直接对流进行操作的类型。
+ * 它的作用是尽可能减小不同平台间对 [Sequence] 的操作差异。
+ *
+ * [Streamable] 会有部分平台专供的API，例如在 JVM 中可转化为 `Stream`。
+ *
+ * @since 4.4.0
+ *
+ * @author ForteScarlet
+ */
+public actual class Streamable<out T> private actual constructor(
+    private val seq: Sequence<T>
+) : Iterable<T> {
+    public actual fun asSequence(): Sequence<T> = seq
+    actual override fun iterator(): Iterator<T> = seq.iterator()
+
+    /**
+     * 将结果转化为 [List]
+     */
+    public actual fun collectToList(): List<T> = seq.toList()
+
+    /**
+     * 将内部的序列结果收集到 [C] 中。
+     */
+    public actual fun <C : MutableCollection<in T>> collectTo(collection: C): C =
+        seq.toCollection(collection)
+
+    public actual companion object {
+        /**
+         * 将 [Sequence] 转化为 [Streamable]
+         */
+        public actual fun <T> Sequence<T>.asStreamable(): Streamable<T> =
+            Streamable(this)
+    }
+}

--- a/simbot-commons/simbot-common-streamable/src/wasmJsMain/kotlin/love/forte/simbot/common/streamable/Streamable.wasmJs.kt
+++ b/simbot-commons/simbot-common-streamable/src/wasmJsMain/kotlin/love/forte/simbot/common/streamable/Streamable.wasmJs.kt
@@ -1,0 +1,71 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.common.streamable
+
+/**
+ *
+ * 一个可流化的包装器类型。
+ * 用于提供更便捷地对 [Sequence] 进行转化的API。
+ *
+ * [Streamable] 是一种用于便捷操作的**转化器**，
+ * 而不是直接对流进行操作的类型。
+ * 它的作用是尽可能减小不同平台间对 [Sequence] 的操作差异。
+ *
+ * [Streamable] 会有部分平台专供的API，例如在 JVM 中可转化为 `Stream`。
+ *
+ * @since 4.4.0
+ *
+ * @author ForteScarlet
+ */
+public actual class Streamable<out T> private actual constructor(
+    private val seq: Sequence<T>
+) : Iterable<T> {
+    public actual fun asSequence(): Sequence<T> = seq
+    actual override fun iterator(): Iterator<T> = seq.iterator()
+
+    /**
+     * 将结果转化为 [List]
+     */
+    public actual fun collectToList(): List<T> = seq.toList()
+
+    /**
+     * 将内部的序列结果收集到 [C] 中。
+     */
+    public actual fun <C : MutableCollection<in T>> collectTo(collection: C): C =
+        seq.toCollection(collection)
+
+    /**
+     * 收集元素为数组。
+     */
+    public fun collectToArray(): Array<out T> =
+        seq.toList().toTypedArray()
+
+    public actual companion object {
+        /**
+         * 将 [Sequence] 转化为 [Streamable]
+         */
+        public actual fun <T> Sequence<T>.asStreamable(): Streamable<T> =
+            Streamable(this)
+    }
+}

--- a/simbot-cores/simbot-core-spring-boot-starter/src/test/kotlin/love/forte/simbot/spring/test/DefaultBinderTests.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter/src/test/kotlin/love/forte/simbot/spring/test/DefaultBinderTests.kt
@@ -1,0 +1,178 @@
+/*
+ *     Copyright (c) 2024. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.spring.test
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import love.forte.simbot.application.Application
+import love.forte.simbot.event.*
+import love.forte.simbot.quantcat.common.annotations.Filter
+import love.forte.simbot.quantcat.common.annotations.FilterValue
+import love.forte.simbot.quantcat.common.annotations.Listener
+import love.forte.simbot.spring.EnableSimbot
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.stereotype.Component
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertNull
+
+
+/**
+ * 测试来源：https://github.com/simple-robot/simpler-robot/issues/895
+ *
+ * @author ForteScarlet
+ */
+@SpringBootTest(
+    classes = [
+        DefaultBinderTests::class,
+        TestListenerContainer::class,
+    ]
+)
+@EnableSimbot
+open class DefaultBinderTests {
+
+    @Test
+    fun binderTest1(
+        @Autowired application: Application
+    ) {
+        fun Event.push(): List<EventResult> {
+            return runBlocking {
+                application.eventDispatcher.push(this@push)
+                    .throwIfError()
+                    .filterNotInvalid()
+                    .toList()
+            }
+        }
+
+        // test1: 应当得到 page=1, 因为匹配内容 page 实际不存在，使用默认值
+        mockk<MessageEvent>(relaxed = true) {
+            every { messageContent.plainText } returns "test_1 1"
+            assertEquals(1, push().first().content)
+        }
+
+        // test2(1): 符合匹配结果，应当得到 1
+        mockk<MessageEvent>(relaxed = true) {
+            every { messageContent.plainText } returns "test_2 1"
+            assertEquals("1", push().first().content)
+        }
+
+        // test2(2): 不符合匹配结果、不是required=false，理应报错
+        mockk<MessageEvent>(relaxed = true) {
+            every { messageContent.plainText } returns "test_2"
+            assertFails { push() }
+        }
+
+        // test3(1): 不符合匹配结果、不是required=false，但参数是可选的，使用默认值，即得到 null
+        mockk<MessageEvent>(relaxed = true) {
+            every { messageContent.plainText } returns "test_3"
+            assertNull(push().first().content)
+        }
+
+        // test3(2): 符合匹配结果、得到 "1"
+        mockk<MessageEvent>(relaxed = true) {
+            every { messageContent.plainText } returns "test_3 1"
+            assertEquals("1", push().first().content)
+        }
+
+        // test4(1): 不符合匹配结果、是required=false，参数是可选的，使用默认值，即得到 null
+        mockk<MessageEvent>(relaxed = true) {
+            every { messageContent.plainText } returns "test_4"
+            assertNull(push().first().content)
+        }
+
+        // test4(2): 符合匹配结果、得到 1
+        mockk<MessageEvent>(relaxed = true) {
+            every { messageContent.plainText } returns "test_4 1"
+            assertEquals(1, push().first().content)
+        }
+
+        // test5(1): 不符合匹配结果、不是required=false，参数是可选的，使用默认值，即得到 1
+        mockk<MessageEvent>(relaxed = true) {
+            every { messageContent.plainText } returns "test_5"
+            assertEquals(1, push().first().content)
+        }
+
+        // test5(2): 符合匹配结果、得到 2
+        mockk<MessageEvent>(relaxed = true) {
+            every { messageContent.plainText } returns "test_5 2"
+            assertEquals(2, push().first().content)
+        }
+
+        // test6(1): 不符合匹配结果、是required=false，参数是可选的，但是参数是可以为null的，因此会填充 null 而不是默认值
+        mockk<MessageEvent>(relaxed = true) {
+            every { messageContent.plainText } returns "test_6"
+            assertNull(push().first().content)
+        }
+
+        // test6(2): 符合匹配结果、得到 2
+        mockk<MessageEvent>(relaxed = true) {
+            every { messageContent.plainText } returns "test_6 2"
+            assertEquals(2, push().first().content)
+        }
+    }
+
+}
+
+@Component
+class TestListenerContainer {
+    @Listener
+    @Filter("^test_1(\\s+(?<page>\\d+))?")
+    fun MessageEvent.handle1(
+        @FilterValue("page", false) page: Int = 1
+    ): Int = page
+
+    @Listener
+    @Filter("^test_2(\\s+(?<page>\\d+))?")
+    fun MessageEvent.handle2(
+        @FilterValue("page") page: String?
+    ): String? = page
+
+    @Listener
+    @Filter("^test_3(\\s+(?<page>\\d+))?")
+    fun MessageEvent.handle3(
+        @FilterValue("page") page: String? = null
+    ): String? = page
+
+    @Listener
+    @Filter("^test_4(\\s+(?<page>\\d+))?")
+    fun MessageEvent.handle4(
+        @FilterValue("page", false) page: Int? = null
+    ): Int? = page
+
+    @Listener
+    @Filter("^test_5(\\s+(?<page>\\d+))?")
+    fun MessageEvent.handle5(
+        @FilterValue("page", false) page: Int = 1
+    ): Int = page
+
+    @Listener
+    @Filter("^test_6(\\s+(?<page>\\d+))?")
+    fun MessageEvent.handle6(
+        @FilterValue("page", false) page: Int? = 1
+    ): Int? = page
+}

--- a/simbot-cores/simbot-core-spring-boot-starter/src/test/kotlin/love/forte/simbot/spring/test/DefaultBinderTests.kt
+++ b/simbot-cores/simbot-core-spring-boot-starter/src/test/kotlin/love/forte/simbot/spring/test/DefaultBinderTests.kt
@@ -167,7 +167,7 @@ class TestListenerContainer {
     @Listener
     @Filter("^test_5(\\s+(?<page>\\d+))?")
     fun MessageEvent.handle5(
-        @FilterValue("page", false) page: Int = 1
+        @FilterValue("page") page: Int = 1
     ): Int = page
 
     @Listener

--- a/simbot-quantcat/simbot-quantcat-common/src/commonMain/kotlin/love/forte/simbot/quantcat/common/annotations/FilterValue.kt
+++ b/simbot-quantcat/simbot-quantcat-common/src/commonMain/kotlin/love/forte/simbot/quantcat/common/annotations/FilterValue.kt
@@ -4,7 +4,7 @@
  *     Project    https://github.com/simple-robot/simpler-robot
  *     Email      ForteScarlet@163.com
  *
- *     This file is part of the Simple Robot Library.
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Lesser General Public License as published by
@@ -26,14 +26,17 @@ package love.forte.simbot.quantcat.common.annotations
 import love.forte.simbot.quantcat.common.filter.FilterValueProperties
 
 /**
- * 指定一个参数，此参数为通过 [love.forte.simbot.quantcat.annotations.Filter]
+ * 指定一个参数，此参数为通过 [love.forte.simbot.quantcat.common.annotations.Filter]
  * 解析而得到的动态参数提取器中的内容。
  *
  * 参数提取格式基于正则匹配模式，参考 [Filter.value] 中的相关说明。
  *
  * @param value 所需动态参数的key。
  * @param required 对于参数绑定器来讲其是否为必须的。
- *  如果不是必须的，则在无法获取参数后传递null作为结果，否则将会抛出异常并交由后续绑定器处理。
+ * 如果不是必须的，则在无法获取参数后传递 `null` 作为结果
+ * (此结果被视为正确结果。换言之如果参数为 `nullable`，
+ * 但是存在一个不是 `null` 的默认值，则最终的参数值依然为 `null`)，
+ * 否则将会抛出异常并交由后续绑定器处理。
  */
 @Target(AnnotationTarget.VALUE_PARAMETER)
 public annotation class FilterValue(val value: String, val required: Boolean = true)

--- a/simbot-quantcat/simbot-quantcat-common/src/commonMain/kotlin/love/forte/simbot/quantcat/common/binder/ParameterBinder.kt
+++ b/simbot-quantcat/simbot-quantcat-common/src/commonMain/kotlin/love/forte/simbot/quantcat/common/binder/ParameterBinder.kt
@@ -4,7 +4,7 @@
  *     Project    https://github.com/simple-robot/simpler-robot
  *     Email      ForteScarlet@163.com
  *
- *     This file is part of the Simple Robot Library.
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Lesser General Public License as published by
@@ -29,6 +29,10 @@ import love.forte.simbot.event.EventListenerContext
  * 监听函数动态参数的绑定器。通过所需的执行参数而得到的参数绑定器。
  *
  * 对于一个可执行函数的参数 `KParameter` 所需的结果获取器。
+ *
+ * 没有任何绑定器时，
+ * 通常会使用 [EmptyBinder][love.forte.simbot.quantcat.common.binder.impl.EmptyBinder]，
+ * 当存在多个绑定器时，通常会使用 [MergedBinder][love.forte.simbot.quantcat.common.binder.impl.MergedBinder]。
  *
  */
 public interface ParameterBinder {


### PR DESCRIPTION
当一个监听函数的某个参数存在多个绑定器时：

评估过程中：

 - 如果参数不可为 `null`、评估结果为成功但是内容为 `null`、同时参数是可选的，
则会忽略此结果，视为无结果。
- 如果评估结果为失败，则暂记此异常，并视为无结果。

期间，遇到任何成功的、不符合上述会造成“无结果”条件的，
直接返回此评估结果，不再继续评估。

当所有binder评估完成，但没有遇到任何结果：

- 如果参数为可选，输出debug日志并使用 [ParameterBinder.Ignore] 标记直接使用默认值。
- 否则，返回 [Result.failure] 错误结果，并追加之前暂记的所有异常堆栈。

resolve #895
