### PR TITLE
调整 InteractionMessage 的 sealed 结构 

### DIFF
--- a/simbot-api/api/simbot-api.api
+++ b/simbot-api/api/simbot-api.api
@@ -1766,21 +1766,24 @@ public abstract class love/forte/simbot/event/InteractionMessage$Extension : lov
 	public fun <init> ()V
 }
 
-public final class love/forte/simbot/event/InteractionMessage$Message : love/forte/simbot/event/InteractionMessage {
+public final class love/forte/simbot/event/InteractionMessage$Message : love/forte/simbot/event/InteractionMessage$Standard {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMessage ()Llove/forte/simbot/message/Message;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class love/forte/simbot/event/InteractionMessage$MessageContent : love/forte/simbot/event/InteractionMessage {
+public final class love/forte/simbot/event/InteractionMessage$MessageContent : love/forte/simbot/event/InteractionMessage$Standard {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMessageContent ()Llove/forte/simbot/message/MessageContent;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class love/forte/simbot/event/InteractionMessage$Text : love/forte/simbot/event/InteractionMessage {
+public abstract class love/forte/simbot/event/InteractionMessage$Standard : love/forte/simbot/event/InteractionMessage {
+}
+
+public final class love/forte/simbot/event/InteractionMessage$Text : love/forte/simbot/event/InteractionMessage$Standard {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getText ()Ljava/lang/String;
 	public fun hashCode ()I

--- a/simbot-api/api/simbot-api.api
+++ b/simbot-api/api/simbot-api.api
@@ -1045,6 +1045,13 @@ public abstract interface class love/forte/simbot/event/ChatChannelEvent : love/
 
 public abstract interface class love/forte/simbot/event/ChatChannelInteractionEvent : love/forte/simbot/event/ChatRoomInteractionEvent {
 	public abstract fun getContent ()Llove/forte/simbot/definition/ChatChannel;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public synthetic fun getTarget ()Llove/forte/simbot/ability/SendSupport;
+	public fun getTarget ()Llove/forte/simbot/definition/ChatChannel;
+	public synthetic fun getTarget ()Llove/forte/simbot/definition/ChatRoom;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ChatChannelMessageEvent : love/forte/simbot/event/ChatChannelEvent, love/forte/simbot/event/ChatRoomMessageEvent, love/forte/simbot/event/MemberAuthorAwareMessageEvent {
@@ -1052,22 +1059,54 @@ public abstract interface class love/forte/simbot/event/ChatChannelMessageEvent 
 
 public abstract interface class love/forte/simbot/event/ChatChannelMessageEventInteractionEvent : love/forte/simbot/event/ChatRoomMessageEventInteractionEvent {
 	public abstract fun getContent ()Llove/forte/simbot/event/ChatChannelMessageEvent;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public fun getTarget ()Llove/forte/simbot/definition/ChatChannel;
+	public synthetic fun getTarget ()Llove/forte/simbot/definition/ChatRoom;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ChatChannelMessageEventPostReplyEvent : love/forte/simbot/event/ChatChannelMessageEventInteractionEvent, love/forte/simbot/event/ChatRoomMessageEventPostReplyEvent {
 	public abstract fun getContent ()Llove/forte/simbot/event/ChatChannelMessageEvent;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public fun getTarget ()Llove/forte/simbot/definition/ChatChannel;
+	public synthetic fun getTarget ()Llove/forte/simbot/definition/ChatRoom;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ChatChannelMessageEventPreReplyEvent : love/forte/simbot/event/ChatChannelMessageEventInteractionEvent, love/forte/simbot/event/ChatRoomMessageEventPreReplyEvent {
 	public abstract fun getContent ()Llove/forte/simbot/event/ChatChannelMessageEvent;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public fun getTarget ()Llove/forte/simbot/definition/ChatChannel;
+	public synthetic fun getTarget ()Llove/forte/simbot/definition/ChatRoom;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ChatChannelPostSendEvent : love/forte/simbot/event/ChatChannelInteractionEvent, love/forte/simbot/event/ChatRoomPostSendEvent {
 	public abstract fun getContent ()Llove/forte/simbot/definition/ChatChannel;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public synthetic fun getTarget ()Llove/forte/simbot/ability/SendSupport;
+	public fun getTarget ()Llove/forte/simbot/definition/ChatChannel;
+	public synthetic fun getTarget ()Llove/forte/simbot/definition/ChatRoom;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ChatChannelPreSendEvent : love/forte/simbot/event/ChatChannelInteractionEvent, love/forte/simbot/event/ChatRoomPreSendEvent {
 	public abstract fun getContent ()Llove/forte/simbot/definition/ChatChannel;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public synthetic fun getTarget ()Llove/forte/simbot/ability/SendSupport;
+	public fun getTarget ()Llove/forte/simbot/definition/ChatChannel;
+	public synthetic fun getTarget ()Llove/forte/simbot/definition/ChatRoom;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ChatGroupEvent : love/forte/simbot/event/ChatRoomEvent, love/forte/simbot/event/OrganizationEvent {
@@ -1083,6 +1122,13 @@ public abstract interface class love/forte/simbot/event/ChatGroupEvent : love/fo
 
 public abstract interface class love/forte/simbot/event/ChatGroupInteractionEvent : love/forte/simbot/event/ChatRoomInteractionEvent {
 	public abstract fun getContent ()Llove/forte/simbot/definition/ChatGroup;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public synthetic fun getTarget ()Llove/forte/simbot/ability/SendSupport;
+	public fun getTarget ()Llove/forte/simbot/definition/ChatGroup;
+	public synthetic fun getTarget ()Llove/forte/simbot/definition/ChatRoom;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ChatGroupJoinRequestEvent : love/forte/simbot/event/ChatGroupEvent, love/forte/simbot/event/OrganizationJoinRequestEvent {
@@ -1155,14 +1201,29 @@ public abstract interface class love/forte/simbot/event/ChatGroupMemberMessageEv
 
 public abstract interface class love/forte/simbot/event/ChatGroupMemberMessageEventInteractionEvent : love/forte/simbot/event/MessageEventInteractionEvent {
 	public abstract fun getContent ()Llove/forte/simbot/event/ChatGroupMemberMessageEvent;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public fun getTarget ()Llove/forte/simbot/definition/Member;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ChatGroupMemberMessageEventPostReplyEvent : love/forte/simbot/event/ChatGroupMemberMessageEventInteractionEvent, love/forte/simbot/event/MessageEventPostReplyEvent {
 	public abstract fun getContent ()Llove/forte/simbot/event/ChatGroupMemberMessageEvent;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public fun getTarget ()Llove/forte/simbot/definition/Member;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ChatGroupMemberMessageEventPreReplyEvent : love/forte/simbot/event/ChatGroupMemberMessageEventInteractionEvent, love/forte/simbot/event/MessageEventPreReplyEvent {
 	public abstract fun getContent ()Llove/forte/simbot/event/ChatGroupMemberMessageEvent;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public fun getTarget ()Llove/forte/simbot/definition/Member;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ChatGroupMessageEvent : love/forte/simbot/event/ChatGroupEvent, love/forte/simbot/event/ChatRoomMessageEvent, love/forte/simbot/event/MemberAuthorAwareMessageEvent {
@@ -1170,22 +1231,54 @@ public abstract interface class love/forte/simbot/event/ChatGroupMessageEvent : 
 
 public abstract interface class love/forte/simbot/event/ChatGroupMessageEventInteractionEvent : love/forte/simbot/event/ChatRoomMessageEventInteractionEvent {
 	public abstract fun getContent ()Llove/forte/simbot/event/ChatGroupMessageEvent;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public fun getTarget ()Llove/forte/simbot/definition/ChatGroup;
+	public synthetic fun getTarget ()Llove/forte/simbot/definition/ChatRoom;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ChatGroupMessageEventPostReplyEvent : love/forte/simbot/event/ChatGroupMessageEventInteractionEvent, love/forte/simbot/event/ChatRoomMessageEventPostReplyEvent {
 	public abstract fun getContent ()Llove/forte/simbot/event/ChatGroupMessageEvent;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public fun getTarget ()Llove/forte/simbot/definition/ChatGroup;
+	public synthetic fun getTarget ()Llove/forte/simbot/definition/ChatRoom;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ChatGroupMessageEventPreReplyEvent : love/forte/simbot/event/ChatGroupMessageEventInteractionEvent, love/forte/simbot/event/ChatRoomMessageEventPreReplyEvent {
 	public abstract fun getContent ()Llove/forte/simbot/event/ChatGroupMessageEvent;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public fun getTarget ()Llove/forte/simbot/definition/ChatGroup;
+	public synthetic fun getTarget ()Llove/forte/simbot/definition/ChatRoom;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ChatGroupPostSendEvent : love/forte/simbot/event/ChatGroupInteractionEvent, love/forte/simbot/event/ChatRoomPostSendEvent {
 	public abstract fun getContent ()Llove/forte/simbot/definition/ChatGroup;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public synthetic fun getTarget ()Llove/forte/simbot/ability/SendSupport;
+	public fun getTarget ()Llove/forte/simbot/definition/ChatGroup;
+	public synthetic fun getTarget ()Llove/forte/simbot/definition/ChatRoom;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ChatGroupPreSendEvent : love/forte/simbot/event/ChatGroupInteractionEvent, love/forte/simbot/event/ChatRoomPreSendEvent {
 	public abstract fun getContent ()Llove/forte/simbot/definition/ChatGroup;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public synthetic fun getTarget ()Llove/forte/simbot/ability/SendSupport;
+	public fun getTarget ()Llove/forte/simbot/definition/ChatGroup;
+	public synthetic fun getTarget ()Llove/forte/simbot/definition/ChatRoom;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ChatRoomEvent : love/forte/simbot/event/ActorEvent {
@@ -1199,6 +1292,12 @@ public abstract interface class love/forte/simbot/event/ChatRoomEvent : love/for
 
 public abstract interface class love/forte/simbot/event/ChatRoomInteractionEvent : love/forte/simbot/event/SendSupportInteractionEvent {
 	public abstract fun getContent ()Llove/forte/simbot/definition/ChatRoom;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public synthetic fun getTarget ()Llove/forte/simbot/ability/SendSupport;
+	public fun getTarget ()Llove/forte/simbot/definition/ChatRoom;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ChatRoomMessageEvent : love/forte/simbot/event/ChatRoomEvent, love/forte/simbot/event/MessageEvent {
@@ -1206,20 +1305,49 @@ public abstract interface class love/forte/simbot/event/ChatRoomMessageEvent : l
 
 public abstract interface class love/forte/simbot/event/ChatRoomMessageEventInteractionEvent : love/forte/simbot/event/MessageEventInteractionEvent {
 	public abstract fun getContent ()Llove/forte/simbot/event/ChatRoomMessageEvent;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public fun getTarget ()Llove/forte/simbot/definition/ChatRoom;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ChatRoomMessageEventPostReplyEvent : love/forte/simbot/event/ChatRoomMessageEventInteractionEvent, love/forte/simbot/event/MessageEventPostReplyEvent {
+	public abstract fun getContent ()Llove/forte/simbot/event/ChatRoomMessageEvent;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public fun getTarget ()Llove/forte/simbot/definition/ChatRoom;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ChatRoomMessageEventPreReplyEvent : love/forte/simbot/event/ChatRoomMessageEventInteractionEvent, love/forte/simbot/event/MessageEventPreReplyEvent {
+	public abstract fun getContent ()Llove/forte/simbot/event/ChatRoomMessageEvent;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public fun getTarget ()Llove/forte/simbot/definition/ChatRoom;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ChatRoomPostSendEvent : love/forte/simbot/event/ChatRoomInteractionEvent, love/forte/simbot/event/SendSupportPostSendEvent {
 	public abstract fun getContent ()Llove/forte/simbot/definition/ChatRoom;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public synthetic fun getTarget ()Llove/forte/simbot/ability/SendSupport;
+	public fun getTarget ()Llove/forte/simbot/definition/ChatRoom;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ChatRoomPreSendEvent : love/forte/simbot/event/ChatRoomInteractionEvent, love/forte/simbot/event/SendSupportPreSendEvent {
 	public abstract fun getContent ()Llove/forte/simbot/definition/ChatRoom;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public synthetic fun getTarget ()Llove/forte/simbot/ability/SendSupport;
+	public fun getTarget ()Llove/forte/simbot/definition/ChatRoom;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ComponentEvent : love/forte/simbot/event/Event {
@@ -1237,6 +1365,12 @@ public abstract interface class love/forte/simbot/event/ContactEvent : love/fort
 
 public abstract interface class love/forte/simbot/event/ContactInteractionEvent : love/forte/simbot/event/SendSupportInteractionEvent {
 	public abstract fun getContent ()Llove/forte/simbot/definition/Contact;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public synthetic fun getTarget ()Llove/forte/simbot/ability/SendSupport;
+	public fun getTarget ()Llove/forte/simbot/definition/Contact;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ContactMessageEvent : love/forte/simbot/event/ContactEvent, love/forte/simbot/event/MessageEvent {
@@ -1244,20 +1378,49 @@ public abstract interface class love/forte/simbot/event/ContactMessageEvent : lo
 
 public abstract interface class love/forte/simbot/event/ContactMessageEventInteractionEvent : love/forte/simbot/event/MessageEventInteractionEvent {
 	public abstract fun getContent ()Llove/forte/simbot/event/ContactMessageEvent;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public fun getTarget ()Llove/forte/simbot/definition/Contact;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ContactMessageEventPostReplyEvent : love/forte/simbot/event/ContactMessageEventInteractionEvent, love/forte/simbot/event/MessageEventPostReplyEvent {
+	public abstract fun getContent ()Llove/forte/simbot/event/ContactMessageEvent;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public fun getTarget ()Llove/forte/simbot/definition/Contact;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ContactMessageEventPreReplyEvent : love/forte/simbot/event/ContactMessageEventInteractionEvent, love/forte/simbot/event/MessageEventPreReplyEvent {
+	public abstract fun getContent ()Llove/forte/simbot/event/ContactMessageEvent;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public fun getTarget ()Llove/forte/simbot/definition/Contact;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ContactPostSendEvent : love/forte/simbot/event/ContactInteractionEvent, love/forte/simbot/event/SendSupportPostSendEvent {
 	public abstract fun getContent ()Llove/forte/simbot/definition/Contact;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public synthetic fun getTarget ()Llove/forte/simbot/ability/SendSupport;
+	public fun getTarget ()Llove/forte/simbot/definition/Contact;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ContactPreSendEvent : love/forte/simbot/event/ContactInteractionEvent, love/forte/simbot/event/SendSupportPreSendEvent {
 	public abstract fun getContent ()Llove/forte/simbot/definition/Contact;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public synthetic fun getTarget ()Llove/forte/simbot/ability/SendSupport;
+	public fun getTarget ()Llove/forte/simbot/definition/Contact;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/ContentEvent : love/forte/simbot/event/Event {
@@ -1561,14 +1724,29 @@ public abstract interface class love/forte/simbot/event/GuildMemberMessageEvent 
 
 public abstract interface class love/forte/simbot/event/GuildMemberMessageEventInteractionEvent : love/forte/simbot/event/MessageEventInteractionEvent {
 	public abstract fun getContent ()Llove/forte/simbot/event/GuildMemberMessageEvent;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public fun getTarget ()Llove/forte/simbot/definition/Member;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/GuildMemberMessageEventPostReplyEvent : love/forte/simbot/event/GuildMemberMessageEventInteractionEvent, love/forte/simbot/event/MessageEventPostReplyEvent {
 	public abstract fun getContent ()Llove/forte/simbot/event/GuildMemberMessageEvent;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public fun getTarget ()Llove/forte/simbot/definition/Member;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/GuildMemberMessageEventPreReplyEvent : love/forte/simbot/event/GuildMemberMessageEventInteractionEvent, love/forte/simbot/event/MessageEventPreReplyEvent {
 	public abstract fun getContent ()Llove/forte/simbot/event/GuildMemberMessageEvent;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public fun getTarget ()Llove/forte/simbot/definition/Member;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class love/forte/simbot/event/InteractionMessage {
@@ -1625,6 +1803,10 @@ public class love/forte/simbot/event/InternalInterceptionException : java/lang/R
 public abstract interface class love/forte/simbot/event/InternalMessageInteractionEvent : love/forte/simbot/event/InternalEvent {
 	public abstract fun getContent ()Ljava/lang/Object;
 	public abstract fun getMessage ()Llove/forte/simbot/event/InteractionMessage;
+	public fun getTarget ()Ljava/lang/Object;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/InternalMessagePostSendEvent : love/forte/simbot/event/InternalMessageInteractionEvent, love/forte/simbot/event/InternalNotificationEvent {
@@ -1789,6 +1971,12 @@ public abstract interface class love/forte/simbot/event/MemberIncreaseOrDecrease
 
 public abstract interface class love/forte/simbot/event/MemberInteractionEvent : love/forte/simbot/event/SendSupportInteractionEvent {
 	public abstract fun getContent ()Llove/forte/simbot/definition/Member;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public synthetic fun getTarget ()Llove/forte/simbot/ability/SendSupport;
+	public fun getTarget ()Llove/forte/simbot/definition/Member;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/MemberMessageEvent : love/forte/simbot/event/MemberEvent, love/forte/simbot/event/MessageEvent {
@@ -1796,22 +1984,49 @@ public abstract interface class love/forte/simbot/event/MemberMessageEvent : lov
 
 public abstract interface class love/forte/simbot/event/MemberMessageEventInteractionEvent : love/forte/simbot/event/MessageEventInteractionEvent {
 	public abstract fun getContent ()Llove/forte/simbot/event/MemberMessageEvent;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public fun getTarget ()Llove/forte/simbot/definition/Member;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/MemberMessageEventPostReplyEvent : love/forte/simbot/event/MemberMessageEventInteractionEvent, love/forte/simbot/event/MessageEventPostReplyEvent {
 	public abstract fun getContent ()Llove/forte/simbot/event/MemberMessageEvent;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public fun getTarget ()Llove/forte/simbot/definition/Member;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/MemberMessageEventPreReplyEvent : love/forte/simbot/event/MemberMessageEventInteractionEvent, love/forte/simbot/event/MessageEventPreReplyEvent {
 	public abstract fun getContent ()Llove/forte/simbot/event/MemberMessageEvent;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public fun getTarget ()Llove/forte/simbot/definition/Member;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/MemberPostSendEvent : love/forte/simbot/event/MemberInteractionEvent, love/forte/simbot/event/SendSupportPostSendEvent {
 	public abstract fun getContent ()Llove/forte/simbot/definition/Member;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public synthetic fun getTarget ()Llove/forte/simbot/ability/SendSupport;
+	public fun getTarget ()Llove/forte/simbot/definition/Member;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/MemberPreSendEvent : love/forte/simbot/event/MemberInteractionEvent, love/forte/simbot/event/SendSupportPreSendEvent {
 	public abstract fun getContent ()Llove/forte/simbot/definition/Member;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public synthetic fun getTarget ()Llove/forte/simbot/ability/SendSupport;
+	public fun getTarget ()Llove/forte/simbot/definition/Member;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/MessageContentAwareEvent : love/forte/simbot/event/Event {
@@ -1905,6 +2120,11 @@ public final class love/forte/simbot/event/RequestEvent$Type : java/lang/Enum {
 
 public abstract interface class love/forte/simbot/event/SendSupportInteractionEvent : love/forte/simbot/event/BotEvent, love/forte/simbot/event/InternalMessageInteractionEvent {
 	public abstract fun getContent ()Llove/forte/simbot/ability/SendSupport;
+	public synthetic fun getTarget ()Ljava/lang/Object;
+	public fun getTarget ()Llove/forte/simbot/ability/SendSupport;
+	public fun getTargetAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getTargetReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun target (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/event/SendSupportPostSendEvent : love/forte/simbot/event/InternalMessagePostSendEvent, love/forte/simbot/event/SendSupportInteractionEvent {

--- a/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/InteractionMessage.kt
+++ b/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/InteractionMessage.kt
@@ -29,10 +29,14 @@ import kotlin.jvm.JvmStatic
 
 /**
  * 拦截或通知中 [SendSupport.send] 或 [ReplySupport.reply] 的消息内容。
+ *
+ * @since 4.11.0
  */
 public sealed class InteractionMessage {
     /**
      * 当参数类型为 [String] 时，表示发送的文本消息。
+     *
+     * @since 4.11.0
      */
     public class Text internal constructor(public val text: String) : InteractionMessage() {
         override fun equals(other: Any?): Boolean {
@@ -55,6 +59,8 @@ public sealed class InteractionMessage {
 
     /**
      * 当参数类型为 [love.forte.simbot.message.Message] 时，表示发送的消息。
+     *
+     * @since 4.11.0
      */
     public class Message internal constructor(public val message: love.forte.simbot.message.Message) :
         InteractionMessage() {
@@ -79,6 +85,8 @@ public sealed class InteractionMessage {
 
     /**
      * 当参数类型为 [love.forte.simbot.message.MessageContent] 时，表示发送的消息内容。
+     *
+     * @since 4.11.0
      */
     public class MessageContent internal constructor(
         public val messageContent: love.forte.simbot.message.MessageContent
@@ -104,6 +112,8 @@ public sealed class InteractionMessage {
     /**
      * 如果组件或 [SendSupport] 的实现者提供了其他三个类型参数以外的参数，
      * 则需要通过 [Extension] 对其进行扩展。
+     *
+     * @since 4.11.0
      */
     public abstract class Extension : InteractionMessage()
 

--- a/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/InteractionMessage.kt
+++ b/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/InteractionMessage.kt
@@ -30,15 +30,34 @@ import kotlin.jvm.JvmStatic
 /**
  * 拦截或通知中 [SendSupport.send] 或 [ReplySupport.reply] 的消息内容。
  *
+ * 主要分为 [标准类型][Standard] 和 [扩展类型][Extension].
+ *
+ * [Standard] 用于表示三个标准库中提供的 Message 标准类型: 文本 [Text], 消息 [Message], 事件消息 [MessageContent].
+ * [Extension] 用于当 [Standard] 无法满足组件需求时进行的额外扩展。
+ *
  * @since 4.11.0
  */
 public sealed class InteractionMessage {
+    /**
+     * 用于表示三个标准库中提供的消息标准类型:
+     * - 文本 [Text]
+     * - 消息 [Message]
+     * - 事件消息 [MessageContent]
+     *
+     * @see InteractionMessage.Text
+     * @see InteractionMessage.Message
+     * @see InteractionMessage.MessageContent
+     *
+     * @since 4.12
+     */
+    public sealed class Standard : InteractionMessage()
+
     /**
      * 当参数类型为 [String] 时，表示发送的文本消息。
      *
      * @since 4.11.0
      */
-    public class Text internal constructor(public val text: String) : InteractionMessage() {
+    public class Text internal constructor(public val text: String) : Standard() {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (other !is Text) return false
@@ -62,8 +81,7 @@ public sealed class InteractionMessage {
      *
      * @since 4.11.0
      */
-    public class Message internal constructor(public val message: love.forte.simbot.message.Message) :
-        InteractionMessage() {
+    public class Message internal constructor(public val message: love.forte.simbot.message.Message) : Standard() {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (other !is Message) return false
@@ -90,7 +108,7 @@ public sealed class InteractionMessage {
      */
     public class MessageContent internal constructor(
         public val messageContent: love.forte.simbot.message.MessageContent
-    ) : InteractionMessage() {
+    ) : Standard() {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (other !is MessageContent) return false

--- a/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/InternalMessageInteractionEvent.kt
+++ b/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/InternalMessageInteractionEvent.kt
@@ -26,6 +26,7 @@ package love.forte.simbot.event
 import love.forte.simbot.ability.ReplySupport
 import love.forte.simbot.ability.SendSupport
 import love.forte.simbot.message.MessageReceipt
+import love.forte.simbot.suspendrunner.STP
 
 /**
  * 在内部一个跟 [Message][love.forte.simbot.message.Message] 的交互有关的事件。
@@ -44,6 +45,9 @@ import love.forte.simbot.message.MessageReceipt
 public interface InternalMessageInteractionEvent : InternalEvent {
     /**
      * 进行消息交互的实体。
+     * 实体取决于当前**被拦截**的主要源目标，
+     * 例如一个 [SendSupport] (参考 [SendSupportInteractionEvent])
+     * 或一个 [ReplySupport] (参考 [ReplySupportInteractionEvent])。
      */
     public val content: Any
 
@@ -51,8 +55,33 @@ public interface InternalMessageInteractionEvent : InternalEvent {
      * 进行交互的消息内容，例如
      * [SendSupport.send] 或 [ReplySupport.reply]
      * 调用时传递的参数。
+     *
+     * @see InteractionMessage
      */
     public val message: InteractionMessage
+
+    /**
+     * 消息的发送目标/目的地。
+     *
+     * 与 [content] 不同，[target] 代表消息将会被发送到哪个目标中。
+     * 在 [SendSupportInteractionEvent] 下，它通常等于 [content],
+     * 而在 [ReplySupportInteractionEvent] 下，它则需要从 [content] 中获取，
+     * 例如在 [ChatGroupMessageEventInteractionEvent] 中消息的发送目标是
+     * [ChatGroup][love.forte.simbot.definition.ChatGroup] 而不是 [ChatGroupMessageEvent]。
+     *
+     * 是否会真正挂起取决于具体实现。
+     *
+     * 如果组件未实现(例如向下兼容的较低版本组件)或无法确定/获取发送目标，则可能得到 `null`。
+     *
+     * @since 4.12
+     *
+     * @return 消息的最终发送目标。大概率是一个 [SendSupport] 或
+     * [Actor][love.forte.simbot.definition.Actor],
+     * 但无法做出保证。
+     * 如果组件未实现(例如向下兼容的较低版本组件)或无法确定/获取发送目标，则可能得到 `null`。
+     */
+    @STP
+    public suspend fun target(): Any? = null
 }
 
 /**

--- a/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/ReplySupportInteractionEvent.kt
+++ b/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/ReplySupportInteractionEvent.kt
@@ -25,6 +25,8 @@ package love.forte.simbot.event
 
 import love.forte.simbot.ability.ReplySupport
 import love.forte.simbot.bot.Bot
+import love.forte.simbot.definition.*
+import love.forte.simbot.suspendrunner.STP
 
 
 /**
@@ -123,6 +125,14 @@ public interface MessageEventPostReplyEvent : MessageEventInteractionEvent, Repl
 @OptIn(FuzzyEventTypeImplementation::class)
 public interface ContactMessageEventInteractionEvent : MessageEventInteractionEvent {
     override val content: ContactMessageEvent
+
+    /**
+     * 发送目标为一个 [Contact], 同 [ContactMessageEvent.content]。
+     *
+     * @see ContactMessageEvent.content
+     */
+    @STP
+    override suspend fun target(): Contact = content.content()
 }
 
 /**
@@ -133,7 +143,17 @@ public interface ContactMessageEventInteractionEvent : MessageEventInteractionEv
  * @see ContactMessageEvent
  */
 @OptIn(FuzzyEventTypeImplementation::class)
-public interface ContactMessageEventPreReplyEvent : ContactMessageEventInteractionEvent, MessageEventPreReplyEvent
+public interface ContactMessageEventPreReplyEvent : ContactMessageEventInteractionEvent, MessageEventPreReplyEvent {
+    override val content: ContactMessageEvent
+
+    /**
+     * 发送目标为一个 [Contact], 同 [ContactMessageEvent.content]。
+     *
+     * @see ContactMessageEvent.content
+     */
+    @STP
+    override suspend fun target(): Contact = content.content()
+}
 
 /**
  * 针对 [ContactMessageEvent.reply] 的内部通知事件。
@@ -143,7 +163,17 @@ public interface ContactMessageEventPreReplyEvent : ContactMessageEventInteracti
  * @see ContactMessageEvent
  */
 @OptIn(FuzzyEventTypeImplementation::class)
-public interface ContactMessageEventPostReplyEvent : ContactMessageEventInteractionEvent, MessageEventPostReplyEvent
+public interface ContactMessageEventPostReplyEvent : ContactMessageEventInteractionEvent, MessageEventPostReplyEvent {
+    override val content: ContactMessageEvent
+
+    /**
+     * 发送目标为一个 [Contact], 同 [ContactMessageEvent.content]。
+     *
+     * @see ContactMessageEvent.content
+     */
+    @STP
+    override suspend fun target(): Contact = content.content()
+}
 
 // endregion
 
@@ -158,6 +188,14 @@ public interface ContactMessageEventPostReplyEvent : ContactMessageEventInteract
 @OptIn(FuzzyEventTypeImplementation::class)
 public interface ChatRoomMessageEventInteractionEvent : MessageEventInteractionEvent {
     override val content: ChatRoomMessageEvent
+
+    /**
+     * 发送目标为一个 [ChatRoom], 同 [ChatRoomMessageEvent.content]。
+     *
+     * @see ChatRoomMessageEvent.content
+     */
+    @STP
+    override suspend fun target(): ChatRoom = content.content()
 }
 
 /**
@@ -168,7 +206,17 @@ public interface ChatRoomMessageEventInteractionEvent : MessageEventInteractionE
  * @see ChatRoomMessageEvent
  */
 @OptIn(FuzzyEventTypeImplementation::class)
-public interface ChatRoomMessageEventPreReplyEvent : ChatRoomMessageEventInteractionEvent, MessageEventPreReplyEvent
+public interface ChatRoomMessageEventPreReplyEvent : ChatRoomMessageEventInteractionEvent, MessageEventPreReplyEvent {
+    override val content: ChatRoomMessageEvent
+
+    /**
+     * 发送目标为一个 [ChatRoom], 同 [ChatRoomMessageEvent.content]。
+     *
+     * @see ChatRoomMessageEvent.content
+     */
+    @STP
+    override suspend fun target(): ChatRoom = content.content()
+}
 
 /**
  * 针对 [ChatRoomMessageEvent.reply] 的内部通知事件。
@@ -178,7 +226,17 @@ public interface ChatRoomMessageEventPreReplyEvent : ChatRoomMessageEventInterac
  * @see ChatRoomMessageEvent
  */
 @OptIn(FuzzyEventTypeImplementation::class)
-public interface ChatRoomMessageEventPostReplyEvent : ChatRoomMessageEventInteractionEvent, MessageEventPostReplyEvent
+public interface ChatRoomMessageEventPostReplyEvent : ChatRoomMessageEventInteractionEvent, MessageEventPostReplyEvent {
+    override val content: ChatRoomMessageEvent
+
+    /**
+     * 发送目标为一个 [ChatRoom], 同 [ChatRoomMessageEvent.content]。
+     *
+     * @see ChatRoomMessageEvent.content
+     */
+    @STP
+    override suspend fun target(): ChatRoom = content.content()
+}
 
 //region ChatGroup
 
@@ -190,6 +248,14 @@ public interface ChatRoomMessageEventPostReplyEvent : ChatRoomMessageEventIntera
  */
 public interface ChatGroupMessageEventInteractionEvent : ChatRoomMessageEventInteractionEvent {
     override val content: ChatGroupMessageEvent
+
+    /**
+     * 发送目标为一个 [ChatGroup], 同 [ChatGroupMessageEvent.content]。
+     *
+     * @see ChatGroupMessageEvent.content
+     */
+    @STP
+    override suspend fun target(): ChatGroup = content.content()
 }
 
 /**
@@ -203,6 +269,14 @@ public interface ChatGroupMessageEventPreReplyEvent :
     ChatGroupMessageEventInteractionEvent,
     ChatRoomMessageEventPreReplyEvent {
     override val content: ChatGroupMessageEvent
+
+    /**
+     * 发送目标为一个 [ChatGroup], 同 [ChatGroupMessageEvent.content]。
+     *
+     * @see ChatGroupMessageEvent.content
+     */
+    @STP
+    override suspend fun target(): ChatGroup = content.content()
 }
 
 /**
@@ -216,6 +290,14 @@ public interface ChatGroupMessageEventPostReplyEvent :
     ChatGroupMessageEventInteractionEvent,
     ChatRoomMessageEventPostReplyEvent {
     override val content: ChatGroupMessageEvent
+
+    /**
+     * 发送目标为一个 [ChatGroup], 同 [ChatGroupMessageEvent.content]。
+     *
+     * @see ChatGroupMessageEvent.content
+     */
+    @STP
+    override suspend fun target(): ChatGroup = content.content()
 }
 //endregion
 //region ChatChannel
@@ -228,6 +310,14 @@ public interface ChatGroupMessageEventPostReplyEvent :
  */
 public interface ChatChannelMessageEventInteractionEvent : ChatRoomMessageEventInteractionEvent {
     override val content: ChatChannelMessageEvent
+
+    /**
+     * 发送目标为一个 [ChatChannel], 同 [ChatChannelMessageEvent.content]。
+     *
+     * @see ChatChannelMessageEvent.content
+     */
+    @STP
+    override suspend fun target(): ChatChannel = content.content()
 }
 
 /**
@@ -241,6 +331,14 @@ public interface ChatChannelMessageEventPreReplyEvent :
     ChatChannelMessageEventInteractionEvent,
     ChatRoomMessageEventPreReplyEvent {
     override val content: ChatChannelMessageEvent
+
+    /**
+     * 发送目标为一个 [ChatChannel], 同 [ChatChannelMessageEvent.content]。
+     *
+     * @see ChatChannelMessageEvent.content
+     */
+    @STP
+    override suspend fun target(): ChatChannel = content.content()
 }
 
 /**
@@ -254,6 +352,14 @@ public interface ChatChannelMessageEventPostReplyEvent :
     ChatChannelMessageEventInteractionEvent,
     ChatRoomMessageEventPostReplyEvent {
     override val content: ChatChannelMessageEvent
+
+    /**
+     * 发送目标为一个 [ChatChannel], 同 [ChatChannelMessageEvent.content]。
+     *
+     * @see ChatChannelMessageEvent.content
+     */
+    @STP
+    override suspend fun target(): ChatChannel = content.content()
 }
 //endregion
 //endregion
@@ -269,6 +375,14 @@ public interface ChatChannelMessageEventPostReplyEvent :
 @OptIn(FuzzyEventTypeImplementation::class)
 public interface MemberMessageEventInteractionEvent : MessageEventInteractionEvent {
     override val content: MemberMessageEvent
+
+    /**
+     * 发送目标为一个 [Member], 同 [MemberMessageEvent.content]。
+     *
+     * @see MemberMessageEvent.content
+     */
+    @STP
+    override suspend fun target(): Member = content.content()
 }
 
 /**
@@ -281,6 +395,14 @@ public interface MemberMessageEventInteractionEvent : MessageEventInteractionEve
 @OptIn(FuzzyEventTypeImplementation::class)
 public interface MemberMessageEventPreReplyEvent : MemberMessageEventInteractionEvent, MessageEventPreReplyEvent {
     override val content: MemberMessageEvent
+
+    /**
+     * 发送目标为一个 [Member], 同 [MemberMessageEvent.content]。
+     *
+     * @see MemberMessageEvent.content
+     */
+    @STP
+    override suspend fun target(): Member = content.content()
 }
 
 /**
@@ -293,6 +415,14 @@ public interface MemberMessageEventPreReplyEvent : MemberMessageEventInteraction
 @OptIn(FuzzyEventTypeImplementation::class)
 public interface MemberMessageEventPostReplyEvent : MemberMessageEventInteractionEvent, MessageEventPostReplyEvent {
     override val content: MemberMessageEvent
+
+    /**
+     * 发送目标为一个 [Member], 同 [MemberMessageEvent.content]。
+     *
+     * @see MemberMessageEvent.content
+     */
+    @STP
+    override suspend fun target(): Member = content.content()
 }
 //endregion
 
@@ -307,6 +437,14 @@ public interface MemberMessageEventPostReplyEvent : MemberMessageEventInteractio
 @OptIn(FuzzyEventTypeImplementation::class)
 public interface GuildMemberMessageEventInteractionEvent : MessageEventInteractionEvent {
     override val content: GuildMemberMessageEvent
+
+    /**
+     * 发送目标为一个 [Member], 同 [GuildMemberMessageEvent.content]。
+     *
+     * @see GuildMemberMessageEvent.content
+     */
+    @STP
+    override suspend fun target(): Member = content.content()
 }
 
 /**
@@ -321,6 +459,14 @@ public interface GuildMemberMessageEventPreReplyEvent :
     GuildMemberMessageEventInteractionEvent,
     MessageEventPreReplyEvent {
     override val content: GuildMemberMessageEvent
+
+    /**
+     * 发送目标为一个 [Member], 同 [GuildMemberMessageEvent.content]。
+     *
+     * @see GuildMemberMessageEvent.content
+     */
+    @STP
+    override suspend fun target(): Member = content.content()
 }
 
 /**
@@ -335,6 +481,14 @@ public interface GuildMemberMessageEventPostReplyEvent :
     GuildMemberMessageEventInteractionEvent,
     MessageEventPostReplyEvent {
     override val content: GuildMemberMessageEvent
+
+    /**
+     * 发送目标为一个 [Member], 同 [GuildMemberMessageEvent.content]。
+     *
+     * @see GuildMemberMessageEvent.content
+     */
+    @STP
+    override suspend fun target(): Member = content.content()
 }
 //endregion
 
@@ -349,6 +503,14 @@ public interface GuildMemberMessageEventPostReplyEvent :
 @OptIn(FuzzyEventTypeImplementation::class)
 public interface ChatGroupMemberMessageEventInteractionEvent : MessageEventInteractionEvent {
     override val content: ChatGroupMemberMessageEvent
+
+    /**
+     * 发送目标为一个 [Member], 同 [ChatGroupMemberMessageEvent.content]。
+     *
+     * @see ChatGroupMemberMessageEvent.content
+     */
+    @STP
+    override suspend fun target(): Member = content.content()
 }
 
 /**
@@ -363,6 +525,14 @@ public interface ChatGroupMemberMessageEventPreReplyEvent :
     ChatGroupMemberMessageEventInteractionEvent,
     MessageEventPreReplyEvent {
     override val content: ChatGroupMemberMessageEvent
+
+    /**
+     * 发送目标为一个 [Member], 同 [ChatGroupMemberMessageEvent.content]。
+     *
+     * @see ChatGroupMemberMessageEvent.content
+     */
+    @STP
+    override suspend fun target(): Member = content.content()
 }
 
 /**
@@ -377,5 +547,13 @@ public interface ChatGroupMemberMessageEventPostReplyEvent :
     ChatGroupMemberMessageEventInteractionEvent,
     MessageEventPostReplyEvent {
     override val content: ChatGroupMemberMessageEvent
+
+    /**
+     * 发送目标为一个 [Member], 同 [ChatGroupMemberMessageEvent.content]。
+     *
+     * @see ChatGroupMemberMessageEvent.content
+     */
+    @STP
+    override suspend fun target(): Member = content.content()
 }
 //endregion

--- a/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/SendSupportInteractionEvent.kt
+++ b/simbot-api/src/commonMain/kotlin/love/forte/simbot/event/SendSupportInteractionEvent.kt
@@ -25,6 +25,7 @@ package love.forte.simbot.event
 
 import love.forte.simbot.ability.SendSupport
 import love.forte.simbot.definition.*
+import love.forte.simbot.suspendrunner.STP
 
 
 /**
@@ -41,6 +42,12 @@ public interface SendSupportInteractionEvent : BotEvent, InternalMessageInteract
      * 当前进行行为的 [SendSupport] 实例。
      */
     override val content: SendSupport
+
+    /**
+     * 消息发送的目标，即 [content] 本身。
+     */
+    @STP
+    override suspend fun target(): SendSupport = content
 }
 
 /**
@@ -80,6 +87,9 @@ public interface SendSupportPostSendEvent : SendSupportInteractionEvent, Interna
 @OptIn(FuzzyEventTypeImplementation::class)
 public interface ContactInteractionEvent : SendSupportInteractionEvent {
     override val content: Contact
+
+    @STP
+    override suspend fun target(): Contact = content
 }
 
 /**
@@ -90,6 +100,9 @@ public interface ContactInteractionEvent : SendSupportInteractionEvent {
 @OptIn(FuzzyEventTypeImplementation::class)
 public interface ContactPreSendEvent : ContactInteractionEvent, SendSupportPreSendEvent {
     override val content: Contact
+
+    @STP
+    override suspend fun target(): Contact = content
 }
 
 /**
@@ -100,6 +113,9 @@ public interface ContactPreSendEvent : ContactInteractionEvent, SendSupportPreSe
 @OptIn(FuzzyEventTypeImplementation::class)
 public interface ContactPostSendEvent : ContactInteractionEvent, SendSupportPostSendEvent {
     override val content: Contact
+
+    @STP
+    override suspend fun target(): Contact = content
 }
 //endregion
 
@@ -113,6 +129,9 @@ public interface ContactPostSendEvent : ContactInteractionEvent, SendSupportPost
 @OptIn(FuzzyEventTypeImplementation::class)
 public interface MemberInteractionEvent : SendSupportInteractionEvent {
     override val content: Member
+
+    @STP
+    override suspend fun target(): Member = content
 }
 
 /**
@@ -123,6 +142,9 @@ public interface MemberInteractionEvent : SendSupportInteractionEvent {
 @OptIn(FuzzyEventTypeImplementation::class)
 public interface MemberPreSendEvent : MemberInteractionEvent, SendSupportPreSendEvent {
     override val content: Member
+
+    @STP
+    override suspend fun target(): Member = content
 }
 
 /**
@@ -133,6 +155,9 @@ public interface MemberPreSendEvent : MemberInteractionEvent, SendSupportPreSend
 @OptIn(FuzzyEventTypeImplementation::class)
 public interface MemberPostSendEvent : MemberInteractionEvent, SendSupportPostSendEvent {
     override val content: Member
+
+    @STP
+    override suspend fun target(): Member = content
 }
 //endregion
 
@@ -146,6 +171,9 @@ public interface MemberPostSendEvent : MemberInteractionEvent, SendSupportPostSe
 @OptIn(FuzzyEventTypeImplementation::class)
 public interface ChatRoomInteractionEvent : SendSupportInteractionEvent {
     override val content: ChatRoom
+
+    @STP
+    override suspend fun target(): ChatRoom = content
 }
 
 /**
@@ -156,6 +184,9 @@ public interface ChatRoomInteractionEvent : SendSupportInteractionEvent {
 @OptIn(FuzzyEventTypeImplementation::class)
 public interface ChatRoomPreSendEvent : ChatRoomInteractionEvent, SendSupportPreSendEvent {
     override val content: ChatRoom
+
+    @STP
+    override suspend fun target(): ChatRoom = content
 }
 
 /**
@@ -166,6 +197,9 @@ public interface ChatRoomPreSendEvent : ChatRoomInteractionEvent, SendSupportPre
 @OptIn(FuzzyEventTypeImplementation::class)
 public interface ChatRoomPostSendEvent : ChatRoomInteractionEvent, SendSupportPostSendEvent {
     override val content: ChatRoom
+
+    @STP
+    override suspend fun target(): ChatRoom = content
 }
 //endregion
 
@@ -178,6 +212,9 @@ public interface ChatRoomPostSendEvent : ChatRoomInteractionEvent, SendSupportPo
  */
 public interface ChatGroupInteractionEvent : ChatRoomInteractionEvent {
     override val content: ChatGroup
+
+    @STP
+    override suspend fun target(): ChatGroup = content
 }
 
 /**
@@ -187,6 +224,9 @@ public interface ChatGroupInteractionEvent : ChatRoomInteractionEvent {
  */
 public interface ChatGroupPreSendEvent : ChatGroupInteractionEvent, ChatRoomPreSendEvent {
     override val content: ChatGroup
+
+    @STP
+    override suspend fun target(): ChatGroup = content
 }
 
 /**
@@ -196,6 +236,9 @@ public interface ChatGroupPreSendEvent : ChatGroupInteractionEvent, ChatRoomPreS
  */
 public interface ChatGroupPostSendEvent : ChatGroupInteractionEvent, ChatRoomPostSendEvent {
     override val content: ChatGroup
+
+    @STP
+    override suspend fun target(): ChatGroup = content
 }
 //endregion
 
@@ -210,6 +253,9 @@ public interface ChatGroupPostSendEvent : ChatGroupInteractionEvent, ChatRoomPos
  */
 public interface ChatChannelInteractionEvent : ChatRoomInteractionEvent {
     override val content: ChatChannel
+
+    @STP
+    override suspend fun target(): ChatChannel = content
 }
 
 /**
@@ -221,6 +267,9 @@ public interface ChatChannelPreSendEvent :
     ChatChannelInteractionEvent,
     ChatRoomPreSendEvent {
     override val content: ChatChannel
+
+    @STP
+    override suspend fun target(): ChatChannel = content
 }
 
 /**
@@ -232,5 +281,8 @@ public interface ChatChannelPostSendEvent :
     ChatChannelInteractionEvent,
     ChatRoomPostSendEvent {
     override val content: ChatChannel
+
+    @STP
+    override suspend fun target(): ChatChannel = content
 }
 //endregion


### PR DESCRIPTION
增加一个 `InteractionMessage.Standard` 来描述三个标准类型。