### PR TITLE
增加若干内部事件、内部行为事件和相关的消息拦截事件

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ fun Application.registerListeners() {
 ## 协助我们
 为我们点亮一个 **✨star🌟** 便是能够给予我们继续走下去的最大动力与支持！
 
-- 阅读 [贡献指南](docs/CONTRIBUTING_CN.md) 来了解如何贡献你的力量！ 
+- 阅读 [**贡献指南**](docs/CONTRIBUTING_CN.md) 来了解如何贡献你的力量！ 
 - 你可以通过 [**讨论区**][discussions] 与其他人或者simbot开发团队相互友好交流。
 - 如果你通过此项目创建了一个很酷的开源项目，欢迎通过 [ISSUES][issues]、[讨论区][discussions]
   等方式留下你的开源项目信息，并将你酷酷的项目展示在作品展示区。

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -16,4 +16,7 @@ and the [Simple Robot Library](https://github.com/simple-robot-library)!
 
 ### Pull Request
 
+> [!info]
+> If you want to contribute code, please submit a Pull Request to the `v4-dev` development branch.
+
 TODO

--- a/docs/CONTRIBUTING_CN.md
+++ b/docs/CONTRIBUTING_CN.md
@@ -57,6 +57,10 @@ override val developers: List<Developer> = developers {
 为其他来者留下一盏指路的明灯~
 
 ## 代码贡献
+
+> [!info]
+> 如果您要提交代码贡献，请向开发分支 `v4-dev` 提交 PR 。
+
 ### 注释风格
 
 simbot核心库对源代码的注释有着一些约定。

--- a/simbot-api/api/simbot-api.api
+++ b/simbot-api/api/simbot-api.api
@@ -1003,7 +1003,7 @@ public abstract interface class love/forte/simbot/event/BotEvent : love/forte/si
 public abstract interface class love/forte/simbot/event/BotRegisteredEvent : love/forte/simbot/event/BotStageEvent {
 }
 
-public abstract interface class love/forte/simbot/event/BotStageEvent : love/forte/simbot/event/BotEvent {
+public abstract interface class love/forte/simbot/event/BotStageEvent : love/forte/simbot/event/BotEvent, love/forte/simbot/event/InternalNotificationEvent {
 	public abstract fun getBot ()Llove/forte/simbot/bot/Bot;
 }
 
@@ -1043,7 +1043,31 @@ public abstract interface class love/forte/simbot/event/ChatChannelEvent : love/
 	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
 }
 
+public abstract interface class love/forte/simbot/event/ChatChannelInteractionEvent : love/forte/simbot/event/ChatRoomInteractionEvent {
+	public abstract fun getContent ()Llove/forte/simbot/definition/ChatChannel;
+}
+
 public abstract interface class love/forte/simbot/event/ChatChannelMessageEvent : love/forte/simbot/event/ChatChannelEvent, love/forte/simbot/event/ChatRoomMessageEvent, love/forte/simbot/event/MemberAuthorAwareMessageEvent {
+}
+
+public abstract interface class love/forte/simbot/event/ChatChannelMessageEventInteractionEvent : love/forte/simbot/event/ChatRoomMessageEventInteractionEvent {
+	public abstract fun getContent ()Llove/forte/simbot/event/ChatChannelMessageEvent;
+}
+
+public abstract interface class love/forte/simbot/event/ChatChannelMessageEventPostReplyEvent : love/forte/simbot/event/ChatChannelMessageEventInteractionEvent, love/forte/simbot/event/ChatRoomMessageEventPostReplyEvent {
+	public abstract fun getContent ()Llove/forte/simbot/event/ChatChannelMessageEvent;
+}
+
+public abstract interface class love/forte/simbot/event/ChatChannelMessageEventPreReplyEvent : love/forte/simbot/event/ChatChannelMessageEventInteractionEvent, love/forte/simbot/event/ChatRoomMessageEventPreReplyEvent {
+	public abstract fun getContent ()Llove/forte/simbot/event/ChatChannelMessageEvent;
+}
+
+public abstract interface class love/forte/simbot/event/ChatChannelPostSendEvent : love/forte/simbot/event/ChatChannelInteractionEvent, love/forte/simbot/event/ChatRoomPostSendEvent {
+	public abstract fun getContent ()Llove/forte/simbot/definition/ChatChannel;
+}
+
+public abstract interface class love/forte/simbot/event/ChatChannelPreSendEvent : love/forte/simbot/event/ChatChannelInteractionEvent, love/forte/simbot/event/ChatRoomPreSendEvent {
+	public abstract fun getContent ()Llove/forte/simbot/definition/ChatChannel;
 }
 
 public abstract interface class love/forte/simbot/event/ChatGroupEvent : love/forte/simbot/event/ChatRoomEvent, love/forte/simbot/event/OrganizationEvent {
@@ -1055,6 +1079,10 @@ public abstract interface class love/forte/simbot/event/ChatGroupEvent : love/fo
 	public synthetic fun getContent ()Llove/forte/simbot/definition/Organization;
 	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
 	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/event/ChatGroupInteractionEvent : love/forte/simbot/event/ChatRoomInteractionEvent {
+	public abstract fun getContent ()Llove/forte/simbot/definition/ChatGroup;
 }
 
 public abstract interface class love/forte/simbot/event/ChatGroupJoinRequestEvent : love/forte/simbot/event/ChatGroupEvent, love/forte/simbot/event/OrganizationJoinRequestEvent {
@@ -1125,7 +1153,39 @@ public abstract interface class love/forte/simbot/event/ChatGroupMemberMessageEv
 	public abstract synthetic fun source (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public abstract interface class love/forte/simbot/event/ChatGroupMemberMessageEventInteractionEvent : love/forte/simbot/event/MessageEventInteractionEvent {
+	public abstract fun getContent ()Llove/forte/simbot/event/ChatGroupMemberMessageEvent;
+}
+
+public abstract interface class love/forte/simbot/event/ChatGroupMemberMessageEventPostReplyEvent : love/forte/simbot/event/ChatGroupMemberMessageEventInteractionEvent, love/forte/simbot/event/MessageEventPostReplyEvent {
+	public abstract fun getContent ()Llove/forte/simbot/event/ChatGroupMemberMessageEvent;
+}
+
+public abstract interface class love/forte/simbot/event/ChatGroupMemberMessageEventPreReplyEvent : love/forte/simbot/event/ChatGroupMemberMessageEventInteractionEvent, love/forte/simbot/event/MessageEventPreReplyEvent {
+	public abstract fun getContent ()Llove/forte/simbot/event/ChatGroupMemberMessageEvent;
+}
+
 public abstract interface class love/forte/simbot/event/ChatGroupMessageEvent : love/forte/simbot/event/ChatGroupEvent, love/forte/simbot/event/ChatRoomMessageEvent, love/forte/simbot/event/MemberAuthorAwareMessageEvent {
+}
+
+public abstract interface class love/forte/simbot/event/ChatGroupMessageEventInteractionEvent : love/forte/simbot/event/ChatRoomMessageEventInteractionEvent {
+	public abstract fun getContent ()Llove/forte/simbot/event/ChatGroupMessageEvent;
+}
+
+public abstract interface class love/forte/simbot/event/ChatGroupMessageEventPostReplyEvent : love/forte/simbot/event/ChatGroupMessageEventInteractionEvent, love/forte/simbot/event/ChatRoomMessageEventPostReplyEvent {
+	public abstract fun getContent ()Llove/forte/simbot/event/ChatGroupMessageEvent;
+}
+
+public abstract interface class love/forte/simbot/event/ChatGroupMessageEventPreReplyEvent : love/forte/simbot/event/ChatGroupMessageEventInteractionEvent, love/forte/simbot/event/ChatRoomMessageEventPreReplyEvent {
+	public abstract fun getContent ()Llove/forte/simbot/event/ChatGroupMessageEvent;
+}
+
+public abstract interface class love/forte/simbot/event/ChatGroupPostSendEvent : love/forte/simbot/event/ChatGroupInteractionEvent, love/forte/simbot/event/ChatRoomPostSendEvent {
+	public abstract fun getContent ()Llove/forte/simbot/definition/ChatGroup;
+}
+
+public abstract interface class love/forte/simbot/event/ChatGroupPreSendEvent : love/forte/simbot/event/ChatGroupInteractionEvent, love/forte/simbot/event/ChatRoomPreSendEvent {
+	public abstract fun getContent ()Llove/forte/simbot/definition/ChatGroup;
 }
 
 public abstract interface class love/forte/simbot/event/ChatRoomEvent : love/forte/simbot/event/ActorEvent {
@@ -1137,7 +1197,29 @@ public abstract interface class love/forte/simbot/event/ChatRoomEvent : love/for
 	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
 }
 
+public abstract interface class love/forte/simbot/event/ChatRoomInteractionEvent : love/forte/simbot/event/SendSupportInteractionEvent {
+	public abstract fun getContent ()Llove/forte/simbot/definition/ChatRoom;
+}
+
 public abstract interface class love/forte/simbot/event/ChatRoomMessageEvent : love/forte/simbot/event/ChatRoomEvent, love/forte/simbot/event/MessageEvent {
+}
+
+public abstract interface class love/forte/simbot/event/ChatRoomMessageEventInteractionEvent : love/forte/simbot/event/MessageEventInteractionEvent {
+	public abstract fun getContent ()Llove/forte/simbot/event/ChatRoomMessageEvent;
+}
+
+public abstract interface class love/forte/simbot/event/ChatRoomMessageEventPostReplyEvent : love/forte/simbot/event/ChatRoomMessageEventInteractionEvent, love/forte/simbot/event/MessageEventPostReplyEvent {
+}
+
+public abstract interface class love/forte/simbot/event/ChatRoomMessageEventPreReplyEvent : love/forte/simbot/event/ChatRoomMessageEventInteractionEvent, love/forte/simbot/event/MessageEventPreReplyEvent {
+}
+
+public abstract interface class love/forte/simbot/event/ChatRoomPostSendEvent : love/forte/simbot/event/ChatRoomInteractionEvent, love/forte/simbot/event/SendSupportPostSendEvent {
+	public abstract fun getContent ()Llove/forte/simbot/definition/ChatRoom;
+}
+
+public abstract interface class love/forte/simbot/event/ChatRoomPreSendEvent : love/forte/simbot/event/ChatRoomInteractionEvent, love/forte/simbot/event/SendSupportPreSendEvent {
+	public abstract fun getContent ()Llove/forte/simbot/definition/ChatRoom;
 }
 
 public abstract interface class love/forte/simbot/event/ComponentEvent : love/forte/simbot/event/Event {
@@ -1153,7 +1235,29 @@ public abstract interface class love/forte/simbot/event/ContactEvent : love/fort
 	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
 }
 
+public abstract interface class love/forte/simbot/event/ContactInteractionEvent : love/forte/simbot/event/SendSupportInteractionEvent {
+	public abstract fun getContent ()Llove/forte/simbot/definition/Contact;
+}
+
 public abstract interface class love/forte/simbot/event/ContactMessageEvent : love/forte/simbot/event/ContactEvent, love/forte/simbot/event/MessageEvent {
+}
+
+public abstract interface class love/forte/simbot/event/ContactMessageEventInteractionEvent : love/forte/simbot/event/MessageEventInteractionEvent {
+	public abstract fun getContent ()Llove/forte/simbot/event/ContactMessageEvent;
+}
+
+public abstract interface class love/forte/simbot/event/ContactMessageEventPostReplyEvent : love/forte/simbot/event/ContactMessageEventInteractionEvent, love/forte/simbot/event/MessageEventPostReplyEvent {
+}
+
+public abstract interface class love/forte/simbot/event/ContactMessageEventPreReplyEvent : love/forte/simbot/event/ContactMessageEventInteractionEvent, love/forte/simbot/event/MessageEventPreReplyEvent {
+}
+
+public abstract interface class love/forte/simbot/event/ContactPostSendEvent : love/forte/simbot/event/ContactInteractionEvent, love/forte/simbot/event/SendSupportPostSendEvent {
+	public abstract fun getContent ()Llove/forte/simbot/definition/Contact;
+}
+
+public abstract interface class love/forte/simbot/event/ContactPreSendEvent : love/forte/simbot/event/ContactInteractionEvent, love/forte/simbot/event/SendSupportPreSendEvent {
+	public abstract fun getContent ()Llove/forte/simbot/definition/Contact;
 }
 
 public abstract interface class love/forte/simbot/event/ContentEvent : love/forte/simbot/event/Event {
@@ -1452,6 +1556,88 @@ public abstract interface class love/forte/simbot/event/GuildMemberMessageEvent 
 	public abstract synthetic fun source (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public abstract interface class love/forte/simbot/event/GuildMemberMessageEventInteractionEvent : love/forte/simbot/event/MessageEventInteractionEvent {
+	public abstract fun getContent ()Llove/forte/simbot/event/GuildMemberMessageEvent;
+}
+
+public abstract interface class love/forte/simbot/event/GuildMemberMessageEventPostReplyEvent : love/forte/simbot/event/GuildMemberMessageEventInteractionEvent, love/forte/simbot/event/MessageEventPostReplyEvent {
+	public abstract fun getContent ()Llove/forte/simbot/event/GuildMemberMessageEvent;
+}
+
+public abstract interface class love/forte/simbot/event/GuildMemberMessageEventPreReplyEvent : love/forte/simbot/event/GuildMemberMessageEventInteractionEvent, love/forte/simbot/event/MessageEventPreReplyEvent {
+	public abstract fun getContent ()Llove/forte/simbot/event/GuildMemberMessageEvent;
+}
+
+public abstract class love/forte/simbot/event/InteractionMessage {
+	public static final field Companion Llove/forte/simbot/event/InteractionMessage$Companion;
+	public static final fun valueOf (Ljava/lang/String;)Llove/forte/simbot/event/InteractionMessage$Text;
+	public static final fun valueOf (Llove/forte/simbot/message/Message;)Llove/forte/simbot/event/InteractionMessage$Message;
+	public static final fun valueOf (Llove/forte/simbot/message/MessageContent;)Llove/forte/simbot/event/InteractionMessage$MessageContent;
+}
+
+public final class love/forte/simbot/event/InteractionMessage$Companion {
+	public final fun valueOf (Ljava/lang/String;)Llove/forte/simbot/event/InteractionMessage$Text;
+	public final fun valueOf (Llove/forte/simbot/message/Message;)Llove/forte/simbot/event/InteractionMessage$Message;
+	public final fun valueOf (Llove/forte/simbot/message/MessageContent;)Llove/forte/simbot/event/InteractionMessage$MessageContent;
+}
+
+public abstract class love/forte/simbot/event/InteractionMessage$Extension : love/forte/simbot/event/InteractionMessage {
+	public fun <init> ()V
+}
+
+public final class love/forte/simbot/event/InteractionMessage$Message : love/forte/simbot/event/InteractionMessage {
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Llove/forte/simbot/message/Message;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/event/InteractionMessage$MessageContent : love/forte/simbot/event/InteractionMessage {
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessageContent ()Llove/forte/simbot/message/MessageContent;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/event/InteractionMessage$Text : love/forte/simbot/event/InteractionMessage {
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/event/InternalEvent : love/forte/simbot/event/Event {
+}
+
+public abstract interface class love/forte/simbot/event/InternalInterceptionEvent : love/forte/simbot/event/InternalEvent {
+}
+
+public class love/forte/simbot/event/InternalInterceptionException : java/lang/RuntimeException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public abstract interface class love/forte/simbot/event/InternalMessageInteractionEvent : love/forte/simbot/event/InternalEvent {
+	public abstract fun getContent ()Ljava/lang/Object;
+	public abstract fun getMessage ()Llove/forte/simbot/event/InteractionMessage;
+}
+
+public abstract interface class love/forte/simbot/event/InternalMessagePostSendEvent : love/forte/simbot/event/InternalMessageInteractionEvent {
+	public abstract fun getMessage ()Llove/forte/simbot/event/InteractionMessage;
+	public abstract fun getReceipt ()Llove/forte/simbot/message/MessageReceipt;
+}
+
+public abstract interface class love/forte/simbot/event/InternalMessagePreSendEvent : love/forte/simbot/event/InternalInterceptionEvent, love/forte/simbot/event/InternalMessageInteractionEvent {
+	public abstract fun getCurrentMessage ()Llove/forte/simbot/event/InteractionMessage;
+	public abstract fun getMessage ()Llove/forte/simbot/event/InteractionMessage;
+	public abstract fun setCurrentMessage (Llove/forte/simbot/event/InteractionMessage;)V
+}
+
+public abstract interface class love/forte/simbot/event/InternalNotificationEvent : love/forte/simbot/event/InternalEvent {
+}
+
 public abstract interface class love/forte/simbot/event/JAsyncEventInterceptor : love/forte/simbot/event/EventInterceptor {
 	public fun createContext (Llove/forte/simbot/event/EventInterceptor$Context;)Llove/forte/simbot/event/JAsyncEventInterceptor$Context;
 	public synthetic fun intercept (Llove/forte/simbot/event/EventInterceptor$Context;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1598,7 +1784,31 @@ public abstract interface class love/forte/simbot/event/MemberIncreaseOrDecrease
 	public abstract synthetic fun member (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public abstract interface class love/forte/simbot/event/MemberInteractionEvent : love/forte/simbot/event/SendSupportInteractionEvent {
+	public abstract fun getContent ()Llove/forte/simbot/definition/Member;
+}
+
 public abstract interface class love/forte/simbot/event/MemberMessageEvent : love/forte/simbot/event/MemberEvent, love/forte/simbot/event/MessageEvent {
+}
+
+public abstract interface class love/forte/simbot/event/MemberMessageEventInteractionEvent : love/forte/simbot/event/MessageEventInteractionEvent {
+	public abstract fun getContent ()Llove/forte/simbot/event/MemberMessageEvent;
+}
+
+public abstract interface class love/forte/simbot/event/MemberMessageEventPostReplyEvent : love/forte/simbot/event/MemberMessageEventInteractionEvent, love/forte/simbot/event/MessageEventPostReplyEvent {
+	public abstract fun getContent ()Llove/forte/simbot/event/MemberMessageEvent;
+}
+
+public abstract interface class love/forte/simbot/event/MemberMessageEventPreReplyEvent : love/forte/simbot/event/MemberMessageEventInteractionEvent, love/forte/simbot/event/MessageEventPreReplyEvent {
+	public abstract fun getContent ()Llove/forte/simbot/event/MemberMessageEvent;
+}
+
+public abstract interface class love/forte/simbot/event/MemberPostSendEvent : love/forte/simbot/event/MemberInteractionEvent, love/forte/simbot/event/SendSupportPostSendEvent {
+	public abstract fun getContent ()Llove/forte/simbot/definition/Member;
+}
+
+public abstract interface class love/forte/simbot/event/MemberPreSendEvent : love/forte/simbot/event/MemberInteractionEvent, love/forte/simbot/event/SendSupportPreSendEvent {
+	public abstract fun getContent ()Llove/forte/simbot/definition/Member;
 }
 
 public abstract interface class love/forte/simbot/event/MessageContentAwareEvent : love/forte/simbot/event/Event {
@@ -1608,6 +1818,16 @@ public abstract interface class love/forte/simbot/event/MessageContentAwareEvent
 public abstract interface class love/forte/simbot/event/MessageEvent : love/forte/simbot/ability/ReplySupport, love/forte/simbot/event/BotEvent, love/forte/simbot/event/MessageContentAwareEvent {
 	public abstract fun getAuthorId ()Llove/forte/simbot/common/id/ID;
 	public abstract fun getMessageContent ()Llove/forte/simbot/message/MessageContent;
+}
+
+public abstract interface class love/forte/simbot/event/MessageEventInteractionEvent : love/forte/simbot/event/ReplySupportInteractionEvent {
+	public abstract fun getContent ()Llove/forte/simbot/event/MessageEvent;
+}
+
+public abstract interface class love/forte/simbot/event/MessageEventPostReplyEvent : love/forte/simbot/event/MessageEventInteractionEvent, love/forte/simbot/event/ReplySupportPostReplyEvent {
+}
+
+public abstract interface class love/forte/simbot/event/MessageEventPreReplyEvent : love/forte/simbot/event/MessageEventInteractionEvent, love/forte/simbot/event/ReplySupportPreReplyEvent {
 }
 
 public abstract interface class love/forte/simbot/event/OrganizationChangeEvent : love/forte/simbot/event/ChangeEvent, love/forte/simbot/event/OrganizationEvent {
@@ -1647,6 +1867,18 @@ public abstract interface class love/forte/simbot/event/OrganizationSourceEvent 
 	public abstract synthetic fun source (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public abstract interface class love/forte/simbot/event/ReplySupportInteractionEvent : love/forte/simbot/event/BotEvent, love/forte/simbot/event/InternalMessageInteractionEvent {
+	public abstract fun getBot ()Llove/forte/simbot/bot/Bot;
+	public abstract fun getContent ()Llove/forte/simbot/ability/ReplySupport;
+	public abstract fun getMessage ()Llove/forte/simbot/event/InteractionMessage;
+}
+
+public abstract interface class love/forte/simbot/event/ReplySupportPostReplyEvent : love/forte/simbot/event/InternalMessagePostSendEvent, love/forte/simbot/event/ReplySupportInteractionEvent {
+}
+
+public abstract interface class love/forte/simbot/event/ReplySupportPreReplyEvent : love/forte/simbot/event/InternalMessagePreSendEvent, love/forte/simbot/event/ReplySupportInteractionEvent {
+}
+
 public abstract interface class love/forte/simbot/event/RequestEvent : love/forte/simbot/ability/AcceptSupport, love/forte/simbot/ability/RejectSupport, love/forte/simbot/event/BotEvent {
 	public abstract synthetic fun accept (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun acceptAsync ()Ljava/util/concurrent/CompletableFuture;
@@ -1666,6 +1898,16 @@ public final class love/forte/simbot/event/RequestEvent$Type : java/lang/Enum {
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Llove/forte/simbot/event/RequestEvent$Type;
 	public static fun values ()[Llove/forte/simbot/event/RequestEvent$Type;
+}
+
+public abstract interface class love/forte/simbot/event/SendSupportInteractionEvent : love/forte/simbot/event/BotEvent, love/forte/simbot/event/InternalMessageInteractionEvent {
+	public abstract fun getContent ()Llove/forte/simbot/ability/SendSupport;
+}
+
+public abstract interface class love/forte/simbot/event/SendSupportPostSendEvent : love/forte/simbot/event/InternalMessagePostSendEvent, love/forte/simbot/event/SendSupportInteractionEvent {
+}
+
+public abstract interface class love/forte/simbot/event/SendSupportPreSendEvent : love/forte/simbot/event/InternalMessagePreSendEvent, love/forte/simbot/event/SendSupportInteractionEvent {
 }
 
 public abstract interface class love/forte/simbot/event/SourceEvent : love/forte/simbot/event/Event {

--- a/simbot-api/src/commonMain/kotlin/love/forte/simbot/ability/ReplySupport.kt
+++ b/simbot-api/src/commonMain/kotlin/love/forte/simbot/ability/ReplySupport.kt
@@ -1,10 +1,10 @@
 /*
- *     Copyright (c) 2024. ForteScarlet.
+ *     Copyright (c) 2024-2025. ForteScarlet.
  *
  *     Project    https://github.com/simple-robot/simpler-robot
  *     Email      ForteScarlet@163.com
  *
- *     This file is part of the Simple Robot Library.
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Lesser General Public License as published by
@@ -23,6 +23,7 @@
 
 package love.forte.simbot.ability
 
+import love.forte.simbot.event.InternalInterceptionException
 import love.forte.simbot.event.MessageEvent
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.MessageContent
@@ -45,6 +46,8 @@ public interface ReplySupport {
      * 发送一段纯文本消息。
      *
      * @return 消息发送成功后的回执
+     * @throws InternalInterceptionException 在拦截事件处理过程中产生的异常，
+     * 每一个具体的异常都会被收集在 [InternalInterceptionException.suppressedExceptions] 中。
      * @throws Exception 可能产生任何异常
      */
     public suspend fun reply(text: String): MessageReceipt
@@ -53,6 +56,8 @@ public interface ReplySupport {
      * 发送一个消息 [Message]。
      *
      * @return 消息发送成功后的回执
+     * @throws InternalInterceptionException 在拦截事件处理过程中产生的异常，
+     * 每一个具体的异常都会被收集在 [InternalInterceptionException.suppressedExceptions] 中。
      * @throws Exception 可能产生任何异常
      */
     public suspend fun reply(message: Message): MessageReceipt
@@ -63,6 +68,8 @@ public interface ReplySupport {
      * 并在不支持的情况下降级为使用 [MessageContent.messages]。
      *
      * @return 消息发送成功后的回执
+     * @throws InternalInterceptionException 在拦截事件处理过程中产生的异常，
+     * 每一个具体的异常都会被收集在 [InternalInterceptionException.suppressedExceptions] 中。
      * @throws Exception 可能产生任何异常
      */
     public suspend fun reply(messageContent: MessageContent): MessageReceipt

--- a/simbot-api/src/commonMain/kotlin/love/forte/simbot/ability/SendSupport.kt
+++ b/simbot-api/src/commonMain/kotlin/love/forte/simbot/ability/SendSupport.kt
@@ -1,10 +1,10 @@
 /*
- *     Copyright (c) 2024. ForteScarlet.
+ *     Copyright (c) 2024-2025. ForteScarlet.
  *
  *     Project    https://github.com/simple-robot/simpler-robot
  *     Email      ForteScarlet@163.com
  *
- *     This file is part of the Simple Robot Library.
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Lesser General Public License as published by
@@ -25,6 +25,7 @@ package love.forte.simbot.ability
 
 import love.forte.simbot.definition.Actor
 import love.forte.simbot.definition.Contact
+import love.forte.simbot.event.InternalInterceptionException
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.MessageContent
 import love.forte.simbot.message.MessageReceipt
@@ -42,6 +43,8 @@ public interface SendSupport {
      * 发送一段纯文本消息。
      *
      * @return 消息发送成功后的回执
+     * @throws InternalInterceptionException 在拦截事件处理过程中产生的异常，
+     * 每一个具体的异常都会被收集在 [InternalInterceptionException.suppressedExceptions] 中。
      * @throws Exception 可能产生任何异常
      */
     public suspend fun send(text: String): MessageReceipt
@@ -50,6 +53,8 @@ public interface SendSupport {
      * 发送一个消息 [Message]。
      *
      * @return 消息发送成功后的回执
+     * @throws InternalInterceptionException 在拦截事件处理过程中产生的异常，
+     * 每一个具体的异常都会被收集在 [InternalInterceptionException.suppressedExceptions] 中。
      * @throws Exception 可能产生任何异常
      */
     public suspend fun send(message: Message): MessageReceipt
@@ -60,6 +65,8 @@ public interface SendSupport {
      * 并在不支持的情况下降级为使用 [MessageContent.messages]。
      *
      * @return 消息发送成功后的回执
+     * @throws InternalInterceptionException 在拦截事件处理过程中产生的异常，
+     * 每一个具体的异常都会被收集在 [InternalInterceptionException.suppressedExceptions] 中。
      * @throws Exception 可能产生任何异常
      */
     public suspend fun send(messageContent: MessageContent): MessageReceipt

--- a/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/InteractionMessage.kt
+++ b/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/InteractionMessage.kt
@@ -1,0 +1,133 @@
+/*
+ *     Copyright (c) 2025. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.event
+
+import love.forte.simbot.ability.ReplySupport
+import love.forte.simbot.ability.SendSupport
+import kotlin.jvm.JvmStatic
+
+/**
+ * 拦截或通知中 [SendSupport.send] 或 [ReplySupport.reply] 的消息内容。
+ */
+public sealed class InteractionMessage {
+    /**
+     * 当参数类型为 [String] 时，表示发送的文本消息。
+     */
+    public class Text internal constructor(public val text: String) : InteractionMessage() {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Text) return false
+
+            if (text != other.text) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            return text.hashCode()
+        }
+
+        override fun toString(): String {
+            return "Text(text='$text')"
+        }
+    }
+
+    /**
+     * 当参数类型为 [love.forte.simbot.message.Message] 时，表示发送的消息。
+     */
+    public class Message internal constructor(public val message: love.forte.simbot.message.Message) :
+        InteractionMessage() {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Message) return false
+
+            if (message != other.message) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            return message.hashCode()
+        }
+
+        override fun toString(): String {
+            return "Message(message=$message)"
+        }
+
+    }
+
+    /**
+     * 当参数类型为 [love.forte.simbot.message.MessageContent] 时，表示发送的消息内容。
+     */
+    public class MessageContent internal constructor(
+        public val messageContent: love.forte.simbot.message.MessageContent
+    ) : InteractionMessage() {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is MessageContent) return false
+
+            if (messageContent != other.messageContent) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            return messageContent.hashCode()
+        }
+
+        override fun toString(): String {
+            return "MessageContent(messageContent=$messageContent)"
+        }
+    }
+
+    /**
+     * 如果组件或 [SendSupport] 的实现者提供了其他三个类型参数以外的参数，
+     * 则需要通过 [Extension] 对其进行扩展。
+     */
+    public abstract class Extension : InteractionMessage()
+
+    public companion object {
+        /**
+         * 创建一个文本消息。
+         * @see InteractionMessage
+         */
+        @JvmStatic
+        public fun valueOf(text: String): Text = Text(text)
+
+        /**
+         * 创建一个消息。
+         * @see InteractionMessage
+         */
+        @JvmStatic
+        public fun valueOf(message: love.forte.simbot.message.Message): Message = Message(message)
+
+        /**
+         * 创建一个消息内容。
+         * @see InteractionMessage
+         */
+        @JvmStatic
+        public fun valueOf(messageContent: love.forte.simbot.message.MessageContent): MessageContent =
+            MessageContent(messageContent)
+    }
+}

--- a/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/InternalEvent.kt
+++ b/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/InternalEvent.kt
@@ -1,0 +1,74 @@
+/*
+ *     Copyright (c) 2025. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.event
+
+
+/**
+ * 一个内部事件。
+ * 用于表示一个仅在内部流转、与外界无关的事件，
+ * 通常用于一些内部的状态通知或功能拦截，例如 [BotStageEvent] 或 [SendSupportInteractionEvent] 等。
+ *
+ * 通常由组件实现进行扩展，不过也提供了一些默认的定义。
+ *
+ * @see InternalNotificationEvent
+ * @see InternalInterceptionEvent
+ * @see BotStageEvent
+ * @see SendSupportInteractionEvent
+ *
+ * @since 4.11.0
+ * @author ForteScarlet
+ */
+public interface InternalEvent : Event
+
+/**
+ * 一个内部通知事件。
+ * 通知性质的内部事件通常仅用作“通知”，即它不会对某些行为造成影响。
+ *
+ * @since 4.11.0
+ */
+public interface InternalNotificationEvent : InternalEvent
+
+/**
+ * 一个内部拦截事件。
+ * 拦截性质的内部事件通常用作“拦截”，即它会对某些行为进行拦截，并有可能会产生影响，
+ * 例如改变原本行为的参数、或者通过抛出异常直接阻止某些行为的发生。
+ * 例如针对 [SendSupport.send][love.forte.simbot.ability.SendSupport.send]
+ * 进行拦截，并改变其入参。
+ *
+ * 在拦截过程中产生的异常应当最终在内部被包装为 [InternalInterceptionException] 再抛出。
+ *
+ * @since 4.11.0
+ *
+ */
+public interface InternalInterceptionEvent : InternalEvent
+
+/**
+ * [InternalInterceptionEvent] 中产生的异常的包装。
+ */
+public open class InternalInterceptionException : RuntimeException {
+    public constructor() : super()
+    public constructor(message: String?) : super(message)
+    public constructor(message: String?, cause: Throwable?) : super(message, cause)
+    public constructor(cause: Throwable?) : super(cause)
+}

--- a/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/InternalEvent.kt
+++ b/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/InternalEvent.kt
@@ -56,7 +56,11 @@ public interface InternalNotificationEvent : InternalEvent
  * 例如针对 [SendSupport.send][love.forte.simbot.ability.SendSupport.send]
  * 进行拦截，并改变其入参。
  *
- * 在拦截过程中产生的异常应当最终在内部被包装为 [InternalInterceptionException] 再抛出。
+ * ## 异常处理
+ *
+ * 在拦截过程中，如果产生了异常，它们不会影响后续事件的继续调度，
+ * 而所有产生的异常都会被收集到 [InternalInterceptionException.suppressedExceptions] 中，
+ * 并在最终抛出并影响原函数的执行。
  *
  * @since 4.11.0
  *
@@ -64,7 +68,11 @@ public interface InternalNotificationEvent : InternalEvent
 public interface InternalInterceptionEvent : InternalEvent
 
 /**
- * [InternalInterceptionEvent] 中产生的异常的包装。
+ * [InternalInterceptionEvent] 中产生的异常的收集与包装。
+ * 更多参考 [InternalInterceptionEvent] 中有关异常的说明。
+ *
+ * @see InternalInterceptionEvent
+ * @since 4.11.0
  */
 public open class InternalInterceptionException : RuntimeException {
     public constructor() : super()

--- a/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/InternalMessageInteractionEvent.kt
+++ b/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/InternalMessageInteractionEvent.kt
@@ -23,11 +23,20 @@
 
 package love.forte.simbot.event
 
+import love.forte.simbot.ability.ReplySupport
+import love.forte.simbot.ability.SendSupport
+import love.forte.simbot.message.MessageReceipt
 
 /**
  * 在内部一个跟 [Message][love.forte.simbot.message.Message] 的交互有关的事件。
  *
  * @since 4.11.0
+ *
+ * @see SendSupportInteractionEvent
+ * @see ReplySupportInteractionEvent
+ *
+ * @see SendSupport
+ * @see ReplySupport
  *
  * @author ForteScarlet
  */
@@ -38,7 +47,68 @@ public interface InternalMessageInteractionEvent : InternalEvent {
     public val content: Any
 
     /**
-     * 进行交互的消息内容。
+     * 进行交互的消息内容，例如
+     * [SendSupport.send] 或 [ReplySupport.reply]
+     * 调用时传递的参数。
      */
     public val message: InteractionMessage
+}
+
+/**
+ * 针对消息交互时的内部拦截事件，可以对其中的参数进行修改。
+ *
+ * 注意：尽可能避免在处理此事件的时候再次进行消息发送，
+ * 以避免出现循环导致应用程序资源匮乏或无法正常运行。
+ *
+ * @since 4.11.0
+ */
+public interface InternalMessagePreSendEvent :
+    InternalInterceptionEvent,
+    InternalMessageInteractionEvent {
+    /**
+     * 最初在消息发送
+     * (例如 [SendSupport.send] 或 [ReplySupport.reply] )
+     * 调用时传递的参数。
+     * 不会因为 [currentMessage] 的变化而改变。
+     */
+    override val message: InteractionMessage
+
+    /**
+     * 可以进行修改的 [InteractionMessage] 内容，会在事件处理完成后被替换为原本的参数。
+     *
+     * [currentMessage] 的变化不会影响 [message] 的值。
+     *
+     * 修改不是线程安全的，不要并发地进行修改，也不可以在异步中延迟修改。
+     * 如果在 [currentMessage] 已经被使用后仍尝试修改，会抛出 [IllegalStateException]。
+     *
+     * @throws IllegalStateException 如果在 [currentMessage] 已经被使用后仍尝试修改，会抛出此异常。
+     */
+    public var currentMessage: InteractionMessage
+}
+
+/**
+ * 针对消息发送
+ * (例如 [SendSupport.send] 或 [ReplySupport.reply] )
+ * 成功后的内部通知事件。
+ * 会在相关API执行成功后带着它的相关结果进行异步通知。
+ *
+ * 注意：尽可能避免在处理此事件的时候再次进行消息发送，
+ * 以避免出现循环导致应用程序资源匮乏或无法正常运行。
+ *
+ * @since 4.11.0
+ */
+public interface InternalMessagePostSendEvent : InternalMessageInteractionEvent {
+    /**
+     * 在消息发送时
+     * (例如 [SendSupport.send] 或 [ReplySupport.reply] )
+     * 实际传递的参数。
+     */
+    override val message: InteractionMessage
+
+    /**
+     * 消息发送
+     * (例如 [SendSupport.send] 或 [ReplySupport.reply] )
+     * 成功后的结果。
+     */
+    public val receipt: MessageReceipt
 }

--- a/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/InternalMessageInteractionEvent.kt
+++ b/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/InternalMessageInteractionEvent.kt
@@ -1,5 +1,5 @@
 /*
- *     Copyright (c) 2024-2025. ForteScarlet.
+ *     Copyright (c) 2025. ForteScarlet.
  *
  *     Project    https://github.com/simple-robot/simpler-robot
  *     Email      ForteScarlet@163.com
@@ -23,33 +23,22 @@
 
 package love.forte.simbot.event
 
-import love.forte.simbot.bot.Bot
-import love.forte.simbot.bot.BotManager
-
 
 /**
- * 与 Bot 相关的阶段性事件。
- * 例如bot被注册了、bot被启动了。
+ * 在内部一个跟 [Message][love.forte.simbot.message.Message] 的交互有关的事件。
+ *
+ * @since 4.11.0
  *
  * @author ForteScarlet
  */
-public interface BotStageEvent : InternalNotificationEvent, BotEvent {
+public interface InternalMessageInteractionEvent : InternalEvent {
     /**
-     * 相关的 bot.
+     * 进行消息交互的实体。
      */
-    override val bot: Bot
+    public val content: Any
+
+    /**
+     * 进行交互的消息内容。
+     */
+    public val message: InteractionMessage
 }
-
-/**
- * 当一个 Bot 已经在某个 [BotManager] 中被注册后的事件。
- *
- * @author ForteScarlet
- */
-public interface BotRegisteredEvent : BotStageEvent
-
-/**
- * 当一个 Bot **首次** 启动成功后的事件。
- *
- * @author ForteScarlet
- */
-public interface BotStartedEvent : BotStageEvent

--- a/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/ReplySupportInteractionEvent.kt
+++ b/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/ReplySupportInteractionEvent.kt
@@ -1,0 +1,360 @@
+/*
+ *     Copyright (c) 2025. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.event
+
+import love.forte.simbot.ability.ReplySupport
+import love.forte.simbot.bot.Bot
+
+
+/**
+ * 针对 [ReplySupport] 的内部交互事件，包括送信前的拦截与送信成功后的通知。
+ *
+ * @since 4.11.0
+ * @author ForteScarlet
+ */
+public interface ReplySupportInteractionEvent : BotEvent, InternalMessageInteractionEvent {
+    /**
+     * 所属Bot。
+     */
+    override val bot: Bot
+
+    /**
+     * 当前进行行为的 [ReplySupport] 实例。
+     */
+    override val content: ReplySupport
+
+    /**
+     * [ReplySupport.reply] 所尝试进行传递的参数。
+     */
+    override val message: InteractionMessage
+}
+
+/**
+ * 针对 [ReplySupport.reply] 的内部拦截事件。
+ * 可以对其中的参数进行修改。
+ *
+ * 注意：尽可能避免在处理此事件的时候再次进行消息发送，
+ * 以避免出现循环导致应用程序资源匮乏或无法正常运行。
+ *
+ * @since 4.11.0
+ * @see ReplySupport
+ */
+public interface ReplySupportPreReplyEvent : ReplySupportInteractionEvent, InternalMessagePreSendEvent
+
+/**
+ * 针对 [ReplySupport.reply] 的内部通知事件。
+ * 会在 [ReplySupport.reply] 执行成功后带着它的相关结果进行异步通知。
+ *
+ * 注意：尽可能避免在处理此事件的时候再次进行消息发送，
+ * 以避免出现循环导致应用程序资源匮乏或无法正常运行。
+ *
+ * @see ReplySupport
+ *
+ * @since 4.11.0
+ */
+public interface ReplySupportPostReplyEvent : ReplySupportInteractionEvent, InternalMessagePostSendEvent
+
+// region MessageEvent
+
+/**
+ * 针对 [MessageEvent.reply] 的内部交互事件。
+ *
+ * @see MessageEvent
+ * @since 4.11.0
+ */
+public interface MessageEventInteractionEvent : ReplySupportInteractionEvent {
+    override val content: MessageEvent
+}
+
+/**
+ * 针对 [MessageEvent.reply] 的内部拦截事件。
+ * 可以对其中的参数进行修改。
+ *
+ * @see MessageEvent
+ * @since 4.11.0
+ */
+public interface MessageEventPreReplyEvent : MessageEventInteractionEvent, ReplySupportPreReplyEvent
+
+/**
+ * 针对 [MessageEvent.reply] 的内部通知事件。
+ * 会在 [MessageEvent.reply] 执行成功后带着它的相关结果进行异步通知。
+ *
+ * @see MessageEvent
+ * @since 4.11.0
+ */
+public interface MessageEventPostReplyEvent : MessageEventInteractionEvent, ReplySupportPostReplyEvent
+// endregion
+
+// region Contact
+
+/**
+ * 针对 [ContactMessageEvent.reply] 的内部交互事件。
+ *
+ * @see ContactMessageEvent
+ * @since 4.11.0
+ */
+public interface ContactMessageEventInteractionEvent : MessageEventInteractionEvent {
+    override val content: ContactMessageEvent
+}
+
+/**
+ * 针对 [ContactMessageEvent.reply] 的内部拦截事件。
+ * 可以对其中的参数进行修改。
+ *
+ * @since 4.11.0
+ * @see ContactMessageEvent
+ */
+public interface ContactMessageEventPreReplyEvent : ContactMessageEventInteractionEvent, MessageEventPreReplyEvent
+
+/**
+ * 针对 [ContactMessageEvent.reply] 的内部通知事件。
+ * 会在 [ContactMessageEvent.reply] 执行成功后带着它的相关结果进行异步通知。
+ *
+ * @since 4.11.0
+ * @see ContactMessageEvent
+ */
+public interface ContactMessageEventPostReplyEvent : ContactMessageEventInteractionEvent, MessageEventPostReplyEvent
+
+// endregion
+
+//region ChatRoom
+
+/**
+ * 针对 [ChatRoomMessageEvent.reply] 的内部交互事件。
+ *
+ * @since 4.11.0
+ * @see ChatRoomMessageEvent
+ */
+public interface ChatRoomMessageEventInteractionEvent : MessageEventInteractionEvent {
+    override val content: ChatRoomMessageEvent
+}
+
+/**
+ * 针对 [ChatRoomMessageEvent.reply] 的内部拦截事件。
+ * 可以对其中的参数进行修改。
+ *
+ * @since 4.11.0
+ * @see ChatRoomMessageEvent
+ */
+public interface ChatRoomMessageEventPreReplyEvent : ChatRoomMessageEventInteractionEvent, MessageEventPreReplyEvent
+
+/**
+ * 针对 [ChatRoomMessageEvent.reply] 的内部通知事件。
+ * 会在 [ChatRoomMessageEvent.reply] 执行成功后带着它的相关结果进行异步通知。
+ *
+ * @since 4.11.0
+ * @see ChatRoomMessageEvent
+ */
+public interface ChatRoomMessageEventPostReplyEvent : ChatRoomMessageEventInteractionEvent, MessageEventPostReplyEvent
+
+//region ChatGroup
+
+/**
+ * 针对 [ChatGroupMessageEvent.reply] 的内部交互事件。
+ *
+ * @since 4.11.0
+ * @see ChatGroupMessageEvent
+ */
+public interface ChatGroupMessageEventInteractionEvent : ChatRoomMessageEventInteractionEvent {
+    override val content: ChatGroupMessageEvent
+}
+
+/**
+ * 针对 [ChatGroupMessageEvent.reply] 的内部拦截事件。
+ * 可以对其中的参数进行修改。
+ *
+ * @since 4.11.0
+ * @see ChatGroupMessageEvent
+ */
+public interface ChatGroupMessageEventPreReplyEvent :
+    ChatGroupMessageEventInteractionEvent,
+    ChatRoomMessageEventPreReplyEvent {
+    override val content: ChatGroupMessageEvent
+}
+
+/**
+ * 针对 [ChatGroupMessageEvent.reply] 的内部通知事件。
+ * 会在 [ChatGroupMessageEvent.reply] 执行成功后带着它的相关结果进行异步通知。
+ *
+ * @since 4.11.0
+ * @see ChatGroupMessageEvent
+ */
+public interface ChatGroupMessageEventPostReplyEvent :
+    ChatGroupMessageEventInteractionEvent,
+    ChatRoomMessageEventPostReplyEvent {
+    override val content: ChatGroupMessageEvent
+}
+//endregion
+//region ChatChannel
+
+/**
+ * 针对 [ChatChannelMessageEvent.reply] 的内部交互事件。
+ *
+ * @since 4.11.0
+ * @see ChatChannelMessageEvent
+ */
+public interface ChatChannelMessageEventInteractionEvent : ChatRoomMessageEventInteractionEvent {
+    override val content: ChatChannelMessageEvent
+}
+
+/**
+ * 针对 [ChatChannelMessageEvent.reply] 的内部拦截事件。
+ * 可以对其中的参数进行修改。
+ *
+ * @since 4.11.0
+ * @see ChatChannelMessageEvent
+ */
+public interface ChatChannelMessageEventPreReplyEvent :
+    ChatChannelMessageEventInteractionEvent,
+    ChatRoomMessageEventPreReplyEvent {
+    override val content: ChatChannelMessageEvent
+}
+
+/**
+ * 针对 [ChatChannelMessageEvent.reply] 的内部通知事件。
+ * 会在 [ChatChannelMessageEvent.reply] 执行成功后带着它的相关结果进行异步通知。
+ *
+ * @since 4.11.0
+ * @see ChatChannelMessageEvent
+ */
+public interface ChatChannelMessageEventPostReplyEvent :
+    ChatChannelMessageEventInteractionEvent,
+    ChatRoomMessageEventPostReplyEvent {
+    override val content: ChatChannelMessageEvent
+}
+//endregion
+//endregion
+
+//region Member
+
+/**
+ * 针对 [MemberMessageEvent.reply] 的内部交互事件。
+ *
+ * @since 4.11.0
+ * @see MemberMessageEvent
+ */
+public interface MemberMessageEventInteractionEvent : MessageEventInteractionEvent {
+    override val content: MemberMessageEvent
+}
+
+/**
+ * 针对 [MemberMessageEvent.reply] 的内部拦截事件。
+ * 可以对其中的参数进行修改。
+ *
+ * @since 4.11.0
+ * @see MemberMessageEvent
+ */
+public interface MemberMessageEventPreReplyEvent : MemberMessageEventInteractionEvent, MessageEventPreReplyEvent {
+    override val content: MemberMessageEvent
+}
+
+/**
+ * 针对 [MemberMessageEvent.reply] 的内部通知事件。
+ * 会在 [MemberMessageEvent.reply] 执行成功后带着它的相关结果进行异步通知。
+ *
+ * @since 4.11.0
+ * @see MemberMessageEvent
+ */
+public interface MemberMessageEventPostReplyEvent : MemberMessageEventInteractionEvent, MessageEventPostReplyEvent {
+    override val content: MemberMessageEvent
+}
+//endregion
+
+//region GuildMember
+
+/**
+ * 针对 [GuildMemberMessageEvent.reply] 的内部交互事件。
+ *
+ * @since 4.11.0
+ * @see GuildMemberMessageEvent
+ */
+public interface GuildMemberMessageEventInteractionEvent : MessageEventInteractionEvent {
+    override val content: GuildMemberMessageEvent
+}
+
+/**
+ * 针对 [GuildMemberMessageEvent.reply] 的内部拦截事件。
+ * 可以对其中的参数进行修改。
+ *
+ * @since 4.11.0
+ * @see GuildMemberMessageEvent
+ */
+public interface GuildMemberMessageEventPreReplyEvent :
+    GuildMemberMessageEventInteractionEvent,
+    MessageEventPreReplyEvent {
+    override val content: GuildMemberMessageEvent
+}
+
+/**
+ * 针对 [GuildMemberMessageEvent.reply] 的内部通知事件。
+ * 会在 [GuildMemberMessageEvent.reply] 执行成功后带着它的相关结果进行异步通知。
+ *
+ * @since 4.11.0
+ * @see GuildMemberMessageEvent
+ */
+public interface GuildMemberMessageEventPostReplyEvent :
+    GuildMemberMessageEventInteractionEvent,
+    MessageEventPostReplyEvent {
+    override val content: GuildMemberMessageEvent
+}
+//endregion
+
+//region ChatGroupMember
+
+/**
+ * 针对 [ChatGroupMemberMessageEvent.reply] 的内部交互事件。
+ *
+ * @since 4.11.0
+ * @see ChatGroupMemberMessageEvent
+ */
+public interface ChatGroupMemberMessageEventInteractionEvent : MessageEventInteractionEvent {
+    override val content: ChatGroupMemberMessageEvent
+}
+
+/**
+ * 针对 [ChatGroupMemberMessageEvent.reply] 的内部拦截事件。
+ * 可以对其中的参数进行修改。
+ *
+ * @since 4.11.0
+ * @see ChatGroupMemberMessageEvent
+ */
+public interface ChatGroupMemberMessageEventPreReplyEvent :
+    ChatGroupMemberMessageEventInteractionEvent,
+    MessageEventPreReplyEvent {
+    override val content: ChatGroupMemberMessageEvent
+}
+
+/**
+ * 针对 [ChatGroupMemberMessageEvent.reply] 的内部通知事件。
+ * 会在 [ChatGroupMemberMessageEvent.reply] 执行成功后带着它的相关结果进行异步通知。
+ *
+ * @since 4.11.0
+ * @see ChatGroupMemberMessageEvent
+ */
+public interface ChatGroupMemberMessageEventPostReplyEvent :
+    ChatGroupMemberMessageEventInteractionEvent,
+    MessageEventPostReplyEvent {
+    override val content: ChatGroupMemberMessageEvent
+}
+//endregion

--- a/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/SendSupportInteractionEvent.kt
+++ b/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/SendSupportInteractionEvent.kt
@@ -24,9 +24,7 @@
 package love.forte.simbot.event
 
 import love.forte.simbot.ability.SendSupport
-import love.forte.simbot.bot.Bot
 import love.forte.simbot.definition.*
-import love.forte.simbot.message.MessageReceipt
 
 
 /**
@@ -39,69 +37,35 @@ import love.forte.simbot.message.MessageReceipt
  */
 public interface SendSupportInteractionEvent : BotEvent, InternalMessageInteractionEvent {
     /**
-     * 所属Bot。
-     */
-    override val bot: Bot
-
-    /**
      * 当前进行行为的 [SendSupport] 实例。
      */
     override val content: SendSupport
-
-    /**
-     * [SendSupport.send] 所尝试进行传递的参数。
-     */
-    override val message: InteractionMessage
 }
 
 /**
  * 针对 [SendSupport.send] 的内部拦截事件。
  * 可以对其中的参数进行修改。
  *
+ * 注意：尽可能避免在处理此事件的时候再次进行消息发送，
+ * 以避免出现循环导致应用程序资源匮乏或无法正常运行。
+ *
  * @since 4.11.0
  * @see SendSupport
  */
-public interface SendSupportPreSendEvent :
-    SendSupportInteractionEvent, InternalInterceptionEvent {
-    /**
-     * 最初在 [SendSupport.send] 调用时传递的参数。
-     * 不会因为 [currentMessage] 的变化而改变。
-     */
-    override val message: InteractionMessage
-
-    /**
-     * 可以进行修改的 [InteractionMessage] 内容，会在事件处理完成后被替换为原本的参数。
-     *
-     * [currentMessage] 的变化不会影响 [message] 的值。
-     *
-     * 修改不是线程安全的，不要并发地进行修改，也不可以在异步中延迟修改。
-     * 如果在 [currentMessage] 已经被使用后仍尝试修改，会抛出 [IllegalStateException]。
-     *
-     * @throws IllegalStateException 如果在 [currentMessage] 已经被使用后仍尝试修改，会抛出此异常。
-     */
-    public var currentMessage: InteractionMessage
-}
+public interface SendSupportPreSendEvent : SendSupportInteractionEvent, InternalMessagePreSendEvent
 
 /**
  * 针对 [SendSupport.send] 的内部通知事件。
  * 会在 [SendSupport.send] 执行成功后带着它的相关结果进行异步通知。
  *
+ * 注意：尽可能避免在处理此事件的时候再次进行消息发送，
+ * 以避免出现循环导致应用程序资源匮乏或无法正常运行。
+ *
  * @see SendSupport
  *
  * @since 4.11.0
  */
-public interface SendSupportPostSendEvent :
-    SendSupportInteractionEvent, InternalNotificationEvent {
-    /**
-     * 在 [SendSupport.send] 调用时传递的参数。
-     */
-    override val message: InteractionMessage
-
-    /**
-     * [SendSupport.send] 执行成功后的结果。
-     */
-    public val receipt: MessageReceipt
-}
+public interface SendSupportPostSendEvent : SendSupportInteractionEvent, InternalMessagePostSendEvent
 
 //region Contact
 

--- a/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/SendSupportInteractionEvent.kt
+++ b/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/SendSupportInteractionEvent.kt
@@ -1,0 +1,260 @@
+/*
+ *     Copyright (c) 2025. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package love.forte.simbot.event
+
+import love.forte.simbot.ability.SendSupport
+import love.forte.simbot.bot.Bot
+import love.forte.simbot.definition.*
+import love.forte.simbot.message.MessageReceipt
+
+
+/**
+ * 针对 [SendSupport] 的内部交互事件，包括送信前的拦截与送信成功后的通知。
+ *
+ * @see SendSupport
+ *
+ * @since 4.11.0
+ * @author ForteScarlet
+ */
+public interface SendSupportInteractionEvent : BotEvent, InternalMessageInteractionEvent {
+    /**
+     * 所属Bot。
+     */
+    override val bot: Bot
+
+    /**
+     * 当前进行行为的 [SendSupport] 实例。
+     */
+    override val content: SendSupport
+
+    /**
+     * [SendSupport.send] 所尝试进行传递的参数。
+     */
+    override val message: InteractionMessage
+}
+
+/**
+ * 针对 [SendSupport.send] 的内部拦截事件。
+ * 可以对其中的参数进行修改。
+ *
+ * @since 4.11.0
+ * @see SendSupport
+ */
+public interface SendSupportPreSendEvent :
+    SendSupportInteractionEvent, InternalInterceptionEvent {
+    /**
+     * 最初在 [SendSupport.send] 调用时传递的参数。
+     * 不会因为 [currentMessage] 的变化而改变。
+     */
+    override val message: InteractionMessage
+
+    /**
+     * 可以进行修改的 [InteractionMessage] 内容，会在事件处理完成后被替换为原本的参数。
+     *
+     * [currentMessage] 的变化不会影响 [message] 的值。
+     *
+     * 修改不是线程安全的，不要并发地进行修改，也不可以在异步中延迟修改。
+     * 如果在 [currentMessage] 已经被使用后仍尝试修改，会抛出 [IllegalStateException]。
+     *
+     * @throws IllegalStateException 如果在 [currentMessage] 已经被使用后仍尝试修改，会抛出此异常。
+     */
+    public var currentMessage: InteractionMessage
+}
+
+/**
+ * 针对 [SendSupport.send] 的内部通知事件。
+ * 会在 [SendSupport.send] 执行成功后带着它的相关结果进行异步通知。
+ *
+ * @see SendSupport
+ *
+ * @since 4.11.0
+ */
+public interface SendSupportPostSendEvent :
+    SendSupportInteractionEvent, InternalNotificationEvent {
+    /**
+     * 在 [SendSupport.send] 调用时传递的参数。
+     */
+    override val message: InteractionMessage
+
+    /**
+     * [SendSupport.send] 执行成功后的结果。
+     */
+    public val receipt: MessageReceipt
+}
+
+//region Contact
+
+/**
+ * 针对 [Contact.send] 的内部交互事件。
+ * @see Contact
+ * @since 4.11.0
+ */
+public interface ContactInteractionEvent : SendSupportInteractionEvent {
+    override val content: Contact
+}
+
+/**
+ * 针对 [Member.send] 的内部交互事件, 在 [Member.send] 执行前拦截。
+ * @see Contact
+ * @since 4.11.0
+ */
+public interface ContactPreSendEvent : ContactInteractionEvent, SendSupportPreSendEvent {
+    override val content: Contact
+}
+
+/**
+ * 针对 [Member.send] 的内部交互事件, 在 [Member.send] 执行后通知。
+ * @see Contact
+ * @since 4.11.0
+ */
+public interface ContactPostSendEvent : ContactInteractionEvent, SendSupportPostSendEvent {
+    override val content: Contact
+}
+//endregion
+
+//region Member
+
+/**
+ * 针对 [Member] 的内部交互事件。
+ * @see Member
+ * @since 4.11.0
+ */
+public interface MemberInteractionEvent : SendSupportInteractionEvent {
+    override val content: Member
+}
+
+/**
+ * 针对 [Member] 的内部交互事件, 在 [Member.send] 执行前拦截。
+ * @see Member
+ * @since 4.11.0
+ */
+public interface MemberPreSendEvent : MemberInteractionEvent, SendSupportPreSendEvent {
+    override val content: Member
+}
+
+/**
+ * 针对 [Member] 的内部交互事件, 在 [Member.send] 执行后通知。
+ * @see Member
+ * @since 4.11.0
+ */
+public interface MemberPostSendEvent : MemberInteractionEvent, SendSupportPostSendEvent {
+    override val content: Member
+}
+//endregion
+
+//region ChatRoom
+
+/**
+ * 针对 [ChatRoom] 的内部交互事件。
+ * @see ChatRoom
+ * @since 4.11.0
+ */
+public interface ChatRoomInteractionEvent : SendSupportInteractionEvent {
+    override val content: ChatRoom
+}
+
+/**
+ * 针对 [ChatRoom] 的内部交互事件, 在 [ChatRoom.send] 执行前拦截。
+ * @see ChatRoom
+ * @since 4.11.0
+ */
+public interface ChatRoomPreSendEvent : ChatRoomInteractionEvent, SendSupportPreSendEvent {
+    override val content: ChatRoom
+}
+
+/**
+ * 针对 [ChatRoom] 的内部交互事件, 在 [ChatRoom.send] 执行后通知。
+ * @see ChatRoom
+ * @since 4.11.0
+ */
+public interface ChatRoomPostSendEvent : ChatRoomInteractionEvent, SendSupportPostSendEvent {
+    override val content: ChatRoom
+}
+//endregion
+
+//region ChatGroup
+
+/**
+ * 针对 [ChatGroup] 的内部交互事件。
+ * @see ChatGroup
+ * @since 4.11.0
+ */
+public interface ChatGroupInteractionEvent : ChatRoomInteractionEvent {
+    override val content: ChatGroup
+}
+
+/**
+ * 针对 [ChatGroup] 的内部交互事件, 在 [ChatGroup.send] 执行前拦截。
+ * @see ChatGroup
+ * @since 4.11.0
+ */
+public interface ChatGroupPreSendEvent : ChatGroupInteractionEvent, ChatRoomPreSendEvent {
+    override val content: ChatGroup
+}
+
+/**
+ * 针对 [ChatGroup] 的内部交互事件, 在 [ChatGroup.send] 执行后通知。
+ * @see ChatGroup
+ * @since 4.11.0
+ */
+public interface ChatGroupPostSendEvent : ChatGroupInteractionEvent, ChatRoomPostSendEvent {
+    override val content: ChatGroup
+}
+//endregion
+
+//region ChatChannel
+
+/**
+ * 针对 [ChatChannel] 的内部交互事件。
+ *
+ * @see ChatChannel
+ *
+ * @since 4.11.0
+ */
+public interface ChatChannelInteractionEvent : ChatRoomInteractionEvent {
+    override val content: ChatChannel
+}
+
+/**
+ * 针对 [ChatChannel] 的内部交互事件, 在 [ChatChannel.send] 执行前拦截。
+ * @see ChatChannel
+ * @since 4.11.0
+ */
+public interface ChatChannelPreSendEvent :
+    ChatChannelInteractionEvent,
+    ChatRoomPreSendEvent {
+    override val content: ChatChannel
+}
+
+/**
+ * 针对 [ChatChannel] 的内部交互事件, 在 [ChatChannel.send] 执行后通知。
+ * @see ChatChannel
+ * @since 4.11.0
+ */
+public interface ChatChannelPostSendEvent :
+    ChatChannelInteractionEvent,
+    ChatRoomPostSendEvent {
+    override val content: ChatChannel
+}
+//endregion

--- a/simbot-api/src/jvmTest/kotlin/event/InternalInteractionEventTests.kt
+++ b/simbot-api/src/jvmTest/kotlin/event/InternalInteractionEventTests.kt
@@ -1,0 +1,114 @@
+/*
+ *     Copyright (c) 2025. ForteScarlet.
+ *
+ *     Project    https://github.com/simple-robot/simpler-robot
+ *     Email      ForteScarlet@163.com
+ *
+ *     This file is part of the Simple Robot Library (Alias: simple-robot, simbot, etc.).
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     Lesser GNU General Public License for more details.
+ *
+ *     You should have received a copy of the Lesser GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package event
+
+import io.mockk.every
+import io.mockk.mockk
+import love.forte.simbot.ability.ReplySupport
+import love.forte.simbot.ability.SendSupport
+import love.forte.simbot.definition.*
+import love.forte.simbot.event.*
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+
+class InternalInteractionEventTests {
+
+    @Test
+    fun sendSupportInteractionEvent_tests() {
+        mockTestSendSupportInteractionEvent<SendSupportInteractionEvent, SendSupport>()
+        mockTestSendSupportInteractionEvent<SendSupportPreSendEvent, SendSupport>()
+        mockTestSendSupportInteractionEvent<SendSupportPostSendEvent, SendSupport>()
+        mockTestSendSupportInteractionEvent<ContactInteractionEvent, Contact>()
+        mockTestSendSupportInteractionEvent<ContactPreSendEvent, Contact>()
+        mockTestSendSupportInteractionEvent<ContactPostSendEvent, Contact>()
+        mockTestSendSupportInteractionEvent<ChatRoomInteractionEvent, ChatRoom>()
+        mockTestSendSupportInteractionEvent<ChatRoomPostSendEvent, ChatRoom>()
+        mockTestSendSupportInteractionEvent<ChatRoomPreSendEvent, ChatRoom>()
+        mockTestSendSupportInteractionEvent<ChatGroupInteractionEvent, ChatGroup>()
+        mockTestSendSupportInteractionEvent<ChatGroupPreSendEvent, ChatGroup>()
+        mockTestSendSupportInteractionEvent<ChatGroupPostSendEvent, ChatGroup>()
+        mockTestSendSupportInteractionEvent<ChatChannelInteractionEvent, ChatChannel>()
+        mockTestSendSupportInteractionEvent<ChatChannelPreSendEvent, ChatChannel>()
+        mockTestSendSupportInteractionEvent<ChatChannelPostSendEvent, ChatChannel>()
+        mockTestSendSupportInteractionEvent<MemberInteractionEvent, Member>()
+        mockTestSendSupportInteractionEvent<MemberPreSendEvent, Member>()
+        mockTestSendSupportInteractionEvent<MemberPostSendEvent, Member>()
+    }
+
+    private inline fun <
+        reified T : SendSupportInteractionEvent,
+        reified C : SendSupport
+        > mockTestSendSupportInteractionEvent() {
+        mockTestInteractionEvent<T, C>()
+    }
+
+
+    @Test
+    fun replySupportInteractionEvent_tests() {
+        mockTestReplySupportInteractionEvent<ReplySupportInteractionEvent, ReplySupport>()
+        mockTestReplySupportInteractionEvent<ReplySupportPreReplyEvent, ReplySupport>()
+        mockTestReplySupportInteractionEvent<ReplySupportPostReplyEvent, ReplySupport>()
+        mockTestReplySupportInteractionEvent<ContactMessageEventInteractionEvent, ContactMessageEvent>()
+        mockTestReplySupportInteractionEvent<ContactMessageEventPreReplyEvent, ContactMessageEvent>()
+        mockTestReplySupportInteractionEvent<ContactMessageEventPostReplyEvent, ContactMessageEvent>()
+        mockTestReplySupportInteractionEvent<ChatRoomMessageEventInteractionEvent, ChatRoomMessageEvent>()
+        mockTestReplySupportInteractionEvent<ChatRoomMessageEventPreReplyEvent, ChatRoomMessageEvent>()
+        mockTestReplySupportInteractionEvent<ChatRoomMessageEventPostReplyEvent, ChatRoomMessageEvent>()
+        mockTestReplySupportInteractionEvent<ChatGroupMessageEventInteractionEvent, ChatGroupMessageEvent>()
+        mockTestReplySupportInteractionEvent<ChatGroupMessageEventPreReplyEvent, ChatGroupMessageEvent>()
+        mockTestReplySupportInteractionEvent<ChatGroupMessageEventPostReplyEvent, ChatGroupMessageEvent>()
+        mockTestReplySupportInteractionEvent<ChatChannelMessageEventInteractionEvent, ChatChannelMessageEvent>()
+        mockTestReplySupportInteractionEvent<ChatChannelMessageEventPreReplyEvent, ChatChannelMessageEvent>()
+        mockTestReplySupportInteractionEvent<ChatChannelMessageEventPostReplyEvent, ChatChannelMessageEvent>()
+        mockTestReplySupportInteractionEvent<MemberMessageEventInteractionEvent, MemberMessageEvent>()
+        mockTestReplySupportInteractionEvent<MemberMessageEventPreReplyEvent, MemberMessageEvent>()
+        mockTestReplySupportInteractionEvent<MemberMessageEventPostReplyEvent, MemberMessageEvent>()
+        mockTestReplySupportInteractionEvent<ChatGroupMemberMessageEventInteractionEvent, ChatGroupMemberMessageEvent>()
+        mockTestReplySupportInteractionEvent<ChatGroupMemberMessageEventPreReplyEvent, ChatGroupMemberMessageEvent>()
+        mockTestReplySupportInteractionEvent<ChatGroupMemberMessageEventPostReplyEvent, ChatGroupMemberMessageEvent>()
+        mockTestReplySupportInteractionEvent<GuildMemberMessageEventInteractionEvent, GuildMemberMessageEvent>()
+        mockTestReplySupportInteractionEvent<GuildMemberMessageEventPreReplyEvent, GuildMemberMessageEvent>()
+        mockTestReplySupportInteractionEvent<GuildMemberMessageEventPostReplyEvent, GuildMemberMessageEvent>()
+    }
+
+    private inline fun <
+        reified T : ReplySupportInteractionEvent,
+        reified C : ReplySupport
+        > mockTestReplySupportInteractionEvent() {
+        mockTestInteractionEvent<T, C>()
+    }
+
+    private inline fun <
+        reified T : InternalMessageInteractionEvent,
+        reified C : Any
+        > mockTestInteractionEvent() {
+        val event = mockk<T>()
+        val content = mockk<C>()
+        every { event.content } returns content
+        val eventContent: C = event.content as C
+        assertIs<C>(eventContent)
+    }
+
+}


### PR DESCRIPTION
> see #1016 

增加若干内部事件、内部行为事件和相关的消息拦截事件，包括：

基础事件：

- `InternalNotificationEvent` 内部通知事件，继承 `InternalEvent`
- `InternalInterceptionEvent` 内部拦截事件，继承 `InternalEvent`

其中，`BotStageEvent` 现在实现 `InternalNotificationEvent`

SendSupport 相关：

基本事件类型：

- `SendSupportInteractionEvent`
    - `SendSupportPreSendEvent`
    - `SendSupportPostSendEvent`

它们下的子类型：

- `ContactInteractionEvent` 联系人 `Contact` 相关
    - `ContactPreSendEvent`
    - `ContactPostSendEvent`
- `MemberInteractionEvent` 成员 `Member` 相关
    - `MemberPreSendEvent`
    - `MemberPostSendEvent`
- `ChatRoomInteractionEvent` `ChatRoom` 相关
    - `ChatRoomPreSendEvent`
    - `ChatRoomPostSendEvent`
    - `ChatGroupInteractionEvent` `ChatGroup` 相关
        - `ChatGroupPreSendEvent`
        - `ChatGroupPostSendEvent`
    - `ChatChannelInteractionEvent` `ChatChannel` 相关
        - `ChatChannelPreSendEvent`
        - `ChatChannelPostSendEvent`

ReplySupport 相关：

基本事件类型：

- `ReplySupportInteractionEvent`
    - `ReplySupportPreReplyEvent`
    - `ReplySupportPostReplyEvent`

它们下的子类型：

- `MessageEventInteractionEvent` 消息事件相关
    - `MessageEventPreReplyEvent`
    - `MessageEventPostReplyEvent`
- `ContactMessageEventInteractionEvent` 联系人消息事件相关
    - `ContactMessageEventPreReplyEvent`
    - `ContactMessageEventPostReplyEvent`
- `ChatRoomMessageEventInteractionEvent` `ChatRoom` 消息事件相关
    - `ChatRoomMessageEventPreReplyEvent`
    - `ChatRoomMessageEventPostReplyEvent`
    - `ChatGroupMessageEventInteractionEvent` `ChatGroup` 消息事件相关
        - `ChatGroupMessageEventPreReplyEvent`
        - `ChatGroupMessageEventPostReplyEvent`
    - `ChatChannelMessageEventInteractionEvent` `ChatChannel` 消息事件相关
        - `ChatChannelMessageEventPreReplyEvent`
        - `ChatChannelMessageEventPostReplyEvent`
- `MemberMessageEventInteractionEvent` `Member` 消息事件相关
    - `MemberMessageEventPreReplyEvent`
    - `MemberMessageEventPostReplyEvent`
- `GuildMemberMessageEventInteractionEvent` `GuildMember` 消息事件相关
    - `GuildMemberMessageEventPreReplyEvent`
    - `GuildMemberMessageEventPostReplyEvent`
- `ChatGroupMemberMessageEventInteractionEvent` `ChatGroupMember` 消息事件相关
    - `ChatGroupMemberMessageEventPreReplyEvent`
    - `ChatGroupMemberMessageEventPostReplyEvent`

closes #1016 